### PR TITLE
fix(httplib): bump httplib version to 14, use epoll

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,7 +6,7 @@
 	url = https://github.com/google/boringssl.git
 [submodule "profiler/third_party/cpp-httplib"]
 	path = profiler/third_party/cpp-httplib
-	url = https://github.com/yhirose/cpp-httplib.git
+	url = https://github.com/pyroscope-io/cpp-httplib.git
 [submodule "profiler/third_party/cppcodec"]
 	path = profiler/third_party/cppcodec
 	url = https://github.com/tplgy/cppcodec.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -6,7 +6,7 @@
 	url = https://github.com/google/boringssl.git
 [submodule "profiler/third_party/cpp-httplib"]
 	path = profiler/third_party/cpp-httplib
-	url = https://github.com/pyroscope-io/cpp-httplib.git
+	url = https://github.com/yhirose/cpp-httplib.git
 [submodule "profiler/third_party/cppcodec"]
 	path = profiler/third_party/cppcodec
 	url = https://github.com/tplgy/cppcodec.git

--- a/Pyroscope/Pyroscope/Pyroscope.csproj
+++ b/Pyroscope/Pyroscope/Pyroscope.csproj
@@ -5,9 +5,9 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-        <PackageVersion>0.8.12-httplib-debug-log</PackageVersion>
-        <AssemblyVersion>0.8.12-httplib-debug-log</AssemblyVersion>
-        <FileVersion>0.8.12-httplib-debug-log</FileVersion>
+        <PackageVersion>0.8.14</PackageVersion>
+        <AssemblyVersion>0.8.14</AssemblyVersion>
+        <FileVersion>0.8.14</FileVersion>
         <LangVersion>10</LangVersion>
     </PropertyGroup>
 

--- a/Pyroscope/Pyroscope/Pyroscope.csproj
+++ b/Pyroscope/Pyroscope/Pyroscope.csproj
@@ -5,9 +5,9 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-        <PackageVersion>0.8.12</PackageVersion>
-        <AssemblyVersion>0.8.12</AssemblyVersion>
-        <FileVersion>0.8.12</FileVersion>
+        <PackageVersion>0.8.12-httplib-debug-log</PackageVersion>
+        <AssemblyVersion>0.8.12-httplib-debug-log</AssemblyVersion>
+        <FileVersion>0.8.12-httplib-debug-log</FileVersion>
         <LangVersion>10</LangVersion>
     </PropertyGroup>
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/CMakeLists.txt
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/CMakeLists.txt
@@ -129,9 +129,8 @@ target_link_libraries(${PROFILER_STATIC_LIB_NAME}
 )
 
 target_include_directories(${PROFILER_STATIC_LIB_NAME} PUBLIC ${PROJECT_SOURCE_DIR}/../../../../profiler/third_party/cpp-httplib)
-target_compile_definitions(${PROFILER_STATIC_LIB_NAME} PUBLIC -DCPPHTTPLIB_USE_POLL)
 target_compile_options(${PROFILER_STATIC_LIB_NAME} PUBLIC -isystem${PROJECT_SOURCE_DIR}/../../../../profiler/third_party/boringssl/include)
-target_compile_definitions(${PROFILER_STATIC_LIB_NAME} PUBLIC -DCPPHTTPLIB_OPENSSL_SUPPORT)
+target_compile_definitions(${PROFILER_STATIC_LIB_NAME} PUBLIC -DCPPHTTPLIB_OPENSSL_SUPPORT -DCPPHTTPLIB_USE_POLL)
 
 add_dependencies(${PROFILER_STATIC_LIB_NAME} fmt-lib libdatadog-lib libunwind-lib coreclr spdlog-headers PPDB)
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/CMakeLists.txt
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/CMakeLists.txt
@@ -128,8 +128,8 @@ target_link_libraries(${PROFILER_STATIC_LIB_NAME}
     -ldl
 )
 
-
 target_include_directories(${PROFILER_STATIC_LIB_NAME} PUBLIC ${PROJECT_SOURCE_DIR}/../../../../profiler/third_party/cpp-httplib)
+target_compile_definitions(${PROFILER_STATIC_LIB_NAME} PUBLIC -DCPPHTTPLIB_USE_POLL)
 target_compile_options(${PROFILER_STATIC_LIB_NAME} PUBLIC -isystem${PROJECT_SOURCE_DIR}/../../../../profiler/third_party/boringssl/include)
 target_compile_definitions(${PROFILER_STATIC_LIB_NAME} PUBLIC -DCPPHTTPLIB_OPENSSL_SUPPORT)
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/PyroscopePprofSink.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/PyroscopePprofSink.cpp
@@ -8,12 +8,6 @@
 #include "cppcodec/base64_rfc4648.hpp"
 #include "nlohmann/json.hpp"
 
-
-extern "C" {
-int httplib_debug_log_enabled = 1;
-}
-
-
 PyroscopePprofSink::PyroscopePprofSink(
     std::string server,
     std::string appName,

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/PyroscopePprofSink.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/PyroscopePprofSink.cpp
@@ -8,6 +8,12 @@
 #include "cppcodec/base64_rfc4648.hpp"
 #include "nlohmann/json.hpp"
 
+
+extern "C" {
+int httplib_debug_log_enabled = 1;
+}
+
+
 PyroscopePprofSink::PyroscopePprofSink(
     std::string server,
     std::string appName,

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/PyroscopePprofSink.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/PyroscopePprofSink.h
@@ -10,7 +10,7 @@
 #include "httplib.h"
 #include "url.hpp"
 
-#define PYROSCOPE_SPY_VERSION "0.8.12-httplib-debug-log"
+#define PYROSCOPE_SPY_VERSION "0.8.14"
 
 class PyroscopePprofSink : public PProfExportSink
 {

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/PyroscopePprofSink.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/PyroscopePprofSink.h
@@ -10,7 +10,7 @@
 #include "httplib.h"
 #include "url.hpp"
 
-#define PYROSCOPE_SPY_VERSION "0.8.12"
+#define PYROSCOPE_SPY_VERSION "0.8.12-httplib-debug-log"
 
 class PyroscopePprofSink : public PProfExportSink
 {


### PR DESCRIPTION
- bump httplib version from 12 to 14
- ~fork httplib, add debug log for connection errors (https://github.com/pyroscope-io/cpp-httplib/commit/fc721209f702c83e1514427c726d0e27f6267c37)~
- add -DCPPHTTPLIB_USE_POLL to avoid errors when sockfd>=1024