### PR TITLE
chore: rename soname to Pyroscope.Profiler.Native

### DIFF
--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   build-profiler-images:
     name: Build Profiler Image
-    runs-on: github-hosted-ubuntu-x64-large
+    runs-on: ubuntu-x64-large
     strategy:
       matrix:
         flavour:
@@ -39,7 +39,7 @@ jobs:
   run-integration-test:
     name: Run Integration Test
     needs: build-profiler-images
-    runs-on: github-hosted-ubuntu-x64-large
+    runs-on: ubuntu-x64-large
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   build-profiler-images:
     name: Build Profiler Image
-    runs-on: ubuntu-latest
+    runs-on: github-hosted-ubuntu-x64-large
     strategy:
       matrix:
         flavour:
@@ -39,7 +39,7 @@ jobs:
   run-integration-test:
     name: Run Integration Test
     needs: build-profiler-images
-    runs-on: ubuntu-latest
+    runs-on: github-hosted-ubuntu-x64-large
     strategy:
       fail-fast: false
       matrix:

--- a/Pyroscope.Dockerfile
+++ b/Pyroscope.Dockerfile
@@ -30,9 +30,9 @@ RUN mkdir build-${CMAKE_BUILD_TYPE} && \
         -DCMAKE_CXX_FLAGS_DEBUG="-g -O0" \
         -DCMAKE_C_FLAGS_DEBUG="-g -O0"
 
-RUN cd build-${CMAKE_BUILD_TYPE} && make -j16 Datadog.Profiler.Native Datadog.Linux.ApiWrapper.x64
+RUN cd build-${CMAKE_BUILD_TYPE} && make -j16 Pyroscope.Profiler.Native Datadog.Linux.ApiWrapper.x64
 
 FROM busybox:1.36.1-glibc
-COPY --from=builder /profiler/profiler/_build/DDProf-Deploy/linux/Datadog.Profiler.Native.so /Pyroscope.Profiler.Native.so
+COPY --from=builder /profiler/profiler/_build/DDProf-Deploy/linux/Pyroscope.Profiler.Native.so /Pyroscope.Profiler.Native.so
 COPY --from=builder /profiler/profiler/_build/DDProf-Deploy/linux/Datadog.Linux.ApiWrapper.x64.so /Pyroscope.Linux.ApiWrapper.x64.so
 

--- a/Pyroscope.Dockerfile
+++ b/Pyroscope.Dockerfile
@@ -30,9 +30,9 @@ RUN mkdir build-${CMAKE_BUILD_TYPE} && \
         -DCMAKE_CXX_FLAGS_DEBUG="-g -O0" \
         -DCMAKE_C_FLAGS_DEBUG="-g -O0"
 
-RUN cd build-${CMAKE_BUILD_TYPE} && make -j16 Pyroscope.Profiler.Native Datadog.Linux.ApiWrapper.x64
+RUN cd build-${CMAKE_BUILD_TYPE} && make -j16 Datadog.Profiler.Native Datadog.Linux.ApiWrapper.x64
 
 FROM busybox:1.36.1-glibc
-COPY --from=builder /profiler/profiler/_build/DDProf-Deploy/linux/Pyroscope.Profiler.Native.so /Pyroscope.Profiler.Native.so
+COPY --from=builder /profiler/profiler/_build/DDProf-Deploy/linux/Datadog.Profiler.Native.so /Pyroscope.Profiler.Native.so
 COPY --from=builder /profiler/profiler/_build/DDProf-Deploy/linux/Datadog.Linux.ApiWrapper.x64.so /Pyroscope.Linux.ApiWrapper.x64.so
 

--- a/Pyroscope.musl.Dockerfile
+++ b/Pyroscope.musl.Dockerfile
@@ -38,9 +38,9 @@ RUN mkdir build-${CMAKE_BUILD_TYPE} && \
         -DCMAKE_CXX_FLAGS_DEBUG="-g -O0" \
         -DCMAKE_C_FLAGS_DEBUG="-g -O0"
 
-RUN cd build-${CMAKE_BUILD_TYPE} && make -j16 Pyroscope.Profiler.Native Datadog.Linux.ApiWrapper.x64
+RUN cd build-${CMAKE_BUILD_TYPE} && make -j16 Datadog.Profiler.Native Datadog.Linux.ApiWrapper.x64
 
 FROM busybox:1.36.1-musl
