### PR TITLE
fix: handle RC versions in release workflows

### DIFF
--- a/.github/workflows/tag_tracing_opentelemetry_helper.yml
+++ b/.github/workflows/tag_tracing_opentelemetry_helper.yml
@@ -44,3 +44,4 @@ jobs:
           files: |
             ./Pyroscope/artifacts/bin/Pyroscope.OpenTelemetry/release/Pyroscope.OpenTelemetry.dll
             ./Pyroscope/artifacts/package/release/Pyroscope.OpenTelemetry*.nupkg
+          make_latest: ${{ !contains(github.ref_name, '-rc') }}

--- a/.github/workflows/tag_tracing_opentracing_helper.yml
+++ b/.github/workflows/tag_tracing_opentracing_helper.yml
@@ -44,3 +44,4 @@ jobs:
           files: |
             ./Pyroscope/artifacts/bin/Pyroscope.OpenTracing/release/Pyroscope.OpenTracing.dll
             ./Pyroscope/artifacts/package/release/Pyroscope.OpenTracing*.nupkg
+          make_latest: ${{ !contains(github.ref_name, '-rc') }}

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ DOCKER_IMAGE ?= pyroscope/pyroscope-dotnet
 ifeq ($(RELEASE_VERSION),)
   $(error "no release version specified")
 endif
-RELEASE_VERSION_TMP := $(shell echo $(RELEASE_VERSION) | sed -E 's/^v([0-9]+\.[0-9]+\.[0-9]+)(-pyroscope)?$$/\1/')
+RELEASE_VERSION_TMP := $(shell echo $(RELEASE_VERSION) | sed -E 's/^v([0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?)(-pyroscope)?$$/\1/')
 #$(error "debug $(RELEASE_VERSION_TMP)")
 RELEASE_VERSION := $(RELEASE_VERSION_TMP)
 


### PR DESCRIPTION
## Summary
- Fix Makefile regex to properly parse RC version tags (e.g., `v0.14.0-rc.6-pyroscope` → `0.14.0-rc.6`)
- Add `make_latest` parameter to OpenTracing and OpenTelemetry release workflows to prevent RC releases from being marked as latest

## Problem
1. The Makefile regex only handled stable versions, causing RC tags like `v0.14.0-rc.6-pyroscope` to pass through unchanged, resulting in invalid NuGet version strings
2. The OpenTracing and OpenTelemetry workflows were missing the `make_latest` logic, potentially marking RC releases as latest

## Test plan
- [x] Verified regex handles all version formats:
  - `v0.14.0-rc.6-pyroscope` → `0.14.0-rc.6`
  - `v0.14.0-pyroscope` → `0.14.0`
  - `v0.14.0` → `0.14.0`
  - `v0.14.0-rc.6` → `0.14.0-rc.6`

🤖 Generated with [Claude Code](https://claude.com/claude-code)