### PR TITLE
fix: allow StackSamplerLoopManager to be started after it is stopped

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.cpp
@@ -2075,7 +2075,7 @@ void CorProfilerCallback::SetStackSamplerEnabled(bool enabled)
     }
     else
     {
-        _pStackSamplerLoopManager->Stop();
+        _pStackSamplerLoopManager->Stop2(ServiceBase::State::Init);
     }
 }
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ServiceBase.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ServiceBase.h
@@ -10,15 +10,6 @@
 class ServiceBase : public IService
 {
 public:
-    ServiceBase();
-
-    bool Start() final override;
-    bool Stop() final override;
-
-protected:
-    virtual bool StartImpl() = 0;
-    virtual bool StopImpl() = 0;
-
     enum class State
     {
         Init,
@@ -27,6 +18,19 @@ protected:
         Stopping,
         Stopped
     };
+    ServiceBase();
+
+    bool Start() final override;
+    bool Stop() final override;
+
+    // Like Stop, but allows to specify stopped state - either Stopped or Init. Init allows the service to be restarted.
+    bool Stop2(State stoppedState); // todo better name
+
+protected:
+    virtual bool StartImpl() = 0;
+    virtual bool StopImpl() = 0;
+
+
 
     State GetState() const;
 


### PR DESCRIPTION
Fixes https://github.com/grafana/pyroscope-dotnet/issues/87

This commit https://github.com/DataDog/dd-trace-dotnet/commit/ae3e73989cf7549b9284ce495450d215f9250167#diff-dbc8e1f96c0425b85759b77ca5c23428632eb53a500ae936e8766ebac93ad88a made impossible service to start after it is stopped.

I missed this during last upgrade.