### PR TITLE
cmake: always generate compile_commands.json

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,8 @@ endif()
 
 project("Datadog.APM.Native" VERSION 2.18.0)
 
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
 # ******************************************************
 # Environment detection
 # ******************************************************


### PR DESCRIPTION
## Summary
- Enable `CMAKE_EXPORT_COMPILE_COMMANDS ON` unconditionally in the top-level `CMakeLists.txt`
- Previously this was only set when the `RUN_ANALYSIS` flag was passed to the profiler subdirectory
- Ensures `compile_commands.json` is always produced in the build directory, improving IDE support (clangd, clang-tidy, etc.)

## Test plan
- [ ] Verify cmake configure step produces `compile_commands.json` in the build directory
- [ ] Verify existing CI builds are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)