### PR TITLE
docs: enforce Unix Makefiles generator in CLAUDE.md build instructions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,12 +12,13 @@ git submodule update --init --recursive
 
 ## Build the profiler (Debug)
 
-Requires clang/clang++ and cmake. Uses `build-claude-Debug` as the build directory.
+Requires clang/clang++ and cmake. Uses `build-claude-Debug` as the build directory. Always use the Unix Makefiles generator (never Ninja).
 
 ```bash
 mkdir build-claude-Debug
 cd build-claude-Debug
 cmake .. \
+    -G "Unix Makefiles" \
     -DCMAKE_C_COMPILER=clang \
     -DCMAKE_CXX_COMPILER=clang++ \
     -DCMAKE_BUILD_TYPE=Debug \


### PR DESCRIPTION
## What changed

Added `-G "Unix Makefiles"` to the `cmake` invocation in `CLAUDE.md` and updated the prose to explicitly state that the Unix Makefiles generator must always be used (never Ninja).

## Why

CMake defaults to Ninja when it is available on the system. Ninja is not supported for this build; using it results in build failures. Pinning the generator to Unix Makefiles ensures AI assistants and developers always produce a working build without needing to debug generator-related issues.

## Changes

- `CLAUDE.md`: added `-G "Unix Makefiles"` flag to the `cmake` command
- `CLAUDE.md`: added prose note "Always use the Unix Makefiles generator (never Ninja)"

🤖 Generated with [Claude Code](https://claude.com/claude-code)