### PR TITLE
Update supported .net versions 

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,7 @@ The .NET profiling agent for Pyroscope.io. Based on [dd-trace-dotnet](https://gi
 
 ## Supported .NET versions:
  - .NET 6.0
+ - .Net 7.0
  
 ## Supported platforms
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,7 +6,7 @@ The .NET profiling agent for Pyroscope.io. Based on [dd-trace-dotnet](https://gi
 
 ## Supported .NET versions:
  - .NET 6.0
- - .Net 7.0
+ - .NET 7.0
  
 ## Supported platforms
 


### PR DESCRIPTION
Updated supported version

in here  https://github.com/pyroscope-io/docs/commit/0faa39fb3e5aa42cdc4ef78a80e4f0e6ac85ef63
https://github.com/pyroscope-io/docs/pull/168

we say we support .NET 

## Supported .NET versions:
 - .NET 6.0
 - .NET 7.0

related https://github.com/grafana/pyroscope/pull/2832/
 