### PR TITLE
Allow changing logging verbosity

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.cpp
@@ -29,7 +29,7 @@ std::string const Configuration::DefaultPyroscopeServerAddress = "http://localho
 
 Configuration::Configuration()
 {
-    _debugLogEnabled = GetEnvironmentValue(EnvironmentVariables::DebugLogEnabled, GetDefaultDebugLogEnabled());
+    _minimumLogLevel = GetEnvironmentValue(EnvironmentVariables::PyroscopeMinimumLogLevel, GetDefaultMinimumLogLevel());
     _logDirectory = ExtractLogDirectory();
     _pprofDirectory = ExtractPprofDirectory();
     _isOperationalMetricsEnabled = GetEnvironmentValue(EnvironmentVariables::OperationalMetricsEnabled, false);
@@ -210,9 +210,9 @@ tags const& Configuration::GetUserTags() const
     return _userTags;
 }
 
-bool Configuration::IsDebugLogEnabled() const
+int32_t Configuration::MinimumLogLevel() const
 {
-    return _debugLogEnabled;
+    return _minimumLogLevel;
 }
 
 std::string const& Configuration::GetVersion() const
@@ -431,12 +431,13 @@ bool Configuration::GetContention()
     return GetEnvironmentValue(EnvironmentVariables::DeprecatedContentionProfilingEnabled, false);
 }
 
-bool Configuration::GetDefaultDebugLogEnabled()
+int32_t Configuration::GetDefaultMinimumLogLevel()
 {
     auto r = shared::GetEnvironmentValue(EnvironmentVariables::DevelopmentConfiguration);
 
     bool isDev;
-    return shared::TryParseBooleanEnvironmentValue(r, isDev) && isDev;
+    // Minimum log level is by default 0 (debug) on dev and 1 (info) otherwise
+    return (shared::TryParseBooleanEnvironmentValue(r, isDev) && isDev) ? 0 : 1;
 }
 
 bool Configuration::IsAgentless() const

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.h
@@ -25,7 +25,7 @@ public:
     bool IsNativeFramesEnabled() const override;
     std::chrono::seconds GetUploadInterval() const override;
     tags const& GetUserTags() const override;
-    bool IsDebugLogEnabled() const override;
+    int32_t MinimumLogLevel() const override;
 
     std::string const& GetVersion() const override;
     std::string const& GetEnvironment() const override;
@@ -76,7 +76,7 @@ private:
     static fs::path ExtractLogDirectory();
     static fs::path ExtractPprofDirectory();
     static std::chrono::seconds GetDefaultUploadInterval();
-    static bool GetDefaultDebugLogEnabled();
+    static int32_t GetDefaultMinimumLogLevel();
     template <typename T>
     static T GetEnvironmentValue(shared::WSTRING const& name, T const& defaultValue);
     template <typename T>
@@ -106,7 +106,7 @@ private:
     bool _isContentionProfilingEnabled;
     bool _isGarbageCollectionProfilingEnabled;
     bool _isHeapProfilingEnabled;
-    bool _debugLogEnabled;
+    int32_t _minimumLogLevel;
     fs::path _logDirectory;
     fs::path _pprofDirectory;
     bool _isOperationalMetricsEnabled;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.h
@@ -249,13 +249,13 @@ private :
     std::shared_ptr<ProxyMetric> _managedThreadsWithContextMetric;
 
 private:
-    static void ConfigureDebugLog();
     static void InspectRuntimeCompatibility(IUnknown* corProfilerInfoUnk, uint16_t& runtimeMajor, uint16_t& runtimeMinor);
     static void InspectProcessorInfo();
     static void InspectRuntimeVersion(ICorProfilerInfo5* pCorProfilerInfo, USHORT& major, USHORT& minor, COR_PRF_RUNTIME_TYPE& runtimeType);
     static const char* SysInfoProcessorArchitectureToStr(WORD wProcArch);
     static void PrintEnvironmentVariables();
 
+    void ConfigureLogging();
     void DisposeInternal();
     bool InitializeServices();
     bool DisposeServices();

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/EnvironmentVariables.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/EnvironmentVariables.h
@@ -31,6 +31,7 @@ public:
     inline static const shared::WSTRING WallTimeProfilingEnabled    = WStr("DD_PROFILING_WALLTIME_ENABLED");
     inline static const shared::WSTRING ExceptionProfilingEnabled   = WStr("DD_PROFILING_EXCEPTION_ENABLED");
 
