### PR TITLE
Update self-hosted runner labels to be more specific

### DIFF
--- a/.github/workflows/build_linux_profiler.yml
+++ b/.github/workflows/build_linux_profiler.yml
@@ -21,7 +21,7 @@ jobs:
           submodules: 'true'
       - run: RELEASE_VERSION=dev-$(git rev-parse --short HEAD) ARCH=x86_64 LIBC=${{ matrix.name }}  make docker/build
   build-linux-profiler-aarch64:
-    runs-on: [self-hosted, Linux, ARM64]
+    runs-on: ubuntu-arm64
     env:
       DOCKER_BUILDKIT: 1
     strategy:

--- a/.github/workflows/tag_linux.yml
+++ b/.github/workflows/tag_linux.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           files: ./*.tar.gz
   release-linux-profiler-aarch64:
-    runs-on: [self-hosted, Linux, ARM64]
+    runs-on: ubuntu-arm64
     env:
       DOCKER_BUILDKIT: 1
       ARCH: aarch64


### PR DESCRIPTION
This pull request updates the runner labels on workflows that are running self-hosted runners to use more specific and explicit labels, the current labels can be interpreted wrongly by the system resulting in dev instances picking up jobs for prod instances.

Part of https://github.com/grafana/deployment_tools/issues/142178
Part of https://github.com/grafana/deployment_tools/issues/142917

Related https://github.com/grafana/pyroscope-rs/pull/166