-COPY --from=builder /profiler/profiler/_build/DDProf-Deploy/linux-musl/Pyroscope.Profiler.Native.so /Pyroscope.Profiler.Native.so
+COPY --from=builder /profiler/profiler/_build/DDProf-Deploy/linux-musl/Datadog.Profiler.Native.so /Pyroscope.Profiler.Native.so
 COPY --from=builder /profiler/profiler/_build/DDProf-Deploy/linux-musl/Datadog.Linux.ApiWrapper.x64.so /Pyroscope.Linux.ApiWrapper.x64.so
 

--- a/Pyroscope.musl.Dockerfile
+++ b/Pyroscope.musl.Dockerfile
@@ -38,9 +38,9 @@ RUN mkdir build-${CMAKE_BUILD_TYPE} && \
         -DCMAKE_CXX_FLAGS_DEBUG="-g -O0" \
         -DCMAKE_C_FLAGS_DEBUG="-g -O0"
 
-RUN cd build-${CMAKE_BUILD_TYPE} && make -j16 Datadog.Profiler.Native Datadog.Linux.ApiWrapper.x64
+RUN cd build-${CMAKE_BUILD_TYPE} && make -j16 Pyroscope.Profiler.Native Datadog.Linux.ApiWrapper.x64
 
 FROM busybox:1.36.1-musl
-COPY --from=builder /profiler/profiler/_build/DDProf-Deploy/linux-musl/Datadog.Profiler.Native.so /Pyroscope.Profiler.Native.so
+COPY --from=builder /profiler/profiler/_build/DDProf-Deploy/linux-musl/Pyroscope.Profiler.Native.so /Pyroscope.Profiler.Native.so
 COPY --from=builder /profiler/profiler/_build/DDProf-Deploy/linux-musl/Datadog.Linux.ApiWrapper.x64.so /Pyroscope.Linux.ApiWrapper.x64.so
 

--- a/Pyroscope/Pyroscope/Profiler.cs
+++ b/Pyroscope/Pyroscope/Profiler.cs
@@ -37,7 +37,6 @@ namespace Pyroscope
         {
             if (_dllNotFound)
             {
-            Console.WriteLine(">>> dll not found");
                 return;
             }
             try

--- a/Pyroscope/Pyroscope/Profiler.cs
+++ b/Pyroscope/Pyroscope/Profiler.cs
@@ -37,6 +37,7 @@ namespace Pyroscope
         {
             if (_dllNotFound)
             {
+            Console.WriteLine(">>> dll not found");
                 return;
             }
             try

--- a/Pyroscope/Pyroscope/Profiler.cs
+++ b/Pyroscope/Pyroscope/Profiler.cs
@@ -43,8 +43,9 @@ namespace Pyroscope
             {
                 NativeInterop.SetDynamicTag(key, value);
             }
-            catch (DllNotFoundException)
+            catch (DllNotFoundException ex)
             {
+                DllNotFound(ex);
                 _dllNotFound = true;
             }
         }
@@ -59,8 +60,9 @@ namespace Pyroscope
             {
                 NativeInterop.ClearDynamicTags();
             }
-            catch (DllNotFoundException)
+            catch (DllNotFoundException ex)
             {
+                DllNotFound(ex);
                 _dllNotFound = true;
             }
         }
@@ -80,8 +82,9 @@ namespace Pyroscope
             {
                 NativeInterop.SetCPUTrackingEnabled(enabled);
             }
-            catch (DllNotFoundException)
+            catch (DllNotFoundException ex)
             {
+                DllNotFound(ex);
                 _dllNotFound = true;
             }
         }
@@ -100,8 +103,9 @@ namespace Pyroscope
             {
                 NativeInterop.SetAllocationTrackingEnabled(enabled);
             }
-            catch (DllNotFoundException)
+            catch (DllNotFoundException ex)
             {
+                DllNotFound(ex);
                 _dllNotFound = true;
             }
         }
@@ -120,8 +124,9 @@ namespace Pyroscope
             {
                 NativeInterop.SetContentionTrackingEnabled(enabled);
             }
-            catch (DllNotFoundException)
+            catch (DllNotFoundException ex)
             {
+                DllNotFound(ex);
                 _dllNotFound = true;
             }
         }
@@ -140,8 +145,9 @@ namespace Pyroscope
             {
                 NativeInterop.SetExceptionTrackingEnabled(enabled);
             }
