### PR TITLE
feat: improve GitHub workflows to support RC releases

### DIFF
--- a/.github/workflows/tag_linux.yml
+++ b/.github/workflows/tag_linux.yml
@@ -36,7 +36,10 @@ jobs:
         with:
           username: ${{ env.DOCKERHUB_USERNAME }}
           password: ${{ env.DOCKERHUB_PASSWORD }}
-      - run: make bump_version && git diff --exit-code
+      - run: make bump_version
+      - name: Check version matches committed version
+        if: ${{ !contains(github.ref_name, '-rc') }}
+        run: git diff --exit-code
       - run: make docker/build
       - run: make docker/push
       - run: make docker/archive
@@ -44,6 +47,7 @@ jobs:
         uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
         with:
           files: ./*.tar.gz
+          make_latest: ${{ !contains(github.ref_name, '-rc') }}
   release-linux-profiler-aarch64:
     permissions:
       contents: write
@@ -73,7 +77,10 @@ jobs:
         with:
           username: ${{ env.DOCKERHUB_USERNAME }}
           password: ${{ env.DOCKERHUB_PASSWORD }}
-      - run: make bump_version && git diff --exit-code
+      - run: make bump_version
+      - name: Check version matches committed version
+        if: ${{ !contains(github.ref_name, '-rc') }}
+        run: git diff --exit-code
       - run: make docker/build
       - run: make docker/push
       - run: make docker/archive
@@ -81,6 +88,7 @@ jobs:
         uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
         with:
           files: ./*.tar.gz
+          make_latest: ${{ !contains(github.ref_name, '-rc') }}
   release-linux-profiler:
     permissions:
       contents: read
@@ -111,3 +119,6 @@ jobs:
           username: ${{ env.DOCKERHUB_USERNAME }}
           password: ${{ env.DOCKERHUB_PASSWORD }}
       - run: make docker/manifest
+      - name: Push latest manifest
+        if: ${{ !contains(github.ref_name, '-rc') }}
+        run: make docker/manifest-latest

--- a/.github/workflows/tag_managed_helper.yml
+++ b/.github/workflows/tag_managed_helper.yml
@@ -25,20 +25,25 @@ jobs:
       - uses: actions/setup-dotnet@131b410979e0b49e2162c0718030257b22d6dc2c
         with:
           dotnet-version: '10.0.100'
-      - run: make bump_version && git diff --exit-code
+      - run: make bump_version
+      - name: Check version matches committed version
+        if: ${{ !contains(github.ref_name, '-rc') }}
+        run: git diff --exit-code
       - run: dotnet build -c Release
         working-directory: Pyroscope
-      - name: Publish NuGet packages
+      - name: Upload NuGet packages
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: packages
           path: ./Pyroscope/artifacts/package/release
           if-no-files-found: error
       - uses: grafana/shared-workflows/actions/get-vault-secrets@ac5193564bb463032623a9a0ba23716f866f309c
+        if: ${{ !contains(github.ref_name, '-rc') }}
         with:
           repo_secrets: |
             NUGET_API_KEY=nuget:api_key
       - name: Publish the package to nuget.org
+        if: ${{ !contains(github.ref_name, '-rc') }}
         run: dotnet nuget push ./Pyroscope/artifacts/package/release/*.nupkg -k "${NUGET_API_KEY}" -s https://api.nuget.org/v3/index.json
         env:
           NUGET_API_KEY: ${{ env.NUGET_API_KEY }}
@@ -49,3 +54,4 @@ jobs:
           files: |
             ./Pyroscope/artifacts/bin/Pyroscope/release/Pyroscope.dll
             ./Pyroscope/artifacts/package/release/Pyroscope*.nupkg
+          make_latest: ${{ !contains(github.ref_name, '-rc') }}

--- a/Makefile
+++ b/Makefile
@@ -45,13 +45,15 @@ docker/manifest:
 	docker manifest create \
 		$(DOCKER_IMAGE):$(RELEASE_VERSION)-$(LIBC)                 \
 		--amend $(DOCKER_IMAGE):$(RELEASE_VERSION)-$(LIBC)-x86_64   \
-		--amend $(DOCKER_IMAGE):$(RELEASE_VERSION)-$(LIBC)-aarch64 
+		--amend $(DOCKER_IMAGE):$(RELEASE_VERSION)-$(LIBC)-aarch64
 	docker manifest push $(DOCKER_IMAGE):$(RELEASE_VERSION)-$(LIBC)
 
+.phony: docker/manifest-latest
+docker/manifest-latest:
 	docker manifest create \
 		$(DOCKER_IMAGE):latest-$(LIBC)                 \
 		--amend $(DOCKER_IMAGE):$(RELEASE_VERSION)-$(LIBC)-x86_64   \
-		--amend $(DOCKER_IMAGE):$(RELEASE_VERSION)-$(LIBC)-aarch64 
+		--amend $(DOCKER_IMAGE):$(RELEASE_VERSION)-$(LIBC)-aarch64
 	docker manifest push $(DOCKER_IMAGE):latest-$(LIBC)
 
 


### PR DESCRIPTION
## Summary
- Skip NuGet publishing for RC releases (managed helper only builds and uploads to GitHub)
- Don't mark RC releases as "latest" on GitHub releases
- Skip version validation (`git diff --exit-code`) for RC releases
- Split `docker/manifest` into `docker/manifest` and `docker/manifest-latest` targets

RC releases are detected by checking if the tag contains `-rc` (e.g., `v1.0.0-rc.1`).

Closes #159

## Test plan
- [ ] Tag a regular release (e.g., `v1.0.0`) and verify normal behavior
- [ ] Tag an RC release (e.g., `v1.0.0-rc.1`) and verify:
  - NuGet publishing is skipped
  - GitHub release is not marked as "latest"
  - Version validation is skipped
  - Docker latest manifest is not pushed

🤖 Generated with [Claude Code](https://claude.com/claude-code)