### PR TITLE
fix: do not use method signatures

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/FrameStore.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/FrameStore.cpp
@@ -176,9 +176,6 @@ FrameInfoView FrameStore::GetManagedFrame(FunctionID functionId)
         return {UnknownManagedAssembly, UnknownManagedFrame, {}, 0};
     }
 
-    // get the method signature
-     std::string signature = GetMethodSignature(_pCorProfilerInfo, pMetadataImport.Get(), mdTokenType, functionId, mdTokenFunc);
-
     // get type related description (assembly, namespace and type name)
     // look into the cache first
     TypeDesc* pTypeDesc = nullptr;  // if already in the cache


### PR DESCRIPTION
FIxes https://github.com/grafana/pyroscope-dotnet/issues/79

The assert fails in clr when we receive method signature

```
pwndbg> bt
#0  DBG_DebugBreak () at /home/korniltsev/github/runtime/src/coreclr/pal/src/arch/amd64/debugbreak.S:9
#1  0x00007ffff552be6f in DebugBreak () at /home/korniltsev/github/runtime/src/coreclr/pal/src/debug/debug.cpp:406
#2  0x00007ffff4fdb3fb in DbgAssertDialog (szFile=0x7ffff40512c0 <str> "/home/korniltsev/github/runtime/src/coreclr/md/compiler/import.cpp", iLine=2749, szExpr=0x7ffff4051d60 <str> "TypeFromToken(pd) == mdtParamDef") at /home/korniltsev/github/runtime/src/coreclr/utilcode/debug.cpp:461
#3  0x00007ffff51bfd46 in RegMeta::GetParamProps (this=0x612000072940, pd=0, pmd=0x0, pulSequence=0x7fff7480ca70, szName=0x7fff7480ca80 u"segment", cchName=259, pchName=0x7fff7480cd10, pdwAttr=0x7fff7480c510, pdwCPlusTypeFlag=0x7fff7480cd20, ppValue=0x0, pchValue=0x0) at /home/korniltsev/github/runtime/src/coreclr/md/compiler/import.cpp:2749
#4  0x00007fffee9b3371 in FrameStore::GetMethodSignature (this=0x614000003a40, pInfo=0x6020000035d0, pMetaData=0x612000072940, mdTokenType=33554570, functionId=140735221300952, mdTokenFunc=100664225) at /home/korniltsev/p/pyroscope-dotnet/profiler/src/ProfilerEngine/Datadog.Profiler.Native/FrameStore.cpp:1027
#5  0x00007fffee9aed83 in FrameStore::GetManagedFrame (this=0x614000003a40, functionId=140735221300952) at /home/korniltsev/p/pyroscope-dotnet/profiler/src/ProfilerEngine/Datadog.Profiler.Native/FrameStore.cpp:180
...
```
Let's not invoke `RegMeta::GetParamProps` method. Pyroscope does not use the result anyways.