### PR TITLE
fix aarch64 release workflow

### DIFF
--- a/.github/workflows/tag_linux.yml
+++ b/.github/workflows/tag_linux.yml
@@ -39,6 +39,7 @@ jobs:
       DOCKER_BUILDKIT: 1
       ARCH: aarch64
       LIBC: ${{ matrix.name }}
+      RELEASE_VERSION: ${{  github.ref_name }}
     strategy:
       matrix:
         name: ['glibc', 'musl']


### PR DESCRIPTION
Fix https://github.com/grafana/pyroscope-dotnet/actions/runs/10401074098/job/28802852559


```
Run make docker/build
  make docker/build
  shell: /usr/bin/bash -e {0}
  env:
    DOCKER_BUILDKIT: 1
    ARCH: aarch64
    LIBC: musl
Makefile:7: *** "no release version specified".  Stop.
```
x86_64 built fine, arm64 failed