### PR TITLE
Add helper packages that enable span profiles

### DIFF
--- a/.github/workflows/build_tracing_packages.yml
+++ b/.github/workflows/build_tracing_packages.yml
@@ -1,0 +1,33 @@
+name: Build tracing libraries
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build-tracing-lib-opentracing:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          submodules: 'true'
+      - uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: '6.0'
+      - run: dotnet build -c Release
+        working-directory: Pyroscope/Pyroscope.Tracing/Pyroscope.Tracing.OpenTracing
+  build-tracing-lib-opentelemetry:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          submodules: 'true'
+      - uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: '6.0'
+      - run: dotnet build -c Release
+        working-directory: Pyroscope/Pyroscope.Tracing/Pyroscope.Tracing.OpenTelemetry

--- a/.github/workflows/tag_tracing_packages.yml
+++ b/.github/workflows/tag_tracing_packages.yml
@@ -1,0 +1,56 @@
+name: Release managed helper
+
+on:
+  push:
+    tags:
+      - v*-pyroscope
+
+jobs:
+  release-tracing-lib-opentracing:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          submodules: 'true'
+      - uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: '6.0'
+      - run: dotnet build -c Release
+        working-directory: Pyroscope/Pyroscope.Tracing/Pyroscope.Tracing.OpenTracing
+      - name: Publish the package to nuget.org
+        run: dotnet nuget push bin/Release/*.nupkg -k $NUGET_AUTH_TOKEN -s https://api.nuget.org/v3/index.json
+        working-directory: Pyroscope/Pyroscope.Tracing/Pyroscope.Tracing.OpenTracing
+        env:
+          NUGET_AUTH_TOKEN: ${{ secrets.NUGET_API_KEY }}
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: |
+            ./Pyroscope/Pyroscope.Tracing/Pyroscope.Tracing.OpenTracing/bin/Release/net6.0/Pyroscope.Tracing.OpenTracing.dll
+            ./Pyroscope/Pyroscope.Tracing/Pyroscope.Tracing.OpenTracing/bin/Release/Pyroscope.Tracing.OpenTracing*.nupkg
+  release-tracing-lib-opentelemetry:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          submodules: 'true'
+      - uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: '6.0'
+      - run: dotnet build -c Release
+        working-directory: Pyroscope/Pyroscope.Tracing/Pyroscope.Tracing.OpenTelemetry
+      - name: Publish the package to nuget.org
+        run: dotnet nuget push bin/Release/*.nupkg -k $NUGET_AUTH_TOKEN -s https://api.nuget.org/v3/index.json
+        working-directory: Pyroscope/Pyroscope.Tracing/Pyroscope.Tracing.OpenTelemetry
+        env:
+          NUGET_AUTH_TOKEN: ${{ secrets.NUGET_API_KEY }}
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: |
+            ./Pyroscope/Pyroscope.Tracing/Pyroscope.Tracing.OpenTelemetry/bin/Release/net6.0/Pyroscope.Tracing.OpenTelemetry.dll
+            ./Pyroscope/Pyroscope.Tracing/Pyroscope.Tracing.OpenTelemetry/bin/Release/Pyroscope.Tracing.OpenTelemetry*.nupkg

--- a/Pyroscope/Pyroscope.Tracing/Pyroscope.Tracing.OpenTelemetry/Pyroscope.Tracing.OpenTelemetry.csproj
+++ b/Pyroscope/Pyroscope.Tracing/Pyroscope.Tracing.OpenTelemetry/Pyroscope.Tracing.OpenTelemetry.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <PackageVersion>0.1.0</PackageVersion>
+    <AssemblyVersion>0.1.0</AssemblyVersion>
+    <FileVersion>0.1.0</FileVersion>
+    <LangVersion>10</LangVersion>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+ </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="OpenTelemetry" Version="1.8.0" />
+    <PackageReference Include="Pyroscope" Version="0.8.14" />
+    <None Include="README.md" Pack="true" PackagePath="\"/>
+  </ItemGroup>
+
+</Project>

--- a/Pyroscope/Pyroscope.Tracing/Pyroscope.Tracing.OpenTelemetry/Pyroscope.Tracing.OpenTelemetry.sln
+++ b/Pyroscope/Pyroscope.Tracing/Pyroscope.Tracing.OpenTelemetry/Pyroscope.Tracing.OpenTelemetry.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.002.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Pyroscope.Tracing.OpenTelemetry", "Pyroscope.Tracing.OpenTelemetry.csproj", "{42160563-B7D4-41D6-89DE-9CEDEEB542AA}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{42160563-B7D4-41D6-89DE-9CEDEEB542AA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{42160563-B7D4-41D6-89DE-9CEDEEB542AA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{42160563-B7D4-41D6-89DE-9CEDEEB542AA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{42160563-B7D4-41D6-89DE-9CEDEEB542AA}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {F472AA5F-5941-4FC4-B363-820E27A5A505}
+	EndGlobalSection
+EndGlobal

--- a/Pyroscope/Pyroscope.Tracing/Pyroscope.Tracing.OpenTelemetry/PyroscopeSpanProcessor.cs
+++ b/Pyroscope/Pyroscope.Tracing/Pyroscope.Tracing.OpenTelemetry/PyroscopeSpanProcessor.cs
@@ -1,0 +1,37 @@
+﻿using System.Diagnostics;
+using OpenTelemetry;
+
+namespace Pyroscope.Tracing.OpenTelemetry;
+
+public class PyroscopeSpanProcessor : BaseProcessor<Activity>
+{
+    private const string ProfileIdSpanTagKey = "pyroscope.profile.id";
+
+    public override void OnStart(Activity data)
+    {
+        if (!IsRootSpan(data)) {
+            return;
+        }
+
+        try
+        {
+            var spanId = data.SpanId.ToString();
+            var spanIdLong = Convert.ToUInt64(spanId.ToUpper(), 16);
+
+            // Establish a two-way connection between the span and profiling data
+            Profiler.Instance.SetProfileId(spanIdLong);
+            data.AddTag(ProfileIdSpanTagKey, spanId);
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"Caught exception while setting profile id in profiler instance: {ex.Message}");
+        }
+
+    }
+
+    private static bool IsRootSpan(Activity data)
+    {
+        var parent = data.Parent;
+        return parent == null || parent.HasRemoteParent;
+    }
+}

--- a/Pyroscope/Pyroscope.Tracing/Pyroscope.Tracing.OpenTelemetry/PyroscopeSpanProcessor.cs
+++ b/Pyroscope/Pyroscope.Tracing/Pyroscope.Tracing.OpenTelemetry/PyroscopeSpanProcessor.cs
@@ -6,10 +6,17 @@ namespace Pyroscope.Tracing.OpenTelemetry;
 public class PyroscopeSpanProcessor : BaseProcessor<Activity>
 {
     private const string ProfileIdSpanTagKey = "pyroscope.profile.id";
+    private readonly Config _config;
+
+    private PyroscopeSpanProcessor()
+    {
+        _config = new Config();
+    }
 
     public override void OnStart(Activity data)
     {
-        if (!IsRootSpan(data)) {
+        if (_config.RootSpanOnly && !IsRootSpan(data))
+        {
             return;
         }
 
@@ -26,12 +33,56 @@ public class PyroscopeSpanProcessor : BaseProcessor<Activity>
         {
             Console.WriteLine($"Caught exception while setting profile id in profiler instance: {ex.Message}");
         }
+    }
 
+    public override void OnEnd(Activity data)
+    {
+        if (IsRootSpan(data))
+        {
+            Profiler.Instance.SetProfileId(0); // TODO: Replace with ResetContext()
+            return;
+        }
+        if (_config.RootSpanOnly)
+        {
+            return;
+        }
+
+        try
+        {
+            var parentSpanId = data.ParentSpanId.ToString();
+            var spanIdLong = Convert.ToUInt64(parentSpanId.ToUpper(), 16);
+            Profiler.Instance.SetProfileId(spanIdLong);
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"Caught exception while restoring previous profile id in profiler instance: {ex.Message}");
+        }
     }
 
     private static bool IsRootSpan(Activity data)
     {
         var parent = data.Parent;
         return parent == null || parent.HasRemoteParent;
+    }
+
+    internal class Config
+    {
+        public bool RootSpanOnly { get; set; } = true;
+    }
+
+    public class Builder
+    {
+        private PyroscopeSpanProcessor _processor = new PyroscopeSpanProcessor();
+
+        public Builder WithRootSpanOnly(bool RootSpanOnly)
+        {
+            _processor._config.RootSpanOnly = RootSpanOnly;
+            return this;
+        }
+
+        public PyroscopeSpanProcessor Build()
+        {
+            return _processor;
+        }
     }
 }

--- a/Pyroscope/Pyroscope.Tracing/Pyroscope.Tracing.OpenTelemetry/README.md
+++ b/Pyroscope/Pyroscope.Tracing/Pyroscope.Tracing.OpenTelemetry/README.md
@@ -1,0 +1,33 @@
+## Span profiles for OpenTelemetry
+
+This package enables application that already rely on OpenTelemetry for tracing and Pyroscope for profiling to link the tracing and profiling data. 
+
+See https://grafana.com/docs/pyroscope/latest/configure-client/trace-span-profiles/ for more information.
+
+### Integration
+
+Add the package to your project:
+
+```shell
+dotnet add package Pyroscope.Tracing.OpenTelemetry
+```
+
+Register the `PyroscopeSpanProcessor`:
+
+```csharp
+
+builder.Services.AddOpenTelemetry()
+    .WithTracing(b =>
+    {
+        b
+        .AddAspNetCoreInstrumentation()
+        .AddConsoleExporter()
+        .AddOtlpExporter()
+        .AddProcessor(new PyroscopeSpanProcessor());
+    });
+
+```
+
+### Example
+
+TODO: Link to an example project

--- a/Pyroscope/Pyroscope.Tracing/Pyroscope.Tracing.OpenTelemetry/README.md
+++ b/Pyroscope/Pyroscope.Tracing/Pyroscope.Tracing.OpenTelemetry/README.md
@@ -27,7 +27,9 @@ builder.Services.AddOpenTelemetry()
         .AddAspNetCoreInstrumentation()
         .AddConsoleExporter()
         .AddOtlpExporter()
-        .AddProcessor(new PyroscopeSpanProcessor());
+        .AddProcessor(new PyroscopeSpanProcessor.Builder()
+            .WithRootSpanOnly(true)
+            .Build());
     });
 
 ```

--- a/Pyroscope/Pyroscope.Tracing/Pyroscope.Tracing.OpenTelemetry/README.md
+++ b/Pyroscope/Pyroscope.Tracing/Pyroscope.Tracing.OpenTelemetry/README.md
@@ -1,18 +1,22 @@
 ## Span profiles for OpenTelemetry
 
-This package enables application that already rely on OpenTelemetry for tracing and Pyroscope for profiling to link the tracing and profiling data. 
+This package enables applications that already rely on [OpenTelemetry](https://opentelemetry.io/docs/instrumentation/net/getting-started/) for distributed tracing and Pyroscope for continuous profiling to link the tracing and profiling data together.
 
 See https://grafana.com/docs/pyroscope/latest/configure-client/trace-span-profiles/ for more information.
 
+### Prerequisites
+- Your .NET application is instrumented with [Pyroscope's profiler](https://grafana.com/docs/pyroscope/latest/configure-client/language-sdks/dotnet/)
+- Your .NET application is instrumented (manually) with [OpenTelemetry](https://opentelemetry.io/docs/instrumentation/net/getting-started/)
+
 ### Integration
 
-Add the package to your project:
+Add the following package to your project:
 
 ```shell
 dotnet add package Pyroscope.Tracing.OpenTelemetry
 ```
 
-Register the `PyroscopeSpanProcessor`:
+Register the `PyroscopeSpanProcessor` in your OpenTelemetry integration:
 
 ```csharp
 
@@ -27,7 +31,3 @@ builder.Services.AddOpenTelemetry()
     });
 
 ```
-
-### Example
-
-TODO: Link to an example project

--- a/Pyroscope/Pyroscope.Tracing/Pyroscope.Tracing.OpenTracing/Pyroscope.Tracing.OpenTracing.csproj
+++ b/Pyroscope/Pyroscope.Tracing/Pyroscope.Tracing.OpenTracing/Pyroscope.Tracing.OpenTracing.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <PackageVersion>0.1.0</PackageVersion>
+    <AssemblyVersion>0.1.0</AssemblyVersion>
+    <FileVersion>0.1.0</FileVersion>
+    <LangVersion>10</LangVersion>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="OpenTracing" Version="0.12.1" />
+    <PackageReference Include="Pyroscope" Version="0.8.14" />
+    <None Include="README.md" Pack="true" PackagePath="\"/>
+  </ItemGroup>
+
+</Project>

--- a/Pyroscope/Pyroscope.Tracing/Pyroscope.Tracing.OpenTracing/Pyroscope.Tracing.OpenTracing.sln
+++ b/Pyroscope/Pyroscope.Tracing/Pyroscope.Tracing.OpenTracing/Pyroscope.Tracing.OpenTracing.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.002.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Pyroscope.Tracing.OpenTracing", "Pyroscope.Tracing.OpenTracing.csproj", "{311866C4-042D-4F43-B025-CC142FDD02B3}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{311866C4-042D-4F43-B025-CC142FDD02B3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{311866C4-042D-4F43-B025-CC142FDD02B3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{311866C4-042D-4F43-B025-CC142FDD02B3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{311866C4-042D-4F43-B025-CC142FDD02B3}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {BFF488AB-A4B8-4DC3-91FE-02E755751CB8}
+	EndGlobalSection
+EndGlobal

--- a/Pyroscope/Pyroscope.Tracing/Pyroscope.Tracing.OpenTracing/PyroscopeSpanBuilder.cs
+++ b/Pyroscope/Pyroscope.Tracing/Pyroscope.Tracing.OpenTracing/PyroscopeSpanBuilder.cs
@@ -1,0 +1,132 @@
+using OpenTracing;
+using OpenTracing.Tag;
+
+namespace Pyroscope.Tracing.OpenTracing;
+
+public class PyroscopeSpanBuilder : ISpanBuilder
+{
+
+    private const string ProfileIdSpanTagKey = "pyroscope.profile.id";
+
+    private readonly ISpanBuilder _delegate;
+
+    public PyroscopeSpanBuilder(ISpanBuilder spanBuilder)
+    {
+        _delegate = spanBuilder;
+    }
+
+    public ISpan Start()
+    {
+        var span = _delegate.Start();
+        ConnectSpanWithProfiling(span);
+        return span;
+    }
+
+    public IScope StartActive()
+    {
+        var scope = _delegate.StartActive();
+        ConnectSpanWithProfiling(scope.Span);
+        return scope;
+    }
+
+    public IScope StartActive(bool finishSpanOnDispose)
+    {
+        var scope = _delegate.StartActive(finishSpanOnDispose);
+        ConnectSpanWithProfiling(scope.Span);
+        return scope;
+    }
+
+    private static void ConnectSpanWithProfiling(ISpan span)
+    {
+        try
+        {
+            var spanId = span.Context.SpanId;
+            var spanIdLong = Convert.ToUInt64(spanId.ToUpper(), 16);
+
+            Profiler.Instance.SetProfileId(spanIdLong);
+            span.SetTag(ProfileIdSpanTagKey, spanId);
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"Caught exception while setting profile id in profiler instance: {ex.Message}");
+        }
+    }
+
+    public ISpanBuilder AsChildOf(ISpan parent)
+    {
+        _delegate.AsChildOf(parent);
+        return this;
+    }
+
+    public ISpanBuilder AsChildOf(ISpanContext parent)
+    {
+        _delegate.AsChildOf(parent);
+        return this;
+    }
+
+    public ISpanBuilder AddReference(string referenceType, ISpanContext referencedContext)
+    {
+        _delegate.AddReference(referenceType, referencedContext);
+        return this;
+    }
+
+    public ISpanBuilder WithTag(string key, bool value)
+    {
+        _delegate.WithTag(key, value);
+        return this;
+    }
+
+    public ISpanBuilder WithTag(string key, double value)
+    {
+        _delegate.WithTag(key, value);
+        return this;
+    }
+
+    public ISpanBuilder WithTag(string key, int value)
+    {
+        _delegate.WithTag(key, value);
+        return this;
+    }
+
+    public ISpanBuilder WithTag(string key, string value)
+    {
+        _delegate.WithTag(key, value);
+        return this;
+    }
+
+    public ISpanBuilder WithTag(BooleanTag tag, bool value)
+    {
+        _delegate.WithTag(tag, value);
+        return this;
+    }
+
+    public ISpanBuilder WithTag(IntOrStringTag tag, string value)
+    {
+        _delegate.WithTag(tag, value);
+        return this;
+    }
+
+    public ISpanBuilder WithTag(IntTag tag, int value)
+    {
+        _delegate.WithTag(tag, value);
+        return this;
+    }
+
+    public ISpanBuilder WithTag(StringTag tag, string value)
+    {
+        _delegate.WithTag(tag, value);
+        return this;
+    }
+
+    public ISpanBuilder WithStartTimestamp(DateTimeOffset startTimestamp)
+    {
+        _delegate.WithStartTimestamp(startTimestamp);
+        return this;
+    }
+
+    public ISpanBuilder IgnoreActiveSpan()
+    {
+        _delegate.IgnoreActiveSpan();
+        return this;
+    }
+}

--- a/Pyroscope/Pyroscope.Tracing/Pyroscope.Tracing.OpenTracing/PyroscopeTracer.cs
+++ b/Pyroscope/Pyroscope.Tracing/Pyroscope.Tracing.OpenTracing/PyroscopeTracer.cs
@@ -8,16 +8,18 @@ public class PyroscopeTracer : ITracer
     private readonly ITracer _delegate;
     public IScopeManager ScopeManager { get; }
     public ISpan? ActiveSpan => ScopeManager.Active?.Span;
+    private readonly Config _config;
 
-    public PyroscopeTracer(ITracer _delegate)
+    private PyroscopeTracer(ITracer tracerDelegate)
     {
-        this._delegate = _delegate;
-        this.ScopeManager = _delegate.ScopeManager;
+        _config = new Config();
+        _delegate = tracerDelegate;
+        ScopeManager = tracerDelegate.ScopeManager;
     }
 
     public ISpanBuilder BuildSpan(string operationName)
     {
-        return new PyroscopeSpanBuilder(_delegate.BuildSpan(operationName));
+        return new PyroscopeSpanBuilder(_config, _delegate.BuildSpan(operationName), ActiveSpan?.Context);
     }
 
     public void Inject<TCarrier>(ISpanContext spanContext, IFormat<TCarrier> format, TCarrier carrier)
@@ -28,5 +30,26 @@ public class PyroscopeTracer : ITracer
     public ISpanContext Extract<TCarrier>(IFormat<TCarrier> format, TCarrier carrier)
     {
         return _delegate.Extract(format, carrier);
+    }
+
+    public class Builder
+    {
+        private readonly PyroscopeTracer _tracer;
+
+        public Builder(ITracer tracerDelegate)
+        {
+            _tracer = new PyroscopeTracer(tracerDelegate);
+        }
+
+        public Builder WithRootSpanOnly(bool RootSpanOnly)
+        {
+            _tracer._config.RootSpanOnly = RootSpanOnly;
+            return this;
+        }
+
+        public PyroscopeTracer Build()
+        {
+            return _tracer;
+        }
     }
 }

--- a/Pyroscope/Pyroscope.Tracing/Pyroscope.Tracing.OpenTracing/PyroscopeTracer.cs
+++ b/Pyroscope/Pyroscope.Tracing/Pyroscope.Tracing.OpenTracing/PyroscopeTracer.cs
@@ -1,0 +1,32 @@
+using OpenTracing;
+using OpenTracing.Propagation;
+
+namespace Pyroscope.Tracing.OpenTracing;
+
+public class PyroscopeTracer : ITracer
+{
+    private readonly ITracer _delegate;
+    public IScopeManager ScopeManager { get; }
+    public ISpan? ActiveSpan => ScopeManager.Active?.Span;
+
+    public PyroscopeTracer(ITracer _delegate)
+    {
+        this._delegate = _delegate;
+        this.ScopeManager = _delegate.ScopeManager;
+    }
+
+    public ISpanBuilder BuildSpan(string operationName)
+    {
+        return new PyroscopeSpanBuilder(_delegate.BuildSpan(operationName));
+    }
+
+    public void Inject<TCarrier>(ISpanContext spanContext, IFormat<TCarrier> format, TCarrier carrier)
+    {
+        _delegate.Inject(spanContext, format, carrier);
+    }
+
+    public ISpanContext Extract<TCarrier>(IFormat<TCarrier> format, TCarrier carrier)
+    {
+        return _delegate.Extract(format, carrier);
+    }
+}

--- a/Pyroscope/Pyroscope.Tracing/Pyroscope.Tracing.OpenTracing/PyroscopeTracerConfig.cs
+++ b/Pyroscope/Pyroscope.Tracing/Pyroscope.Tracing.OpenTracing/PyroscopeTracerConfig.cs
@@ -1,0 +1,6 @@
+namespace Pyroscope.Tracing.OpenTracing;
+
+class Config
+{
+    public bool RootSpanOnly { get; set; } = true;
+}

--- a/Pyroscope/Pyroscope.Tracing/Pyroscope.Tracing.OpenTracing/README.md
+++ b/Pyroscope/Pyroscope.Tracing/Pyroscope.Tracing.OpenTracing/README.md
@@ -1,29 +1,29 @@
 ## Span profiles for OpenTracing
 
-This package enables application that already rely on OpenTracing for tracing and Pyroscope for profiling to link the tracing and profiling data. 
+This package enables applications that already rely on [OpenTracing](https://opentracing.io/guides/csharp/) for distributed tracing and Pyroscope for continuous profiling to link the tracing and profiling data together.
 
 See https://grafana.com/docs/pyroscope/latest/configure-client/trace-span-profiles/ for more information.
 
+### Prerequisites
+- Your .NET application is instrumented with [Pyroscope's profiler](https://grafana.com/docs/pyroscope/latest/configure-client/language-sdks/dotnet/)
+- Your .NET application is instrumented with [OpenTracing](https://opentracing.io/guides/csharp/)
+
 ### Integration
 
-Add the package to your project:
+Add the following package to your project:
 
 ```shell
 dotnet add package Pyroscope.Tracing.OpenTracing
 ```
 
-Wrap your existing tracer with the `PyroscopeTracer`:
+Wrap your existing tracer with the `PyroscopeTracer` and register it globally:
 
 ```csharp
 
-// obtain the OpenTracing tracer (note, this can be done in different ways)
+// obtain the OpenTracing tracer (note that this can vary between applications)
 var tracingConfig = Configuration.FromEnv(loggerFactory);
 var tracer = tracingConfig.GetTracer();
 
 // wrap the OpenTracing tracer with the PyroscopeTracer and register it
-builder.Services.AddSingleton(new PyroscopeTracer(tracer));
+GlobalTracer.Register(new PyroscopeTracer(tracer));
 ```
-
-### Example
-
-TODO: Link to an example project

--- a/Pyroscope/Pyroscope.Tracing/Pyroscope.Tracing.OpenTracing/README.md
+++ b/Pyroscope/Pyroscope.Tracing/Pyroscope.Tracing.OpenTracing/README.md
@@ -25,5 +25,7 @@ var tracingConfig = Configuration.FromEnv(loggerFactory);
 var tracer = tracingConfig.GetTracer();
 
 // wrap the OpenTracing tracer with the PyroscopeTracer and register it
-GlobalTracer.Register(new PyroscopeTracer(tracer));
+GlobalTracer.Register(new PyroscopeTracer.Builder(tracer)
+    .WithRootSpanOnly(true)
+    .Build()));
 ```

--- a/Pyroscope/Pyroscope.Tracing/Pyroscope.Tracing.OpenTracing/README.md
+++ b/Pyroscope/Pyroscope.Tracing/Pyroscope.Tracing.OpenTracing/README.md
@@ -1,0 +1,29 @@
+## Span profiles for OpenTracing
+
+This package enables application that already rely on OpenTracing for tracing and Pyroscope for profiling to link the tracing and profiling data. 
+
+See https://grafana.com/docs/pyroscope/latest/configure-client/trace-span-profiles/ for more information.
+
+### Integration
+
+Add the package to your project:
+
+```shell
+dotnet add package Pyroscope.Tracing.OpenTracing
+```
+
+Wrap your existing tracer with the `PyroscopeTracer`:
+
+```csharp
+
+// obtain the OpenTracing tracer (note, this can be done in different ways)
+var tracingConfig = Configuration.FromEnv(loggerFactory);
+var tracer = tracingConfig.GetTracer();
+
+// wrap the OpenTracing tracer with the PyroscopeTracer and register it
+builder.Services.AddSingleton(new PyroscopeTracer(tracer));
+```
+
+### Example
+
+TODO: Link to an example project


### PR DESCRIPTION
Adds `Pyroscope.Tracing.OpenTelemetry` and `Pyroscope.Tracing.OpenTracing` packages that applications can use to link their tracing and profiling data.

See https://github.com/grafana/pyroscope/compare/feat/dotnet-span-profiles-playground?expand=1 for example usage.