-            catch (DllNotFoundException)
+            catch (DllNotFoundException ex)
             {
+                DllNotFound(ex);
                 _dllNotFound = true;
             }
         }
@@ -156,8 +162,9 @@ namespace Pyroscope
             {
                 NativeInterop.SetAuthToken(authToken);
             }
-            catch (DllNotFoundException)
+            catch (DllNotFoundException ex)
             {
+                DllNotFound(ex);
                 _dllNotFound = true;
             }
         }
@@ -172,10 +179,15 @@ namespace Pyroscope
             {
                 NativeInterop.SetBasicAuth(username, password);
             }
-            catch (DllNotFoundException)
+            catch (DllNotFoundException ex)
             {
+                DllNotFound(ex);
                 _dllNotFound = true;
             }
+        }
+
+        private static void DllNotFound(DllNotFoundException ex) {
+            Console.WriteLine($"[Profiler] Failed to load Pyroscope.Profiler.Native.so : {ex}.\nConsider setting LD_LIBRARY_PATH pointing to the directory containing the Pyroscope.Profiler.Native.so");
         }
         
         private readonly ContextTracker _contextTracker;

--- a/itest.Dockerfile
+++ b/itest.Dockerfile
@@ -33,15 +33,17 @@ FROM --platform=linux/amd64 mcr.microsoft.com/dotnet/aspnet:$SDK_VERSION$SDK_IMA
 
 WORKDIR /dotnet
 
-COPY --from=sdk /Pyroscope.Profiler.Native.so ./Pyroscope.Profiler.Native.so
-COPY --from=sdk /Pyroscope.Linux.ApiWrapper.x64.so ./Pyroscope.Linux.ApiWrapper.x64.so
+# place the binaries in a subfolder - to rigger a problme when SONAME was Datadog.Profiler.Native
+# and dynamic linker could not find the profiler lib.
+COPY --from=sdk /Pyroscope.Profiler.Native.so ./subfolder/Pyroscope.Profiler.Native.so
+COPY --from=sdk /Pyroscope.Linux.ApiWrapper.x64.so ./subfolder/Pyroscope.Linux.ApiWrapper.x64.so
 COPY --from=build /dotnet/app ./
 
 
 ENV CORECLR_ENABLE_PROFILING=1
 ENV CORECLR_PROFILER={BD1A650D-AC5D-4896-B64F-D6FA25D6B26A}
-ENV CORECLR_PROFILER_PATH=/dotnet/Pyroscope.Profiler.Native.so
-ENV LD_PRELOAD=/dotnet/Pyroscope.Linux.ApiWrapper.x64.so
+ENV CORECLR_PROFILER_PATH=/dotnet/subfolder/Pyroscope.Profiler.Native.so
+ENV LD_PRELOAD=/dotnet/subfolder/Pyroscope.Linux.ApiWrapper.x64.so
 
 ENV PYROSCOPE_SERVER_ADDRESS=http://pyroscope:4040
 ENV PYROSCOPE_LOG_LEVEL=debug

--- a/itest.Dockerfile
+++ b/itest.Dockerfile
@@ -39,6 +39,8 @@ COPY --from=sdk /Pyroscope.Profiler.Native.so ./subfolder/Pyroscope.Profiler.Nat
 COPY --from=sdk /Pyroscope.Linux.ApiWrapper.x64.so ./subfolder/Pyroscope.Linux.ApiWrapper.x64.so
 COPY --from=build /dotnet/app ./
 
+# Fix for alpine not being able to dlopen an already loaded library
+ENV LD_LIBRARY_PATH=/dotnet/subfolder/
 
 ENV CORECLR_ENABLE_PROFILING=1
 ENV CORECLR_PROFILER={BD1A650D-AC5D-4896-B64F-D6FA25D6B26A}

--- a/profiler/CMakeLists.txt
+++ b/profiler/CMakeLists.txt
@@ -143,7 +143,7 @@ enable_testing()
 add_subdirectory(test)
 
 add_custom_target(profiler)
-add_dependencies(profiler Datadog.Profiler.Native)
+add_dependencies(profiler Pyroscope.Profiler.Native)
 
 add_custom_target(all-profiler)
 add_dependencies(all-profiler profiler profiler-native-tests)

--- a/profiler/CMakeLists.txt
+++ b/profiler/CMakeLists.txt
@@ -143,7 +143,7 @@ enable_testing()
 add_subdirectory(test)
 
 add_custom_target(profiler)