+    inline static const shared::WSTRING PyroscopeMinimumLogLevel       = WStr("PYROSCOPE_MINIMUM_LOG_LEVEL");
     inline static const shared::WSTRING PyroscopeServerAddress         = WStr("PYROSCOPE_SERVER_ADDRESS");
     inline static const shared::WSTRING PyroscopeAuthToken             = WStr("PYROSCOPE_AUTH_TOKEN");
     inline static const shared::WSTRING PyroscopeApplicationName       = WStr("PYROSCOPE_APPLICATION_NAME");

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/IConfiguration.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/IConfiguration.h
@@ -17,7 +17,7 @@ class IConfiguration
 {
 public:
     virtual ~IConfiguration() = default;
-    virtual bool IsDebugLogEnabled() const = 0;
+    virtual int32_t MinimumLogLevel() const = 0;
     virtual fs::path const& GetLogDirectory() const = 0;
     virtual fs::path const& GetProfilesOutputDirectory() const = 0;
     virtual bool IsNativeFramesEnabled() const = 0;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Log.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Log.h
@@ -39,9 +39,9 @@ public:
         return Instance->IsDebugEnabled();
     }
 
-    static void EnableDebug()
+    static void SetMinimumLogLevel(int32_t minimumLogLevel)
     {
-        Instance->EnableDebug();
+        Instance->SetMinimumLogLevel(minimumLogLevel);
     }
 
     template <typename... Args>

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/PyroscopePprofSink.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/PyroscopePprofSink.cpp
@@ -157,12 +157,12 @@ void PyroscopePprofSink::upload(Pprof pprof, ProfileTime& startTime, ProfileTime
     auto res = _client.Post(path, headers, data);
     if (res)
     {
-        Log::Info("PyroscopePprofSink ", res->status);
+        Log::Debug("PyroscopePprofSink ", res->status);
     }
     else
     {
         auto err = res.error();
-        Log::Info("PyroscopePprofSink err ", to_string(err), " ", _url);
+        Log::Error("PyroscopePprofSink err ", to_string(err), " ", _url);
     }
 }
 

--- a/shared/src/Datadog.Trace.ClrProfiler.Native/dllmain.cpp
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/dllmain.cpp
@@ -57,7 +57,7 @@ EXTERN_C BOOL STDMETHODCALLTYPE DllMain(HMODULE hModule, DWORD ul_reason_for_cal
 
             if (isLogDebugEnabled)
             {
-                Log::EnableDebug();
+                Log::SetMinimumLogLevel(0);
             }
 
             Log::Debug("DllMain: DLL_PROCESS_ATTACH");

--- a/shared/src/Datadog.Trace.ClrProfiler.Native/log.h
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/log.h
@@ -37,9 +37,9 @@ public:
         return Instance->IsDebugEnabled();
     }
 
-    static void EnableDebug()
+    static void SetMinimumLogLevel(int32_t minimumLogLevel)
     {
-        Instance->EnableDebug();
+        Instance->SetMinimumLogLevel(minimumLogLevel);
     }
 
     template <typename... Args>

--- a/shared/src/native-src/logger.h
+++ b/shared/src/native-src/logger.h
@@ -41,15 +41,19 @@ public:
 
     inline void Flush();
 
-    inline void EnableDebug();
-    inline bool IsDebugEnabled() const;
+    inline void SetMinimumLogLevel(int32_t minimumLogLevel);
 
+    inline bool IsDebugEnabled() const;
+    inline bool IsInfoEnabled() const;
+    inline bool IsWarningEnabled() const;
+    inline bool IsErrorEnabled() const;
+    inline bool IsCriticalEnabled() const;
 
 private:
 
     friend class LogManager;
 
-    Logger(std::shared_ptr<spdlog::logger> const& logger) : _internalLogger{logger}, m_debug_logging_enabled{false}
+    Logger(std::shared_ptr<spdlog::logger> const& logger) : _internalLogger{logger}, m_minimum_log_level{0}
     {
     }
 
@@ -72,7 +76,7 @@ private:
     static std::shared_ptr<spdlog::logger> CreateInternalLogger();
 
     std::shared_ptr<spdlog::logger> _internalLogger;
-    bool m_debug_logging_enabled;
+    int32_t m_minimum_log_level;
 };
 
 template <class LoggerPolicy>
@@ -200,25 +204,37 @@ void Logger::Debug(const Args&... args)
 template <typename... Args>
 void Logger::Info(const Args&... args)
 {
-    _internalLogger->info(LogToString(args...));
+    if (IsInfoEnabled())
+    {
+        _internalLogger->info(LogToString(args...));
+    }
 }
 
 template <typename... Args>
 void Logger::Warn(const Args&... args)
 {
-    _internalLogger->warn(LogToString(args...));
+    if (IsWarningEnabled())
+    {
+        _internalLogger->warn(LogToString(args...));
+    }
 }
 
 template <typename... Args>
 void Logger::Error(const Args&... args)
 {
-    _internalLogger->error(LogToString(args...));
+    if (IsErrorEnabled())
+    {
+        _internalLogger->error(LogToString(args...));
+    }
 }
 
 template <typename... Args>
 void Logger::Critical(const Args&... args)
 {
-    _internalLogger->critical(LogToString(args...));
+    if (IsCriticalEnabled())
+    {
+        _internalLogger->critical(LogToString(args...));
+    }
 }
 
 inline void Logger::Flush()
