### PR TITLE
switch pyroscope profiler artifacts tagging scheme

### DIFF
--- a/.github/workflows/tag_linux.yml
+++ b/.github/workflows/tag_linux.yml
@@ -3,8 +3,9 @@ name: Release linux profiler
 on:
   push:
     tags:
-      - v*-pyroscope
-
+      - 'v*'
+      - '!v*opentelemetry'
+      - '!v*opentracing'
 jobs:
   release-linux-profiler-x86_64:
     runs-on: ubuntu-latest
@@ -26,6 +27,7 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
+      - run: make bump_version && git diff --exit-code
       - run: make docker/build
       - run: make docker/push
       - run: make docker/archive
@@ -53,6 +55,7 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
+      - run: make bump_version && git diff --exit-code
       - run: make docker/build
       - run: make docker/push
       - run: make docker/archive

--- a/.github/workflows/tag_managed_helper.yml
+++ b/.github/workflows/tag_managed_helper.yml
@@ -3,20 +3,24 @@ name: Release managed helper
 on:
   push:
     tags:
-      - v*-pyroscope
+      - 'v*'
+      - '!v*opentelemetry'
+      - '!v*opentracing'
 
 jobs:
   release-managed-helper:
     runs-on: ubuntu-latest
+    env:
+      RELEASE_VERSION: ${{  github.ref_name }}
     steps:
-      -
-        name: Checkout
+      - name: Checkout
         uses: actions/checkout@v4
         with:
           submodules: 'true'
       - uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '6.0'
+      - run: make bump_version && git diff --exit-code
       - run: dotnet build -c Release
         working-directory: Pyroscope
       - name: Publish the package to nuget.org

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ DOCKER_IMAGE ?= pyroscope/pyroscope-dotnet
 ifeq ($(RELEASE_VERSION),)
   $(error "no release version specified")
 endif
-RELEASE_VERSION_TMP := $(shell echo $(RELEASE_VERSION) | sed -E 's/^v([0-9]+\.[0-9]+\.[0-9]+)-pyroscope$$/\1/')
+RELEASE_VERSION_TMP := $(shell echo $(RELEASE_VERSION) | sed -E 's/^v([0-9]+\.[0-9]+\.[0-9]+)(-pyroscope)?$$/\1/')
 #$(error "debug $(RELEASE_VERSION_TMP)")
 RELEASE_VERSION := $(RELEASE_VERSION_TMP)
 

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.100",
+    "version": "6.0.0",
     "rollForward": "minor"
   }
 }


### PR DESCRIPTION
- remove `-pyroscope` from the tag names
- add `make bump_version && git diff --exit-code`  to make sure we bumped version in source code
- modify globals.json ( i'm not entirely sure why, but it worked fine without this change in grafana repo, but not in korniltsev fork repo) :shrug: