### PR TITLE
Add async support to LabelsWrapper

### DIFF
--- a/IntegrationTest/BikeService.cs
+++ b/IntegrationTest/BikeService.cs
@@ -1,16 +1,7 @@
 namespace Example;
 
-internal class BikeService
+internal class BikeService(OrderService orderService)
 {
-    private readonly OrderService _orderService;
-
-    public BikeService(OrderService orderService)
-    {
-        _orderService = orderService;
-    }
-
-    public void Order(int searchRadius)
-    {
-        _orderService.FindNearestVehicle(searchRadius, "bike");
-    }
+    public void Order(int searchRadius) =>
+        orderService.FindNearestVehicle(searchRadius, "bike");
 }

--- a/IntegrationTest/CarService.cs
+++ b/IntegrationTest/CarService.cs
@@ -1,16 +1,7 @@
 namespace Example;
 
-internal class CarService
+internal class CarService(OrderService orderService)
 {
-    private readonly OrderService _orderService;
-
-    public CarService(OrderService orderService)
-    {
-        _orderService = orderService;
-    }
-
-    public void Order(int searchRadius)
-    {
-        _orderService.FindNearestVehicle(searchRadius, "car");
-    }
+    public void Order(int searchRadius) =>
+        orderService.FindNearestVehicle(searchRadius, "car");
 }

--- a/IntegrationTest/Dockerfile.load-generator
+++ b/IntegrationTest/Dockerfile.load-generator
@@ -1,4 +1,4 @@
-FROM python:3.9
+FROM python:3.12
 
 RUN pip3 install requests
 
@@ -7,4 +7,3 @@ COPY load-generator.py ./load-generator.py
 ENV PYTHONUNBUFFERED=1
 
 CMD [ "python", "load-generator.py" ]
-

--- a/IntegrationTest/HelicopterService.cs
+++ b/IntegrationTest/HelicopterService.cs
@@ -1,0 +1,28 @@
+using System.Globalization;
+using Pyroscope;
+
+namespace Example;
+
+internal class HelicopterService(OrderService orderService)
+{
+    public async Task Order(int searchRadius)
+    {
+        orderService.FindNearestVehicle(searchRadius, "helicopter");
+        await DoWorkAsync(searchRadius);
+    }
+
+    private static async Task DoWorkAsync(int searchRadius)
+    {
+        var labels = LabelSet.Empty.BuildUpon()
+            .Add("search_radius", searchRadius.ToString(CultureInfo.InvariantCulture))
+            .Build();
+
+        await LabelsWrapper.DoAsync(labels, async () =>
+        {
+            for (long i = 0; i < 1_000_000_000; i++)
+            {
+                await Task.Yield();
+            }
+        });
+    }
+}

--- a/IntegrationTest/HelicopterService.cs
+++ b/IntegrationTest/HelicopterService.cs
@@ -19,7 +19,7 @@ internal class HelicopterService(OrderService orderService)
 
         await LabelsWrapper.DoAsync(labels, async () =>
         {
-            for (long i = 0; i < 1_000_000_000; i++)
+            for (long i = 0; i < 1_000; i++)
             {
                 await Task.Yield();
             }

--- a/IntegrationTest/Program.cs
+++ b/IntegrationTest/Program.cs
@@ -1,45 +1,37 @@
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Threading;
-using System.Collections;
+using Example;
 
-using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Builder;
-using Microsoft.Extensions.DependencyInjection;
+var builder = WebApplication.CreateBuilder(args);
 
-namespace Example;
+builder.Services.AddSingleton<BikeService>();
+builder.Services.AddSingleton<CarService>();
+builder.Services.AddSingleton<HelicopterService>();
+builder.Services.AddSingleton<OrderService>();
+builder.Services.AddSingleton<ScooterService>();
 
-public static class Program
+var app = builder.Build();
+
+app.MapGet("/bike", (BikeService service) =>
 {
-    private static readonly List<FileStream> Files = new();
-    public static void Main(string[] args)
-    {
-        var orderService = new OrderService();
-        var bikeService = new BikeService(orderService);
-        var scooterService = new ScooterService(orderService);
-        var carService = new CarService(orderService);
+    service.Order(1);
+    return "Bike ordered";
+});
 
-        var builder = WebApplication.CreateBuilder(args);
-        var app = builder.Build();
+app.MapGet("/scooter", (ScooterService service) =>
+{
+    service.Order(2);
+    return "Scooter ordered";
+});
 
-        app.MapGet("/bike", () =>
-        {
-            bikeService.Order(1);
-            return "Bike ordered";
-        });
-        app.MapGet("/scooter", () =>
-        {
-            scooterService.Order(2);
-            return "Scooter ordered";
-        });
+app.MapGet("/car", (CarService service) =>
+{
+    service.Order(3);
+    return "Car ordered";
+});
 
-        app.MapGet("/car", () =>
-        {
-            carService.Order(3);
-            return "Car ordered";
-        });
+app.MapGet("/helicopter", async (HelicopterService service) =>
+{
+    await service.Order(4);
+    return "Helicopter ordered";
+});
 
-        app.Run();
-    }
-}
+app.Run();

--- a/IntegrationTest/Properties/launchSettings.json
+++ b/IntegrationTest/Properties/launchSettings.json
@@ -1,0 +1,12 @@
+{
+  "profiles": {
+    "Rideshare": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "https://localhost:56129;http://localhost:56130"
+    }
+  }
+}

--- a/IntegrationTest/Rideshare.csproj
+++ b/IntegrationTest/Rideshare.csproj
@@ -1,9 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>rideshare</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>rideshare</PackageId>
+    <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>

--- a/IntegrationTest/ScooterService.cs
+++ b/IntegrationTest/ScooterService.cs
@@ -1,33 +1,25 @@
-using System.Diagnostics;
-
 namespace Example;
 
-internal class ScooterService
+internal class ScooterService(OrderService orderService)
 {
-    private readonly OrderService _orderService;
-
-    public ScooterService(OrderService orderService)
-    {
-        _orderService = orderService;
-    }
-
     public void Order(int searchRadius)
     {
-        for (long i = 0; i < 2000000000; i++)
+        for (long i = 0; i < 2_000_000_000; i++)
         {
         }
+
         OrderInternal(searchRadius);
         DoSomeOtherWork();
     }
 
     private void OrderInternal(int searchRadius)
     {
-        _orderService.FindNearestVehicle(searchRadius, "scooter");
+        orderService.FindNearestVehicle(searchRadius, "scooter");
     }
 
-    private void DoSomeOtherWork()
+    private static void DoSomeOtherWork()
     {
-        for (long i = 0; i < 1000000000; i++)
+        for (long i = 0; i < 1_000_000_000; i++)
         {
         }
     }

--- a/IntegrationTest/load-generator.py
+++ b/IntegrationTest/load-generator.py
@@ -9,6 +9,7 @@ VEHICLES = [
     'bike',
     'scooter',
     'car',
+    'helicopter',
 ]
 
 if __name__ == "__main__":

--- a/IntegrationTest/verify_profiles.sh
+++ b/IntegrationTest/verify_profiles.sh
@@ -20,7 +20,7 @@ cat profilecli_output.json
 labels=$(cat profilecli_output.json)
 
 # Verify that all expected labels are present
-expected_labels=("bike" "car" "scooter")
+expected_labels=("bike" "car" "scooter", "helicopter")
 actual_labels=($(cat profilecli_output.json))
 
 if [ ${#actual_labels[@]} -ne ${#expected_labels[@]} ]; then
@@ -41,4 +41,4 @@ for i in "${!expected_labels[@]}"; do
   fi
 done
 
-echo "Successfully verified all expected labels (bike, car, scooter) are present"
+echo "Successfully verified all expected labels (bike, car, scooter, helicopter) are present"

--- a/Pyroscope/Pyroscope.OpenTelemetry/Pyroscope.OpenTelemetry.csproj
+++ b/Pyroscope/Pyroscope.OpenTelemetry/Pyroscope.OpenTelemetry.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <PackageVersion>0.3.0</PackageVersion>
     <AssemblyVersion>0.3.0</AssemblyVersion>
     <FileVersion>0.3.0</FileVersion>

--- a/Pyroscope/Pyroscope.OpenTracing/Pyroscope.OpenTracing.csproj
+++ b/Pyroscope/Pyroscope.OpenTracing/Pyroscope.OpenTracing.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <PackageVersion>0.3.0</PackageVersion>
     <AssemblyVersion>0.3.0</AssemblyVersion>
     <FileVersion>0.3.0</FileVersion>

--- a/Pyroscope/Pyroscope.OpenTracing/PyroscopeSpanBuilder.cs
+++ b/Pyroscope/Pyroscope.OpenTracing/PyroscopeSpanBuilder.cs
@@ -8,7 +8,7 @@ public class PyroscopeSpanBuilder : ISpanBuilder
     private const string ProfileIdSpanTagKey = "pyroscope.profile.id";
 
     private readonly ISpanBuilder _delegate;
-    private ISpanContext? _parent;
+    private readonly ISpanContext? _parent;
 
     internal PyroscopeSpanBuilder(ISpanBuilder spanBuilder, ISpanContext? parent)
     {
@@ -135,7 +135,7 @@ public class PyroscopeSpanBuilder : ISpanBuilder
         return this;
     }
 
-    class PyroscopeScope : IScope
+    private sealed class PyroscopeScope : IScope
     {
         private readonly IScope _delegate;
         private readonly ISpanContext? _parent;

--- a/Pyroscope/Pyroscope/LabelsWrapper.cs
+++ b/Pyroscope/Pyroscope/LabelsWrapper.cs
@@ -11,14 +11,84 @@ public static class LabelsWrapper
         }
         finally
         {
-            if (labels.Previous == null)
-            {
-                Profiler.Instance.ClearDynamicTags();
-            }
-            else
-            {
-                labels.Previous.Activate();
-            }
+            ResetLabels(labels);
+        }
+    }
+
+    public static void Do<T>(LabelSet labels, Action<T> a, T state)
+    {
+        try
+        {
+            labels.Activate();
+            a.Invoke(state);
+        }
+        finally
+        {
+            ResetLabels(labels);
+        }
+    }
+
+    public static async Task DoAsync(LabelSet labels, Func<Task> a)
+    {
+        try
+        {
+            labels.Activate();
+            await a();
+        }
+        finally
+        {
+            ResetLabels(labels);
+        }
+    }
+
+    public static async Task DoAsync<T>(LabelSet labels, T state, Func<T, Task> a)
+    {
+        try
+        {
+            labels.Activate();
+            await a(state);
+        }
+        finally
+        {
+            ResetLabels(labels);
+        }
+    }
+
+    public static async Task<T> DoAsync<T>(LabelSet labels, Func<Task<T>> a)
+    {
+        try
+        {
+            labels.Activate();
+            return await a();
+        }
+        finally
+        {
+            ResetLabels(labels);
+        }
+    }
+
+    public static async Task<TResult> DoAsync<TState, TResult>(LabelSet labels, TState state, Func<TState, Task<TResult>> a)
+    {
+        try
+        {
+            labels.Activate();
+            return await a(state);
+        }
+        finally
+        {
+            ResetLabels(labels);
+        }
+    }
+
+    private static void ResetLabels(LabelSet labels)
+    {
+        if (labels.Previous == null)
+        {
+            Profiler.Instance.ClearDynamicTags();
+        }
+        else
+        {
+            labels.Previous.Activate();
         }
     }
 }

--- a/Pyroscope/Pyroscope/Pyroscope.csproj
+++ b/Pyroscope/Pyroscope/Pyroscope.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
         <PackageVersion>0.12.0</PackageVersion>
         <AssemblyVersion>0.12.0</AssemblyVersion>
         <FileVersion>0.12.0</FileVersion>


### PR DESCRIPTION
- Add new overloads to `LabelsWrapper` to support `async` and passing through state to avoid allocating closures.
- Add target for `net8.0` to the Pyroscope libraries.
- Update the application in the integration tests to .NET 8 and use more modern C# features.
- Update integration tests to use Python 3.12.
- Fix some code analysis warnings.
