### PR TITLE
fix: use default server address when env var is not set

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.cpp
@@ -703,11 +703,14 @@ static bool convert_to(shared::WSTRING const& s, DeploymentMode& result)
 template <typename T>
 T Configuration::GetEnvironmentValue(shared::WSTRING const& name, T const& defaultValue, bool shouldLog)
 {
-    // pyroscope: next line is removed because shared::GetEnvironmentValue has DD_ => PYROSCOPE_ fallback
-    // if (!shared::EnvironmentExist(name)) return defaultValue;
+    bool existed = false;
+    auto r = shared::GetEnvironmentValue(name, existed);
+    if (!existed)
+    {
+        return defaultValue;
+    }
 
     T result{};
-    auto r = shared::GetEnvironmentValue(name);
     if (!convert_to(r, result))
     {
         if (shouldLog)

--- a/shared/src/native-src/util.h
+++ b/shared/src/native-src/util.h
@@ -51,8 +51,10 @@ namespace shared
     bool EnvironmentExist(const WSTRING& name);
 
     // GetEnvironmentValue returns the environment variable value for the given
-    // name. Space is trimmed.
+    // name. Space is trimmed. If existed is provided, it will be set to true if
+    // the environment variable exists, false otherwise.
     WSTRING GetEnvironmentValue(const WSTRING& name);
+    WSTRING GetEnvironmentValue(const WSTRING& name, bool& existed);
 
     // GetEnvironmentValues returns environment variable values for the given name
     // split by the delimiter. Space is trimmed and empty values are ignored.


### PR DESCRIPTION
## Summary
- Added `GetEnvironmentValue` overload that reports whether the environment variable exists
- `Configuration::GetEnvironmentValue` now returns the default value when the env var doesn't exist (rather than when it's empty)
- This fixes the issue where `PYROSCOPE_SERVER_ADDRESS` defaulted to an empty string instead of `http://localhost:4040`

Fixes #167

## Test plan
- [ ] Set `PYROSCOPE_SERVER_ADDRESS` to a custom value → custom value is used
- [ ] Set `PYROSCOPE_SERVER_ADDRESS=""` → empty string is used
- [ ] Don't set `PYROSCOPE_SERVER_ADDRESS` → default `http://localhost:4040` is used

🤖 Generated with [Claude Code](https://claude.ai/code)