@@ -226,13 +242,33 @@ inline void Logger::Flush()
     _internalLogger->flush();
 }
 
-inline void Logger::EnableDebug()
+inline void Logger::SetMinimumLogLevel(int32_t minimumLogLevel)
 {
-    m_debug_logging_enabled = true;
+    m_minimum_log_level = minimumLogLevel;
 }
 
 inline bool Logger::IsDebugEnabled() const
 {
-    return m_debug_logging_enabled;
+    return m_minimum_log_level <= 0;
+}
+
+inline bool Logger::IsInfoEnabled() const
+{
+    return m_minimum_log_level <= 1;
+}
+
+inline bool Logger::IsWarningEnabled() const
+{
+    return m_minimum_log_level <= 2;
+}
+
+inline bool Logger::IsErrorEnabled() const
+{
+    return m_minimum_log_level <= 3;
+}
+
+inline bool Logger::IsCriticalEnabled() const
+{
+    return m_minimum_log_level <= 4;
 }
 } // namespace datadog::shared

--- a/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
+++ b/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
@@ -46,7 +46,7 @@ HRESULT STDMETHODCALLTYPE CorProfiler::Initialize(IUnknown* cor_profiler_info_un
     // check if debug mode is enabled
     if (IsDebugEnabled())
     {
-        Logger::EnableDebug();
+        Logger::SetMinimumLogLevel(0);
     }
 
     CorProfilerBase::Initialize(cor_profiler_info_unknown);

--- a/tracer/src/Datadog.Tracer.Native/logger.h
+++ b/tracer/src/Datadog.Tracer.Native/logger.h
@@ -40,6 +40,12 @@ private:
     inline static ds::Logger* const Instance = ds::LogManager::Get<TracerLoggerPolicy>();
 
 public:
+
+    static bool IsDebugEnabled()
+    {
+        return Instance->IsDebugEnabled();
+    }
+
     template <typename... Args>
     static void Debug(const Args&... args)
     {
@@ -57,25 +63,22 @@ public:
     {
         Instance->Warn(args...);
     }
+
     template <typename... Args>
     static void Error(const Args&... args)
     {
         Instance->Error(args...);
     }
+
     template <typename... Args>
     static void Critical(const Args&... args)
     {
         Instance->Critical(args...);
     }
 
-    static void EnableDebug()
+    static void SetMinimumLogLevel(int32_t minimumLogLevel)
     {
-        Instance->EnableDebug();
-    }
-
-    static bool IsDebugEnabled()
-    {
-        return Instance->IsDebugEnabled();
+        Instance->SetMinimumLogLevel(minimumLogLevel);
     }
 
     static void Flush()


### PR DESCRIPTION
# Context

The pyroscope native profiler produces at lot of `INFO` logs, both at startup and for each sample sent after. This produces a lot of noise from the profiled application standpoint. 

```
[...]
[2024-01-15 13:07:18.188 | info | PId: 1 | TId: 1] Enable debug log = 0 from (`DD_TRACE_DEBUG` environment variable)
[2024-01-15 13:07:18.188 | info | PId: 1 | TId: 1] Environment variables:
[2024-01-15 13:07:18.188 | info | PId: 1 | TId: 1] ICorProfilerInfo12 available. Profiling API compatibility: .NET Core 5.0 or later.
[2024-01-15 13:07:18.188 | info | PId: 1 | TId: 1] Initializing the Profiler: Reported runtime version : { clrInstanceId: 0, 
[...]
[2024-01-15 13:07:18.189 | info | PId: 1 | TId: 1] SamplesCollector started successfully.
[...]
[13:07:52 INF] Some logs from profiler application
[...]
[2024-01-15 13:08:00.101 | info | PId: 1 | TId: 17] PyroscopePprofSink 200
[2024-01-15 13:08:10.196 | info | PId: 1 | TId: 17] PyroscopePprofSink 200
[2024-01-15 13:08:20.161 | info | PId: 1 | TId: 17] PyroscopePprofSink 200
[2024-01-15 13:08:30.123 | info | PId: 1 | TId: 17] PyroscopePprofSink 200
[2024-01-15 13:08:40.126 | info | PId: 1 | TId: 17] PyroscopePprofSink 200
[2024-01-15 13:08:50.140 | info | PId: 1 | TId: 17] PyroscopePprofSink 200
[...]
```

# Problem

It is possible currently to disable DEBUG logs with `DD_TRACE_DEBUG=0`, but there is no way to disable `INFO` logs. 

# Solution

A solution is to change the way logging verbosity is chosen by introducing a "minimum log level". This is a very common practice. Usually:
- 0 refers to `DEBUG`
- 1 refers to `INFO`
- 2 refers to `WARNING`
- 3 refers to `ERROR`
- 4 refers to `CRITICAL`

With this, we introduce the new environment variable `PYROSCOPE_MINIMUM_LOG_LEVEL`. This replaces `DD_TRACE_DEBUG` for the native profiler.