### PR TITLE
Add Makefile for running integration test locally

### DIFF
--- a/IntegrationTest/Makefile
+++ b/IntegrationTest/Makefile
@@ -17,4 +17,4 @@ run:
 	PYROSCOPE_SERVER_ADDRESS=http://localhost:4040 \
 	PYROSCOPE_APPLICATION_NAME=rideshare.dotnet.app \
 	ASPNETCORE_URLS=http://*:5000 \
-	$(DOTNET) run --project Rideshare.csproj --framework net8.0
+	$(DOTNET) run --project Rideshare.csproj --framework net8.0 --no-launch-profile


### PR DESCRIPTION
## Summary
- Add `IntegrationTest/Makefile` with a `make run` target that launches the Rideshare app with all profiler env vars configured for local testing

## Test plan
- [ ] `cd IntegrationTest && make run` starts the app with profiling enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)