### PR TITLE
fix: do not use EnvironmentExist in GetEnvironmentValue

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.cpp
@@ -682,7 +682,8 @@ static bool convert_to(shared::WSTRING const& s, DeploymentMode& result)
 template <typename T>
 T Configuration::GetEnvironmentValue(shared::WSTRING const& name, T const& defaultValue)
 {
-    if (!shared::EnvironmentExist(name)) return defaultValue;
+    // pyroscope: next line is removed because shared::GetEnvironmentValue has DD_ => PYROSCOPE_ fallback
+    // if (!shared::EnvironmentExist(name)) return defaultValue;
 
     T result{};
     auto r = shared::GetEnvironmentValue(name);


### PR DESCRIPTION
EnvironmentExist should not be used because it checks for DD_ prefixed keys most of the time, however GetEnvironmentValue has some extra logic for PYROSCOPE_ prefixed keys