-add_dependencies(profiler Pyroscope.Profiler.Native)
+add_dependencies(profiler Datadog.Profiler.Native)
 
 add_custom_target(all-profiler)
 add_dependencies(all-profiler profiler profiler-native-tests)

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/CMakeLists.txt
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/CMakeLists.txt
@@ -55,7 +55,7 @@ endif()
 # Environment detection
 # ******************************************************
 
-SET(PROFILER_BASENAME Datadog.Profiler.Native)
+SET(PROFILER_BASENAME Pyroscope.Profiler.Native)
 SET(PROFILER_STATIC_LIB_NAME ${PROFILER_BASENAME}.static)
 SET(PROFILER_SHARED_LIB_NAME ${PROFILER_BASENAME})
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/CMakeLists.txt
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/CMakeLists.txt
@@ -55,7 +55,7 @@ endif()
 # Environment detection
 # ******************************************************
 
-SET(PROFILER_BASENAME Pyroscope.Profiler.Native)
+SET(PROFILER_BASENAME Datadog.Profiler.Native)
 SET(PROFILER_STATIC_LIB_NAME ${PROFILER_BASENAME}.static)
 SET(PROFILER_SHARED_LIB_NAME ${PROFILER_BASENAME})
 

--- a/profiler/test/Datadog.Profiler.Native.Tests/CMakeLists.txt
+++ b/profiler/test/Datadog.Profiler.Native.Tests/CMakeLists.txt
@@ -63,7 +63,7 @@ target_include_directories(${TEST_EXECUTABLE_NAME}
     PUBLIC ${googletest_SOURCE_DIR}/googlemock/include
 )
 
-add_dependencies(${TEST_EXECUTABLE_NAME} gmock gtest Datadog.Profiler.Native.static libunwind)
+add_dependencies(${TEST_EXECUTABLE_NAME} gmock gtest Pyroscope.Profiler.Native.static libunwind)
 
 if (RUN_ASAN)
     target_link_libraries(${TEST_EXECUTABLE_NAME} -fsanitize=address)
@@ -74,7 +74,7 @@ if (RUN_UBSAN)
 endif()
 
 target_link_libraries(${TEST_EXECUTABLE_NAME}
-  Datadog.Profiler.Native.static
+  Pyroscope.Profiler.Native.static
   gtest_main
   gmock_main
   -static-libgcc

--- a/profiler/test/Datadog.Profiler.Native.Tests/CMakeLists.txt
+++ b/profiler/test/Datadog.Profiler.Native.Tests/CMakeLists.txt
@@ -63,7 +63,7 @@ target_include_directories(${TEST_EXECUTABLE_NAME}
     PUBLIC ${googletest_SOURCE_DIR}/googlemock/include
 )
 
-add_dependencies(${TEST_EXECUTABLE_NAME} gmock gtest Pyroscope.Profiler.Native.static libunwind)
+add_dependencies(${TEST_EXECUTABLE_NAME} gmock gtest Datadog.Profiler.Native.static libunwind)
 
 if (RUN_ASAN)
     target_link_libraries(${TEST_EXECUTABLE_NAME} -fsanitize=address)
@@ -74,7 +74,7 @@ if (RUN_UBSAN)
 endif()
 
 target_link_libraries(${TEST_EXECUTABLE_NAME}
-  Pyroscope.Profiler.Native.static
+  Datadog.Profiler.Native.static
   gtest_main
   gmock_main
   -static-libgcc


### PR DESCRIPTION
Fixes an issue with tags

```
[ProfilerStatus] Failed to get profiler status pointer: Unable to load shared library 'Pyroscope.Profiler.Native' or one of its dependencies. In order to help diagnose loading problems, consider using a tool like strace. If you're using glibc, consider setting the LD_DEBUG environment variable:
/usr/share/dotnet/shared/Microsoft.NETCore.App/8.0.20/Pyroscope.Profiler.Native.so: cannot open shared object file: No such file or directory
/app/Pyroscope.Profiler.Native.so: cannot open shared object file: No such file or directory
```

Before:
```
 0x000000000000000e (SONAME)             Library soname: [Datadog.Profiler.Native.so]
```
After:
```
 0x000000000000000e (SONAME)             Library soname: [Pyroscope.Profiler.Native.so]
```

To reproduce - put the profiler into non-current directory - I updated the test accordingly.