### PR TITLE
fix sigsegv: mask SIGPROF during SIGSEGV handling by the coreclr

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Linux.ApiWrapper/functions_to_wrap.c
+++ b/profiler/src/ProfilerEngine/Datadog.Linux.ApiWrapper/functions_to_wrap.c
@@ -575,6 +575,7 @@ static void patch_coreclr_sigsegv_sigaction(int signum, struct sigaction* act)
         return;
     }
     sigaddset(&act->sa_mask, SIGPROF);
+    sigaddset(&act->sa_mask, SIGUSR1);
 }
 
 int sigaction(int signum, const struct sigaction* act, struct sigaction* oldact)


### PR DESCRIPTION
This is a workaround for a SIGSEGV when the kernel fails to setup a `rt_sigframe` for `SIGPROF` / `SIGUSR1` while handling `SIGSEGV` ( null pointer dereference in managed code)
```
x64_setup_rt_frame failed for pid 1018346 (.NET TP Worker), ret=-14, sig=10
        handle_signal
        arch_do_signal_or_restart
        irqentry_exit_to_user_mode
        irqentry_exit
        sysvec_reschedule_ipi
        asm_sysvec_reschedule_ipi

signal_setup_done failed for pid 1018346 (.NET TP Worker), sig=10
        signal_setup_done
        arch_do_signal_or_restart
        irqentry_exit_to_user_mode
        irqentry_exit
        sysvec_reschedule_ipi
        asm_sysvec_reschedule_ipi

vfs_coredump for pid 1018346 (.NET TP Worker)
        do_coredump
        arch_do_signal_or_restart
        irqentry_exit_to_user_mode
        irqentry_exit
        sysvec_reschedule_ipi
        asm_sysvec_reschedule_ipi
```
