### PR TITLE
docs: add CLAUDE.md with build instructions for AI assistants 

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,5 +29,3 @@ make -j$(nproc) Pyroscope.Profiler.Native Datadog.Linux.ApiWrapper.x64
 Output artifacts:
 - `profiler/_build/DDProf-Deploy/linux/Pyroscope.Profiler.Native.so`
 - `profiler/_build/DDProf-Deploy/linux/Datadog.Linux.ApiWrapper.x64.so`
-
-For musl/Alpine builds, set `IsAlpine=true` and artifacts will be under `profiler/_build/DDProf-Deploy/linux-musl/`.


### PR DESCRIPTION
## What changed

Added a `CLAUDE.md` file at the root of the `pyroscope-dotnet` subdirectory to provide context and instructions for AI coding assistants (Claude Code and similar tools).

## Why

AI assistants benefit from a concise project overview and actionable build instructions so they can work effectively in the repo without needing to reverse-engineer the build system from Dockerfiles or other scattered documentation.

## Details

- **Project description**: Brief note that this is a fork of [dd-trace-dotnet](https://github.com/DataDog/dd-trace-dotnet) with the upstream tracer removed — only the profiler remains.
- **Submodule setup**: Calls out that third-party dependencies are managed via git submodules and must be initialized before any work (`git submodule update --init --recursive`).
- **Debug build instructions**: Direct `cmake` + `make` commands using clang/clang++, extracted from `Pyroscope.Dockerfile`. Uses a dedicated `build-claude-Debug` directory (already covered by the existing `build-*` gitignore pattern) to avoid colliding with developer build directories.
- **Artifact paths**: Documents where the compiled `.so` files land, including the musl/Alpine variant.

