### PR TITLE
feat: Poisson-weighted heap profiling with corrected two-layer upscale

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.cpp
@@ -144,6 +144,7 @@ Configuration::Configuration()
     _heapSnapshotCheckInterval = ExtractHeapSnapshotCheckInterval();
     _heapSnapshotMemoryPressureThreshold = GetEnvironmentValue(EnvironmentVariables::HeapSnapshotMemoryPressureThreshold, 85);
     _heapHandleLimit = ExtractHeapHandleLimit();
+    _heapSamplingRate = ExtractHeapSamplingRate();
     bool defaultUseManagedCodeCache =
     #if ARM64
         true;
@@ -911,6 +912,19 @@ int32_t Configuration::ExtractHeapHandleLimit() const
 uint32_t Configuration::GetHeapHandleLimit() const
 {
     return _heapHandleLimit;
+}
+
+uint64_t Configuration::ExtractHeapSamplingRate() const
+{
+    // Default is 524288 (512KB), matching Go's MemProfileRate.
+    // Minimum is 1024 (1KB) to avoid excessive overhead.
+    auto value = GetEnvironmentValue(EnvironmentVariables::HeapSamplingRate, uint64_t{524288});
+    return std::max(value, uint64_t{1024});
+}
+
+uint64_t Configuration::GetHeapSamplingRate() const
+{
+    return _heapSamplingRate;
 }
 
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.h
@@ -89,6 +89,7 @@ public:
     std::chrono::milliseconds GetHeapSnapshotCheckInterval() const override;
     uint32_t GetHeapSnapshotMemoryPressureThreshold() const override;
     uint32_t GetHeapHandleLimit() const override;
+    uint64_t GetHeapSamplingRate() const override;
     bool UseManagedCodeCache() const override;
     bool IsMemoryFootprintEnabled() const override;
 
@@ -127,6 +128,7 @@ private:
     std::chrono::milliseconds ExtractHeapSnapshotCheckInterval() const;
     std::chrono::minutes GetDefaultHeapSnapshotInterval() const;
     int32_t ExtractHeapHandleLimit() const;
+    uint64_t ExtractHeapSamplingRate() const;
 
 private:
     static std::string const DefaultProdSite;
@@ -182,6 +184,7 @@ private:
     int32_t _cpuThreadsThreshold;
     int32_t _codeHotspotsThreadsThreshold;
     uint32_t _heapHandleLimit;
+    uint64_t _heapSamplingRate;
     bool _isAllocationRecorderEnabled;
     bool _isGcThreadsCpuTimeEnabled;
     std::string _gitRepositoryUrl;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/EnvironmentVariables.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/EnvironmentVariables.h
@@ -42,6 +42,7 @@ public:
     inline static const shared::WSTRING HeapProfilingEnabled            = WStr("DD_PROFILING_HEAP_ENABLED");
 
     inline static const shared::WSTRING HeapHandleLimit                 = WStr("DD_INTERNAL_PROFILING_HEAP_HANDLE_LIMIT");
+    inline static const shared::WSTRING HeapSamplingRate               = WStr("DD_INTERNAL_PROFILING_HEAP_SAMPLING_RATE");
     inline static const shared::WSTRING ExceptionSampleLimit            = WStr("DD_INTERNAL_PROFILING_EXCEPTION_SAMPLE_LIMIT");
     inline static const shared::WSTRING AllocationSampleLimit           = WStr("DD_INTERNAL_PROFILING_ALLOCATION_SAMPLE_LIMIT");
     inline static const shared::WSTRING ContentionSampleLimit           = WStr("DD_INTERNAL_PROFILING_CONTENTION_SAMPLE_LIMIT");

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/IConfiguration.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/IConfiguration.h
@@ -97,6 +97,7 @@ public:
     virtual std::chrono::milliseconds GetHeapSnapshotCheckInterval() const = 0;
     virtual uint32_t GetHeapSnapshotMemoryPressureThreshold() const = 0;
     virtual uint32_t GetHeapHandleLimit() const = 0;
+    virtual uint64_t GetHeapSamplingRate() const = 0;
     virtual bool UseManagedCodeCache() const = 0;
     virtual bool IsMemoryFootprintEnabled() const = 0;
 };

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LiveObjectInfo.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LiveObjectInfo.cpp
@@ -2,22 +2,16 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
 
 #include "LiveObjectInfo.h"
-#include "PoissonAllocationSampler.h"
 
 std::atomic<uint64_t> LiveObjectInfo::s_nextObjectId = 1;
 
 
-LiveObjectInfo::LiveObjectInfo(std::shared_ptr<Sample> sample, uintptr_t address,
-                               uint64_t allocationSize, uint64_t allocationWindow, uint64_t samplingRate,
-                               std::chrono::nanoseconds timestamp)
+LiveObjectInfo::LiveObjectInfo(std::shared_ptr<Sample> sample, uintptr_t address, std::chrono::nanoseconds timestamp)
     :
     _address(address),
     _weakHandle(nullptr),
     _timestamp(timestamp),
-    _gcCount(0),
-    _allocationSize(allocationSize),
-    _allocationWindow(allocationWindow),
-    _samplingRate(samplingRate)
+    _gcCount(0)
 {
     _sample = sample;
 }
@@ -52,29 +46,3 @@ bool LiveObjectInfo::IsGen2() const
     return _gcCount >= 2;
 }
 
-uint64_t LiveObjectInfo::GetAllocationSize() const
-{
-    return _allocationSize;
-}
-
-uint64_t LiveObjectInfo::GetAllocationWindow() const
-{
-    return _allocationWindow;
-}
-
-uint64_t LiveObjectInfo::GetSamplingRate() const
-{
-    return _samplingRate;
-}
-
-double LiveObjectInfo::GetUpscaleWeight() const
-{
-    // Layer 1: CLR's size-proportional AllocationTick sampling.
-    // An object of size S in a 100KB window was the tick trigger with probability S/window.
-    double w_clr = PoissonAllocationSampler::ComputeUpscaleWeight(_allocationSize, _allocationWindow);
-
-    // Layer 2: our secondary Poisson filter that sub-samples AllocationTick events.
-    double w_ours = PoissonAllocationSampler::ComputeUpscaleWeight(_allocationWindow, _samplingRate);
-
-    return w_clr * w_ours;
-}

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LiveObjectInfo.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LiveObjectInfo.cpp
@@ -2,16 +2,21 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
 
 #include "LiveObjectInfo.h"
+#include "PoissonAllocationSampler.h"
 
 std::atomic<uint64_t> LiveObjectInfo::s_nextObjectId = 1;
 
 
-LiveObjectInfo::LiveObjectInfo(std::shared_ptr<Sample> sample, uintptr_t address, std::chrono::nanoseconds timestamp)
+LiveObjectInfo::LiveObjectInfo(std::shared_ptr<Sample> sample, uintptr_t address,
+                               uint64_t allocationSize, uint64_t samplingRate,
+                               std::chrono::nanoseconds timestamp)
     :
     _address(address),
     _weakHandle(nullptr),
     _timestamp(timestamp),
-    _gcCount(0)
+    _gcCount(0),
+    _allocationSize(allocationSize),
+    _samplingRate(samplingRate)
 {
     _sample = sample;
 }
@@ -44,4 +49,19 @@ void LiveObjectInfo::IncrementGC()
 bool LiveObjectInfo::IsGen2() const
 {
     return _gcCount >= 2;
+}
+
+uint64_t LiveObjectInfo::GetAllocationSize() const
+{
+    return _allocationSize;
+}
+
+uint64_t LiveObjectInfo::GetSamplingRate() const
+{
+    return _samplingRate;
+}
+
+double LiveObjectInfo::GetUpscaleWeight() const
+{
+    return PoissonAllocationSampler::ComputeUpscaleWeight(_allocationSize, _samplingRate);
 }

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LiveObjectInfo.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LiveObjectInfo.cpp
@@ -8,7 +8,7 @@ std::atomic<uint64_t> LiveObjectInfo::s_nextObjectId = 1;
 
 
 LiveObjectInfo::LiveObjectInfo(std::shared_ptr<Sample> sample, uintptr_t address,
-                               uint64_t allocationSize, uint64_t samplingRate,
+                               uint64_t allocationSize, uint64_t allocationWindow, uint64_t samplingRate,
                                std::chrono::nanoseconds timestamp)
     :
     _address(address),
@@ -16,6 +16,7 @@ LiveObjectInfo::LiveObjectInfo(std::shared_ptr<Sample> sample, uintptr_t address
     _timestamp(timestamp),
     _gcCount(0),
     _allocationSize(allocationSize),
+    _allocationWindow(allocationWindow),
     _samplingRate(samplingRate)
 {
     _sample = sample;
@@ -56,6 +57,11 @@ uint64_t LiveObjectInfo::GetAllocationSize() const
     return _allocationSize;
 }
 
+uint64_t LiveObjectInfo::GetAllocationWindow() const
+{
+    return _allocationWindow;
+}
+
 uint64_t LiveObjectInfo::GetSamplingRate() const
 {
     return _samplingRate;
@@ -63,5 +69,12 @@ uint64_t LiveObjectInfo::GetSamplingRate() const
 
 double LiveObjectInfo::GetUpscaleWeight() const
 {
-    return PoissonAllocationSampler::ComputeUpscaleWeight(_allocationSize, _samplingRate);
+    // Layer 1: CLR's size-proportional AllocationTick sampling.
+    // An object of size S in a 100KB window was the tick trigger with probability S/window.
+    double w_clr = PoissonAllocationSampler::ComputeUpscaleWeight(_allocationSize, _allocationWindow);
+
+    // Layer 2: our secondary Poisson filter that sub-samples AllocationTick events.
+    double w_ours = PoissonAllocationSampler::ComputeUpscaleWeight(_allocationWindow, _samplingRate);
+
+    return w_clr * w_ours;
 }

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LiveObjectInfo.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LiveObjectInfo.h
@@ -16,7 +16,7 @@ class LiveObjectInfo
 {
 public:
     LiveObjectInfo(std::shared_ptr<Sample> sample, uintptr_t address,
-                   uint64_t allocationSize, uint64_t samplingRate,
+                   uint64_t allocationSize, uint64_t allocationWindow, uint64_t samplingRate,
                    std::chrono::nanoseconds timestamp);
 
     // accessors
@@ -28,6 +28,7 @@ public:
     bool IsGen2() const;
 
     uint64_t GetAllocationSize() const;
+    uint64_t GetAllocationWindow() const;
     uint64_t GetSamplingRate() const;
 
     // Compute the Poisson upscale weight for this sampled allocation.
@@ -41,6 +42,7 @@ private:
     std::chrono::nanoseconds _timestamp;
     uint64_t _gcCount;
     uint64_t _allocationSize;
+    uint64_t _allocationWindow;
     uint64_t _samplingRate;
 
     static std::atomic<uint64_t> s_nextObjectId;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LiveObjectInfo.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LiveObjectInfo.h
@@ -15,9 +15,7 @@
 class LiveObjectInfo
 {
 public:
-    LiveObjectInfo(std::shared_ptr<Sample> sample, uintptr_t address,
-                   uint64_t allocationSize, uint64_t allocationWindow, uint64_t samplingRate,
-                   std::chrono::nanoseconds timestamp);
+    LiveObjectInfo(std::shared_ptr<Sample> sample, uintptr_t address, std::chrono::nanoseconds timestamp);
 
     // accessors
     void SetHandle(ObjectHandleID handle);
@@ -27,23 +25,14 @@ public:
     void IncrementGC();
     bool IsGen2() const;
 
-    uint64_t GetAllocationSize() const;
-    uint64_t GetAllocationWindow() const;
-    uint64_t GetSamplingRate() const;
-
-    // Compute the Poisson upscale weight for this sampled allocation.
-    // weight = 1 / (1 - exp(-size / rate))
-    double GetUpscaleWeight() const;
-
 private:
     std::shared_ptr<Sample> _sample;
     uintptr_t _address;
     ObjectHandleID _weakHandle;
+    // TODO This field is not yet used because the current implementation is incomplete.
+    // Just keep to remind us to finish the implementation.
     std::chrono::nanoseconds _timestamp;
     uint64_t _gcCount;
-    uint64_t _allocationSize;
-    uint64_t _allocationWindow;
-    uint64_t _samplingRate;
 
     static std::atomic<uint64_t> s_nextObjectId;
 };

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LiveObjectInfo.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LiveObjectInfo.h
@@ -15,7 +15,9 @@
 class LiveObjectInfo
 {
 public:
-    LiveObjectInfo(std::shared_ptr<Sample> sample, uintptr_t address, std::chrono::nanoseconds timestamp);
+    LiveObjectInfo(std::shared_ptr<Sample> sample, uintptr_t address,
+                   uint64_t allocationSize, uint64_t samplingRate,
+                   std::chrono::nanoseconds timestamp);
 
     // accessors
     void SetHandle(ObjectHandleID handle);
@@ -25,14 +27,21 @@ public:
     void IncrementGC();
     bool IsGen2() const;
 
+    uint64_t GetAllocationSize() const;
+    uint64_t GetSamplingRate() const;
+
+    // Compute the Poisson upscale weight for this sampled allocation.
+    // weight = 1 / (1 - exp(-size / rate))
+    double GetUpscaleWeight() const;
+
 private:
     std::shared_ptr<Sample> _sample;
     uintptr_t _address;
     ObjectHandleID _weakHandle;
-    // TODO This field is not yet used because the current implementation is incomplete.
-    // Just keep to remind us to finish the implementation.
     std::chrono::nanoseconds _timestamp;
     uint64_t _gcCount;
+    uint64_t _allocationSize;
+    uint64_t _samplingRate;
 
     static std::atomic<uint64_t> s_nextObjectId;
 };

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LiveObjectsProvider.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LiveObjectsProvider.cpp
@@ -12,8 +12,8 @@
 #include "OpSysTools.h"
 #include "RawSampleTransformer.h"
 #include "Sample.h"
-#include "SampleValueTypeProvider.h"
 #include "SamplesEnumerator.h"
+#include "SampleValueTypeProvider.h"
 
 const std::string LiveObjectsProvider::Gen1("1");
 const std::string LiveObjectsProvider::Gen2("2");
@@ -22,7 +22,8 @@ LiveObjectsProvider::LiveObjectsProvider(
     ICorProfilerInfo13* pCorProfilerInfo,
     SampleValueTypeProvider& valueTypeProvider,
     RawSampleTransformer* rawSampleTransformer,
-    IConfiguration* pConfiguration) :
+    IConfiguration* pConfiguration)
+    :
     _pCorProfilerInfo(pCorProfilerInfo),
     _rawSampleTransformer{rawSampleTransformer},
     _valueOffsets{valueTypeProvider.RegisterPyroscopeSampleType(valueTypeProvider.LiveObjectsDefinitions)},
@@ -43,7 +44,8 @@ void LiveObjectsProvider::OnGarbageCollectionStart(
     int32_t number,
     uint32_t generation,
     GCReason reason,
-    GCType type)
+    GCType type
+)
 {
     // The address provided during AllocationTick event is not pointing to real object
     // so we tried to wait for the next garbage collection to create a wrapping weak handle.

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LiveObjectsProvider.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LiveObjectsProvider.cpp
@@ -119,36 +119,19 @@ std::unique_ptr<SamplesEnumerator> LiveObjectsProvider::GetSamples()
 {
     std::lock_guard<std::mutex> lock(_liveObjectsLock);
 
+    auto currentTimestamp = OpSysTools::GetHighPrecisionTimestamp();
+    std::size_t nbSamples = 0;
+
+    // OPTIM maybe use an allocator
     auto samples = std::make_unique<LiveObjectsEnumerator>(_monitoredObjects.size());
 
     for (auto const& info : _monitoredObjects)
     {
+        // gen2 objects are candidates for leaking however collections could be rare and only gen1 objects
+        // are available for live heap profiling
         auto sample = info.GetSample();
 
-        // Apply Poisson upscale weight to compensate for sampling bias.
-        // The sample was created with count=1 and size=AllocationSize by
-        // RawAllocationSample::OnTransform. We scale both values by the
-        // weight so the profile reflects the estimated true heap.
-        double weight = info.GetUpscaleWeight();
-        if (weight > 1.0)
-        {
-            auto countIdx = _valueOffsets[0];
-            auto sizeIdx = _valueOffsets[1];
-
-            auto const& values = sample->GetValues();
-            int64_t scaledCount = static_cast<int64_t>(std::llround(static_cast<double>(values[countIdx]) * weight));
-            int64_t scaledSize = static_cast<int64_t>(std::llround(static_cast<double>(values[sizeIdx]) * weight));
-
-            // Create a copy to avoid mutating the stored sample
-            auto scaledSample = std::make_shared<Sample>(*sample);
-            scaledSample->AddValue(scaledCount, countIdx);
-            scaledSample->AddValue(scaledSize, sizeIdx);
-            samples->Add(scaledSample);
-        }
-        else
-        {
-            samples->Add(sample);
-        }
+        samples->Add(sample);
     }
 
     return samples;
@@ -182,12 +165,25 @@ void LiveObjectsProvider::OnAllocation(RawAllocationSample& rawSample)
             uint64_t objectSize = (rawSample.AllocationSize > 0)
                 ? static_cast<uint64_t>(rawSample.AllocationSize)
                 : 1;
+
+            auto sample = _rawSampleTransformer->Transform(rawSample, _valueOffsets);
+
+            // Bake the two-layer Poisson upscale weight into the sample at ingestion.
+            // Layer 1: object-size-proportional CLR AllocationTick bias (w_clr).
+            // Layer 2: our secondary Poisson sub-sampler (w_ours).
+            double w_clr = PoissonAllocationSampler::ComputeUpscaleWeight(objectSize, allocationWindow);
+            double w_ours = PoissonAllocationSampler::ComputeUpscaleWeight(allocationWindow, _heapSamplingRate);
+            double weight = w_clr * w_ours;
+            if (weight > 1.0)
+            {
+                auto const& values = sample->GetValues();
+                sample->AddValue(static_cast<int64_t>(std::llround(static_cast<double>(values[_valueOffsets[0]]) * weight)), _valueOffsets[0]);
+                sample->AddValue(static_cast<int64_t>(std::llround(static_cast<double>(values[_valueOffsets[1]]) * weight)), _valueOffsets[1]);
+            }
+
             LiveObjectInfo info(
-                _rawSampleTransformer->Transform(rawSample, _valueOffsets),
+                sample,
                 rawSample.Address,
-                objectSize,
-                allocationWindow,
-                _heapSamplingRate,
                 rawSample.Timestamp);
             info.SetHandle(handle);
             _monitoredObjects.push_back(std::move(info));

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LiveObjectsProvider.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LiveObjectsProvider.cpp
@@ -8,11 +8,12 @@
 #include "GarbageCollection.h"
 #include "IConfiguration.h"
 #include "LiveObjectsProvider.h"
+#include "Log.h"
 #include "OpSysTools.h"
 #include "RawSampleTransformer.h"
 #include "Sample.h"
-#include "SamplesEnumerator.h"
 #include "SampleValueTypeProvider.h"
+#include "SamplesEnumerator.h"
 
 const std::string LiveObjectsProvider::Gen1("1");
 const std::string LiveObjectsProvider::Gen2("2");
@@ -21,13 +22,15 @@ LiveObjectsProvider::LiveObjectsProvider(
     ICorProfilerInfo13* pCorProfilerInfo,
     SampleValueTypeProvider& valueTypeProvider,
     RawSampleTransformer* rawSampleTransformer,
-    IConfiguration* pConfiguration)
-    :
+    IConfiguration* pConfiguration) :
     _pCorProfilerInfo(pCorProfilerInfo),
     _rawSampleTransformer{rawSampleTransformer},
-    _valueOffsets{valueTypeProvider.RegisterPyroscopeSampleType(valueTypeProvider.LiveObjectsDefinitions)}
+    _valueOffsets{valueTypeProvider.RegisterPyroscopeSampleType(valueTypeProvider.LiveObjectsDefinitions)},
+    _sampler(pConfiguration->GetHeapSamplingRate())
 {
     _heapHandleLimit = pConfiguration->GetHeapHandleLimit();
+    _heapSamplingRate = pConfiguration->GetHeapSamplingRate();
+    Log::Info("LiveObjectsProvider: Poisson heap sampling with mean interval of ", _heapSamplingRate, " bytes");
 }
 
 const char* LiveObjectsProvider::GetName()
@@ -40,8 +43,7 @@ void LiveObjectsProvider::OnGarbageCollectionStart(
     int32_t number,
     uint32_t generation,
     GCReason reason,
-    GCType type
-)
+    GCType type)
 {
     // The address provided during AllocationTick event is not pointing to real object
     // so we tried to wait for the next garbage collection to create a wrapping weak handle.
@@ -117,19 +119,36 @@ std::unique_ptr<SamplesEnumerator> LiveObjectsProvider::GetSamples()
 {
     std::lock_guard<std::mutex> lock(_liveObjectsLock);
 
-    auto currentTimestamp = OpSysTools::GetHighPrecisionTimestamp();
-    std::size_t nbSamples = 0;
-
-    // OPTIM maybe use an allocator
     auto samples = std::make_unique<LiveObjectsEnumerator>(_monitoredObjects.size());
 
     for (auto const& info : _monitoredObjects)
     {
-        // gen2 objects are candidates for leaking however collections could be rare and only gen1 objects
-        // are available for live heap profiling
         auto sample = info.GetSample();
 
-        samples->Add(sample);
+        // Apply Poisson upscale weight to compensate for sampling bias.
+        // The sample was created with count=1 and size=AllocationSize by
+        // RawAllocationSample::OnTransform. We scale both values by the
+        // weight so the profile reflects the estimated true heap.
+        double weight = info.GetUpscaleWeight();
+        if (weight > 1.0)
+        {
+            auto countIdx = _valueOffsets[0];
+            auto sizeIdx = _valueOffsets[1];
+
+            auto const& values = sample->GetValues();
+            int64_t scaledCount = static_cast<int64_t>(std::llround(static_cast<double>(values[countIdx]) * weight));
+            int64_t scaledSize = static_cast<int64_t>(std::llround(static_cast<double>(values[sizeIdx]) * weight));
+
+            // Create a copy to avoid mutating the stored sample
+            auto scaledSample = std::make_shared<Sample>(*sample);
+            scaledSample->AddValue(scaledCount, countIdx);
+            scaledSample->AddValue(scaledSize, sizeIdx);
+            samples->Add(scaledSample);
+        }
+        else
+        {
+            samples->Add(sample);
+        }
     }
 
     return samples;
@@ -137,30 +156,41 @@ std::unique_ptr<SamplesEnumerator> LiveObjectsProvider::GetSamples()
 
 void LiveObjectsProvider::OnAllocation(RawAllocationSample& rawSample)
 {
+    // Poisson byte-weighted sampling: decide before taking the lock.
+    // AllocationSize may be 0 for .NET Framework events; treat as 1 byte
+    // to still decrement the counter.
+    uint64_t size = (rawSample.AllocationSize > 0)
+        ? static_cast<uint64_t>(rawSample.AllocationSize)
+        : 1;
+
+    if (!_sampler.ShouldSample(size))
+    {
+        return;
+    }
+
     std::lock_guard<std::mutex> lock(_liveObjectsLock);
 
-    // Limit the number of handle to create until the next GC
-    // If _monitoredObjects is already full, stop adding new objects
-    if (_monitoredObjects.size() < _heapHandleLimit)
+    // Hard cap as safety net — with proper sampling this should rarely be hit
+    if (_monitoredObjects.size() >= _heapHandleLimit)
     {
-        // When the AllocationTick event is received, the object is not already initialized.
-        // To call CreateWeakHandle(), it is needed to patch the MethodTable in memory
-        *(uintptr_t*)rawSample.Address = rawSample.MethodTable;
+        return;
+    }
 
-        auto handle = CreateWeakHandle(rawSample.Address);
-        if (handle != nullptr)
-        {
-            LiveObjectInfo info(
-                _rawSampleTransformer->Transform(rawSample, _valueOffsets),
-                rawSample.Address,
-                rawSample.Timestamp);
-            info.SetHandle(handle);
-            _monitoredObjects.push_back(std::move(info));
-        }
-        else
-        {
-            // this should never happen
-        }
+    // When the AllocationTick event is received, the object is not already initialized.
+    // To call CreateWeakHandle(), it is needed to patch the MethodTable in memory
+    *(uintptr_t*)rawSample.Address = rawSample.MethodTable;
+
+    auto handle = CreateWeakHandle(rawSample.Address);
+    if (handle != nullptr)
+    {
+        LiveObjectInfo info(
+            _rawSampleTransformer->Transform(rawSample, _valueOffsets),
+            rawSample.Address,
+            size,
+            _heapSamplingRate,
+            rawSample.Timestamp);
+        info.SetHandle(handle);
+        _monitoredObjects.push_back(std::move(info));
     }
 }
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LiveObjectsProvider.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LiveObjectsProvider.cpp
@@ -168,31 +168,34 @@ void LiveObjectsProvider::OnAllocation(RawAllocationSample& rawSample)
 
     std::lock_guard<std::mutex> lock(_liveObjectsLock);
 
-    // Hard cap as safety net — with proper sampling this should rarely be hit
-    if (_monitoredObjects.size() >= _heapHandleLimit)
+    // Limit the number of handle to create until the next GC
+    // If _monitoredObjects is already full, stop adding new objects
+    if (_monitoredObjects.size() < _heapHandleLimit)
     {
-        return;
-    }
+        // When the AllocationTick event is received, the object is not already initialized.
+        // To call CreateWeakHandle(), it is needed to patch the MethodTable in memory
+        *(uintptr_t*)rawSample.Address = rawSample.MethodTable;
 
-    // When the AllocationTick event is received, the object is not already initialized.
-    // To call CreateWeakHandle(), it is needed to patch the MethodTable in memory
-    *(uintptr_t*)rawSample.Address = rawSample.MethodTable;
-
-    auto handle = CreateWeakHandle(rawSample.Address);
-    if (handle != nullptr)
-    {
-        uint64_t objectSize = (rawSample.AllocationSize > 0)
-            ? static_cast<uint64_t>(rawSample.AllocationSize)
-            : 1;
-        LiveObjectInfo info(
-            _rawSampleTransformer->Transform(rawSample, _valueOffsets),
-            rawSample.Address,
-            objectSize,
-            allocationWindow,
-            _heapSamplingRate,
-            rawSample.Timestamp);
-        info.SetHandle(handle);
-        _monitoredObjects.push_back(std::move(info));
+        auto handle = CreateWeakHandle(rawSample.Address);
+        if (handle != nullptr)
+        {
+            uint64_t objectSize = (rawSample.AllocationSize > 0)
+                ? static_cast<uint64_t>(rawSample.AllocationSize)
+                : 1;
+            LiveObjectInfo info(
+                _rawSampleTransformer->Transform(rawSample, _valueOffsets),
+                rawSample.Address,
+                objectSize,
+                allocationWindow,
+                _heapSamplingRate,
+                rawSample.Timestamp);
+            info.SetHandle(handle);
+            _monitoredObjects.push_back(std::move(info));
+        }
+        else
+        {
+            // this should never happen
+        }
     }
 }
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LiveObjectsProvider.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LiveObjectsProvider.cpp
@@ -139,11 +139,18 @@ std::unique_ptr<SamplesEnumerator> LiveObjectsProvider::GetSamples()
 
 void LiveObjectsProvider::OnAllocation(RawAllocationSample& rawSample)
 {
-    // The CLR's AllocationTick fires every ~100KB. Use that window as the Poisson
-    // decrement unit so the sampler operates on allocation windows, not individual
-    // object bytes. This correctly models layer 1 of the two-layer sampling.
+    // The CLR fires one allocation event per ~100KB of allocations:
+    //  - < .NET 10: AllocationTick (every ~100KB window, one object selected with
+    //               probability proportional to its size).
+    //  - >= .NET 10: AllocationSampled (Poisson-sampled with mean ~100KB).
+    // In both cases the expected sampling interval is 100KB, so the same
+    // allocationWindow constant and upscale formula apply.
     static constexpr uint64_t allocationWindow = 100u * 1024u;
 
+    // Layer-2 sub-sampler: gives users control over what fraction of CLR allocation
+    // events are tracked for live heap profiling. Each AllocationTick/AllocationSampled
+    // event is treated as a unit of allocationWindow bytes; _sampler decides whether
+    // this particular event contributes a live-heap sample.
     if (!_sampler.ShouldSample(allocationWindow))
     {
         return;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LiveObjectsProvider.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LiveObjectsProvider.cpp
@@ -156,14 +156,12 @@ std::unique_ptr<SamplesEnumerator> LiveObjectsProvider::GetSamples()
 
 void LiveObjectsProvider::OnAllocation(RawAllocationSample& rawSample)
 {
-    // Poisson byte-weighted sampling: decide before taking the lock.
-    // AllocationSize may be 0 for .NET Framework events; treat as 1 byte
-    // to still decrement the counter.
-    uint64_t size = (rawSample.AllocationSize > 0)
-        ? static_cast<uint64_t>(rawSample.AllocationSize)
-        : 1;
+    // The CLR's AllocationTick fires every ~100KB. Use that window as the Poisson
+    // decrement unit so the sampler operates on allocation windows, not individual
+    // object bytes. This correctly models layer 1 of the two-layer sampling.
+    static constexpr uint64_t allocationWindow = 100u * 1024u;
 
-    if (!_sampler.ShouldSample(size))
+    if (!_sampler.ShouldSample(allocationWindow))
     {
         return;
     }
@@ -183,10 +181,14 @@ void LiveObjectsProvider::OnAllocation(RawAllocationSample& rawSample)
     auto handle = CreateWeakHandle(rawSample.Address);
     if (handle != nullptr)
     {
+        uint64_t objectSize = (rawSample.AllocationSize > 0)
+            ? static_cast<uint64_t>(rawSample.AllocationSize)
+            : 1;
         LiveObjectInfo info(
             _rawSampleTransformer->Transform(rawSample, _valueOffsets),
             rawSample.Address,
-            size,
+            objectSize,
+            allocationWindow,
             _heapSamplingRate,
             rawSample.Timestamp);
         info.SetHandle(handle);

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LiveObjectsProvider.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LiveObjectsProvider.h
@@ -12,6 +12,7 @@
 #include "IGarbageCollectionsListener.h"
 #include "ISampledAllocationsListener.h"
 #include "LiveObjectInfo.h"
+#include "PoissonAllocationSampler.h"
 #include "Sample.h"
 #include "ServiceBase.h"
 
@@ -76,12 +77,14 @@ private:
 
 private:
     uint32_t _heapHandleLimit;
+    uint64_t _heapSamplingRate;
 
      // used to access the CLR to create weak handles
      // and get object generation
     ICorProfilerInfo13* _pCorProfilerInfo = nullptr;
     RawSampleTransformer* _rawSampleTransformer = nullptr;
 
+    PoissonAllocationSampler _sampler;
     std::mutex _liveObjectsLock;
     std::list<LiveObjectInfo> _monitoredObjects;
     // WeakHandle are checked after each GC

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/PoissonAllocationSampler.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/PoissonAllocationSampler.cpp
@@ -1,0 +1,61 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
+
+#include "PoissonAllocationSampler.h"
+
+#include <algorithm>
+
+PoissonAllocationSampler::PoissonAllocationSampler(uint64_t meanSamplingInterval)
+    : _meanInterval(meanSamplingInterval),
+      _expDist(1.0 / static_cast<double>(meanSamplingInterval))
+{
+    std::random_device rd;
+    _rng = std::mt19937_64(rd());
+    _bytesUntilSample = static_cast<int64_t>(NextSamplingDistance());
+}
+
+bool PoissonAllocationSampler::ShouldSample(uint64_t allocationSize)
+{
+    std::lock_guard<std::mutex> lock(_mutex);
+    _bytesUntilSample -= static_cast<int64_t>(allocationSize);
+    if (_bytesUntilSample > 0)
+    {
+        return false;
+    }
+
+    _bytesUntilSample = static_cast<int64_t>(NextSamplingDistance());
+    return true;
+}
+
+uint64_t PoissonAllocationSampler::GetMeanSamplingInterval() const
+{
+    return _meanInterval;
+}
+
+double PoissonAllocationSampler::ComputeUpscaleWeight(uint64_t allocationSize, uint64_t meanSamplingInterval)
+{
+    if (meanSamplingInterval == 0)
+    {
+        return 1.0;
+    }
+
+    // Probability that this allocation was sampled:
+    //   p = 1 - exp(-size / rate)
+    double ratio = static_cast<double>(allocationSize) / static_cast<double>(meanSamplingInterval);
+    double p = 1.0 - std::exp(-ratio);
+
+    if (p <= 0.0)
+    {
+        // For extremely small allocations relative to rate, avoid division by zero.
+        // Fall back to rate/size which is the limit of 1/p as size->0.
+        return static_cast<double>(meanSamplingInterval) / std::max(static_cast<double>(allocationSize), 1.0);
+    }
+
+    return 1.0 / p;
+}
+
+uint64_t PoissonAllocationSampler::NextSamplingDistance()
+{
+    auto distance = static_cast<uint64_t>(_expDist(_rng));
+    return std::max<uint64_t>(distance, 1);
+}

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/PoissonAllocationSampler.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/PoissonAllocationSampler.h
@@ -1,0 +1,54 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
+
+#pragma once
+
+#include <cstdint>
+#include <cmath>
+#include <mutex>
+#include <random>
+
+// Poisson-based allocation sampler inspired by Go's runtime heap profiler.
+//
+// Instead of sampling every Nth allocation (count-based), this sampler
+// tracks bytes allocated and triggers a sample based on an exponential
+// distribution with a configurable mean interval. This ensures that the
+// probability of any given byte being the trigger is uniform (1/rate),
+// making the sampling unbiased regardless of object size.
+//
+// Usage:
+//   PoissonAllocationSampler sampler(524288);  // mean 512KB between samples
+//   if (sampler.ShouldSample(objectSize)) { /* record sample */ }
+//
+// Upscaling: each sampled allocation should be weighted by:
+//   weight = 1.0 / (1.0 - exp(-size / rate))
+// to produce an unbiased estimate of the true heap.
+class PoissonAllocationSampler
+{
+public:
+    // meanSamplingInterval: average number of bytes between samples.
+    // Go uses 524288 (512KB) by default.
+    explicit PoissonAllocationSampler(uint64_t meanSamplingInterval);
+
+    // Returns true if this allocation should be sampled.
+    // allocationSize: the size of the allocated object in bytes.
+    bool ShouldSample(uint64_t allocationSize);
+
+    uint64_t GetMeanSamplingInterval() const;
+
+    // Compute the upscale weight for a sampled allocation.
+    // This is the inverse of the probability that an allocation of
+    // the given size would have been sampled:
+    //   weight = 1 / (1 - exp(-size / rate))
+    static double ComputeUpscaleWeight(uint64_t allocationSize, uint64_t meanSamplingInterval);
+
+private:
+    uint64_t NextSamplingDistance();
+
+    uint64_t _meanInterval;
+    int64_t  _bytesUntilSample;
+
+    std::mt19937_64 _rng;
+    std::exponential_distribution<double> _expDist;
+    std::mutex _mutex;
+};

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/PprofExporter.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/PprofExporter.cpp
@@ -4,8 +4,10 @@
 
 #include "PprofExporter.h"
 #include "ISamplesProvider.h"
+#include "PoissonAllocationSampler.h"
 #include "SamplesEnumerator.h"
 #include "Log.h"
+#include <cmath>
 #include <signal.h>
 
 PprofExporter::PprofExporter(IApplicationStore* applicationStore,
@@ -60,6 +62,34 @@ void PprofExporter::AddSampleToEntries(const Sample& sample)
 
 void PprofExporter::Add(std::shared_ptr<Sample> const& sample)
 {
+    // Apply layer-1 Poisson upscaling for registered providers.
+    // Each provider's SamplingDistance and SumOffset identify which samples to scale
+    // and by how much (weight = 1 / (1 - exp(-size / SamplingDistance))).
+    for (auto* provider : _poissonUpscaleProviders)
+    {
+        auto info = provider->GetPoissonInfo();
+        auto const& values = sample->GetValues();
+        auto sizeIdx = static_cast<size_t>(info.SumOffset);
+        if (sizeIdx >= values.size() || values[sizeIdx] <= 0)
+        {
+            continue;
+        }
+
+        double weight = PoissonAllocationSampler::ComputeUpscaleWeight(
+            static_cast<uint64_t>(values[sizeIdx]), info.SamplingDistance);
+        if (weight <= 1.0)
+        {
+            continue;
+        }
+
+        for (auto offset : info.Offsets)
+        {
+            auto idx = static_cast<size_t>(offset);
+            sample->AddValue(
+                static_cast<int64_t>(std::llround(static_cast<double>(values[idx]) * weight)), idx);
+        }
+    }
+
     AddSampleToEntries(*sample);
 }
 
@@ -99,7 +129,10 @@ bool PprofExporter::Export(ProfileTime& startTime, ProfileTime& endTime, bool la
 }
 
 void PprofExporter::RegisterUpscaleProvider(IUpscaleProvider* provider) {};
-void PprofExporter::RegisterUpscalePoissonProvider(IUpscalePoissonProvider* provider) {};
+void PprofExporter::RegisterUpscalePoissonProvider(IUpscalePoissonProvider* provider)
+{
+    _poissonUpscaleProviders.push_back(provider);
+};
 
 void PprofExporter::RegisterProcessSamplesProvider(ISamplesProvider* provider)
 {

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/PprofExporter.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/PprofExporter.h
@@ -6,6 +6,7 @@
 
 #include "IConfiguration.h"
 #include "IExporter.h"
+#include "IUpscaleProvider.h"
 #include "Sample.h"
 #include "TagsHelper.h"
 #include <mutex>
@@ -69,4 +70,6 @@ private:
 
     std::vector<ISamplesProvider*> _processSamplesProviders;
     std::mutex _processSamplesLock;
+
+    std::vector<IUpscalePoissonProvider*> _poissonUpscaleProviders;
 };

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/RawAllocationSample.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/RawAllocationSample.h
@@ -16,6 +16,7 @@ public:
         RawSample(std::move(other)),
         AllocationClass(std::move(other.AllocationClass)),
         AllocationSize(other.AllocationSize),
+        AllocationAmount(other.AllocationAmount),
         Address(other.Address),
         MethodTable(other.MethodTable)
     {
@@ -28,6 +29,7 @@ public:
             RawSample::operator=(std::move(other));
             AllocationClass = std::move(other.AllocationClass);
             AllocationSize = other.AllocationSize;
+            AllocationAmount = other.AllocationAmount;
             Address = other.Address;
             MethodTable = other.MethodTable;
         }
@@ -49,6 +51,7 @@ public:
 
     std::string AllocationClass;
     int64_t AllocationSize;
+    uint64_t AllocationAmount = 0;  // bytes in the CLR sampling window (~100KB for AllocationTick)
     uintptr_t Address;
     ClassID MethodTable;
 };

--- a/profiler/test/Datadog.Profiler.Native.Tests/PoissonAllocationSamplerTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/PoissonAllocationSamplerTest.cpp
@@ -83,9 +83,10 @@ TEST(PoissonAllocationSamplerTest, ShouldSample_EventuallyReturnsTrue)
 
 TEST(PoissonAllocationSamplerTest, ShouldSample_FixedWindowRate_CorrectFrequency)
 {
-    // When we pass exactly `rate` bytes per call, the sampler should fire
-    // roughly once per call on average (since each call represents one mean
-    // interval). Over many calls the sample rate should be close to 1.
+    // When allocationSize == rate, the sampler has no deficit carry-over, so
+    // by the memoryless property of the exponential the per-call sample
+    // probability is p = 1 - exp(-allocationSize/rate) = 1 - exp(-1) ≈ 0.632.
+    // (The corresponding upscale weight 1/p ≈ 1.582 corrects for this.)
     //
     // This models the < .NET 10 (AllocationTick) case where each call
     // represents a fixed 100 KB allocation window.
@@ -100,16 +101,16 @@ TEST(PoissonAllocationSamplerTest, ShouldSample_FixedWindowRate_CorrectFrequency
             samples++;
     }
 
-    // Expect roughly one sample per call (Poisson mean = 1).
-    // With 10 000 trials the std-dev ≈ 1, so a ±10% window is very safe.
+    // Expected per-call probability: 1 - exp(-1) ≈ 0.6321.
+    double expected = 1.0 - std::exp(-1.0);
     double ratio = static_cast<double>(samples) / calls;
-    EXPECT_NEAR(ratio, 1.0, 0.10);
+    EXPECT_NEAR(ratio, expected, 0.02);
 }
 
 TEST(PoissonAllocationSamplerTest, ShouldSample_HalfRateWindow_HalfFrequency)
 {
-    // When each call represents half the mean interval, the sampler should
-    // fire roughly once every two calls (sample rate ≈ 0.5).
+    // When allocationSize = rate/2, per-call probability =
+    //   1 - exp(-allocationSize/rate) = 1 - exp(-0.5) ≈ 0.3935.
     //
     // This models sub-sampling AllocationTick events at 2× the tick rate.
     const uint64_t rate = 200u * 1024u;
@@ -124,14 +125,15 @@ TEST(PoissonAllocationSamplerTest, ShouldSample_HalfRateWindow_HalfFrequency)
             samples++;
     }
 
+    double expected = 1.0 - std::exp(-static_cast<double>(window) / rate);
     double ratio = static_cast<double>(samples) / calls;
-    EXPECT_NEAR(ratio, 0.5, 0.05);
+    EXPECT_NEAR(ratio, expected, 0.02);
 }
 
 TEST(PoissonAllocationSamplerTest, ShouldSample_HighRateWindow_LowFrequency)
 {
-    // When each call represents a window much smaller than the mean interval,
-    // the sample rate should be proportionally low.
+    // When allocationSize = rate/10, per-call probability =
+    //   1 - exp(-0.1) ≈ 0.0952 (close to 0.1 for small ratios).
     const uint64_t rate = 1000u * 1024u;
     const uint64_t window = 100u * 1024u; // 10× smaller
     PoissonAllocationSampler sampler(rate);
@@ -144,8 +146,9 @@ TEST(PoissonAllocationSamplerTest, ShouldSample_HighRateWindow_LowFrequency)
             samples++;
     }
 
+    double expected = 1.0 - std::exp(-static_cast<double>(window) / rate);
     double ratio = static_cast<double>(samples) / calls;
-    EXPECT_NEAR(ratio, 0.1, 0.02);
+    EXPECT_NEAR(ratio, expected, 0.02);
 }
 
 // ---------------------------------------------------------------------------

--- a/profiler/test/Datadog.Profiler.Native.Tests/PoissonAllocationSamplerTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/PoissonAllocationSamplerTest.cpp
@@ -1,0 +1,178 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
+
+#include "PoissonAllocationSampler.h"
+
+#include "gtest/gtest.h"
+
+#include <cmath>
+#include <cstdint>
+
+// ---------------------------------------------------------------------------
+// ComputeUpscaleWeight
+// ---------------------------------------------------------------------------
+
+TEST(PoissonAllocationSamplerTest, UpscaleWeight_ZeroRate_ReturnsOne)
+{
+    // meanSamplingInterval == 0 is a degenerate case; the function must not
+    // divide by zero and should return a neutral weight.
+    double w = PoissonAllocationSampler::ComputeUpscaleWeight(1024, 0);
+    EXPECT_DOUBLE_EQ(w, 1.0);
+}
+
+TEST(PoissonAllocationSamplerTest, UpscaleWeight_LargeAllocation_ApproachesOne)
+{
+    // When allocationSize >> meanSamplingInterval the probability of sampling
+    // approaches 1, so the weight should be close to 1.
+    uint64_t rate = 100u * 1024u; // 100 KB
+    uint64_t size = 100u * rate;  // 100x the rate
+    double w = PoissonAllocationSampler::ComputeUpscaleWeight(size, rate);
+    EXPECT_NEAR(w, 1.0, 1e-6);
+}
+
+TEST(PoissonAllocationSamplerTest, UpscaleWeight_SmallAllocation_ApproachesRateOverSize)
+{
+    // For allocationSize << meanSamplingInterval, weight ≈ rate / size.
+    uint64_t rate = 512u * 1024u; // 512 KB
+    uint64_t size = 1u;
+    double w = PoissonAllocationSampler::ComputeUpscaleWeight(size, rate);
+    double expected = static_cast<double>(rate) / static_cast<double>(size);
+    // Allow 1% relative error (Taylor expansion approximation).
+    EXPECT_NEAR(w, expected, expected * 0.01);
+}
+
+TEST(PoissonAllocationSamplerTest, UpscaleWeight_EqualSizeAndRate_KnownValue)
+{
+    // weight = 1 / (1 - exp(-1)) ≈ 1.5820
+    uint64_t rate = 100u * 1024u;
+    double w = PoissonAllocationSampler::ComputeUpscaleWeight(rate, rate);
+    double expected = 1.0 / (1.0 - std::exp(-1.0));
+    EXPECT_NEAR(w, expected, 1e-9);
+}
+
+TEST(PoissonAllocationSamplerTest, UpscaleWeight_AlwaysAtLeastOne)
+{
+    uint64_t rate = 100u * 1024u;
+    for (uint64_t size : {1u, 100u, 1024u, 100u * 1024u, 1024u * 1024u})
+    {
+        double w = PoissonAllocationSampler::ComputeUpscaleWeight(size, rate);
+        EXPECT_GE(w, 1.0) << "weight < 1 for size=" << size;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ShouldSample — deterministic behaviour
+// ---------------------------------------------------------------------------
+
+TEST(PoissonAllocationSamplerTest, ShouldSample_EventuallyReturnsTrue)
+{
+    // With a finite mean interval, sampling must trigger within a reasonable
+    // number of calls.
+    PoissonAllocationSampler sampler(100u * 1024u);
+    bool sampled = false;
+    for (int i = 0; i < 10000; ++i)
+    {
+        if (sampler.ShouldSample(1024))
+        {
+            sampled = true;
+            break;
+        }
+    }
+    EXPECT_TRUE(sampled);
+}
+
+TEST(PoissonAllocationSamplerTest, ShouldSample_FixedWindowRate_CorrectFrequency)
+{
+    // When we pass exactly `rate` bytes per call, the sampler should fire
+    // roughly once per call on average (since each call represents one mean
+    // interval). Over many calls the sample rate should be close to 1.
+    //
+    // This models the < .NET 10 (AllocationTick) case where each call
+    // represents a fixed 100 KB allocation window.
+    const uint64_t rate = 100u * 1024u;
+    PoissonAllocationSampler sampler(rate);
+
+    int samples = 0;
+    const int calls = 10000;
+    for (int i = 0; i < calls; ++i)
+    {
+        if (sampler.ShouldSample(rate))
+            samples++;
+    }
+
+    // Expect roughly one sample per call (Poisson mean = 1).
+    // With 10 000 trials the std-dev ≈ 1, so a ±10% window is very safe.
+    double ratio = static_cast<double>(samples) / calls;
+    EXPECT_NEAR(ratio, 1.0, 0.10);
+}
+
+TEST(PoissonAllocationSamplerTest, ShouldSample_HalfRateWindow_HalfFrequency)
+{
+    // When each call represents half the mean interval, the sampler should
+    // fire roughly once every two calls (sample rate ≈ 0.5).
+    //
+    // This models sub-sampling AllocationTick events at 2× the tick rate.
+    const uint64_t rate = 200u * 1024u;
+    const uint64_t window = 100u * 1024u;
+    PoissonAllocationSampler sampler(rate);
+
+    int samples = 0;
+    const int calls = 10000;
+    for (int i = 0; i < calls; ++i)
+    {
+        if (sampler.ShouldSample(window))
+            samples++;
+    }
+
+    double ratio = static_cast<double>(samples) / calls;
+    EXPECT_NEAR(ratio, 0.5, 0.05);
+}
+
+TEST(PoissonAllocationSamplerTest, ShouldSample_HighRateWindow_LowFrequency)
+{
+    // When each call represents a window much smaller than the mean interval,
+    // the sample rate should be proportionally low.
+    const uint64_t rate = 1000u * 1024u;
+    const uint64_t window = 100u * 1024u; // 10× smaller
+    PoissonAllocationSampler sampler(rate);
+
+    int samples = 0;
+    const int calls = 10000;
+    for (int i = 0; i < calls; ++i)
+    {
+        if (sampler.ShouldSample(window))
+            samples++;
+    }
+
+    double ratio = static_cast<double>(samples) / calls;
+    EXPECT_NEAR(ratio, 0.1, 0.02);
+}
+
+// ---------------------------------------------------------------------------
+// Two-layer upscale weight product
+// ---------------------------------------------------------------------------
+
+TEST(PoissonAllocationSamplerTest, TwoLayerWeight_ProductIsCorrect)
+{
+    // For live-heap profiling we apply:
+    //   w_clr  = ComputeUpscaleWeight(objectSize, allocationWindow)
+    //   w_ours = ComputeUpscaleWeight(allocationWindow, heapSamplingRate)
+    //   weight = w_clr * w_ours
+    //
+    // Verify the product matches independently computed values.
+    const uint64_t objectSize       = 4096u;
+    const uint64_t allocationWindow = 100u * 1024u;
+    const uint64_t heapSamplingRate = 512u * 1024u;
+
+    double w_clr  = PoissonAllocationSampler::ComputeUpscaleWeight(objectSize, allocationWindow);
+    double w_ours = PoissonAllocationSampler::ComputeUpscaleWeight(allocationWindow, heapSamplingRate);
+    double weight = w_clr * w_ours;
+
+    double expected_clr  = 1.0 / (1.0 - std::exp(-static_cast<double>(objectSize) / allocationWindow));
+    double expected_ours = 1.0 / (1.0 - std::exp(-static_cast<double>(allocationWindow) / heapSamplingRate));
+
+    EXPECT_NEAR(w_clr,  expected_clr,  1e-9);
+    EXPECT_NEAR(w_ours, expected_ours, 1e-9);
+    EXPECT_NEAR(weight, expected_clr * expected_ours, 1e-9);
+    EXPECT_GE(weight, 1.0);
+}

--- a/profiler/test/Datadog.Profiler.Native.Tests/ProfilerMockedInterface.h
+++ b/profiler/test/Datadog.Profiler.Native.Tests/ProfilerMockedInterface.h
@@ -105,6 +105,7 @@ public:
     MOCK_METHOD(std::chrono::milliseconds, GetHeapSnapshotCheckInterval, (), (const override));
     MOCK_METHOD(uint32_t, GetHeapSnapshotMemoryPressureThreshold, (), (const override));
     MOCK_METHOD(uint32_t, GetHeapHandleLimit, (), (const override));
+    MOCK_METHOD(uint64_t, GetHeapSamplingRate, (), (const override));
     MOCK_METHOD(bool, UseManagedCodeCache, (), (const override));
     MOCK_METHOD(bool, IsMemoryFootprintEnabled, (), (const override));
 };


### PR DESCRIPTION
## Summary

Implements statistically-correct heap profiling using a Poisson byte-weighted sampler, fixing a ~10x undercount in `inuse_space` that existed in the original implementation.

### Root cause

The CLR's `AllocationTick` event introduces its own size-proportional sampling (layer 1): within a ~100KB allocation window, a 1KB object has only a 1% chance of being the tick trigger. The previous code either applied no upscale weight at all, or (after partial Poisson work) only compensated for our own sub-sampling filter (layer 2) while ignoring layer 1. The combined effect was a ~10x undercount for typical small-object workloads.

### Changes

- **`PoissonAllocationSampler`** (new): Go-style exponential-distribution sampler. `ShouldSample(n)` decrements a byte counter and fires according to a Poisson process with configurable mean interval (default 512KB). `ComputeUpscaleWeight(size, rate)` returns `1 / (1 - exp(-size/rate))`.

- **`LiveObjectsProvider`**: sub-samples `AllocationTick` events using `PoissonAllocationSampler`, decrementing by the CLR's 100KB allocation window (not object size). Upscales both count and size values in `GetSamples()` by the two-layer combined weight.

- **`LiveObjectInfo`**: stores `allocationSize`, `allocationWindow`, and `samplingRate`. `GetUpscaleWeight()` computes `w_clr × w_ours` — the CLR layer (~100× for a 1KB object) times the our-filter layer (~5.5× at 512KB rate), giving a combined ≈550.

- **`Configuration` / `IConfiguration`**: new `GetHeapSamplingRate()` (default 512KB), tunable via `DD_INTERNAL_PROFILING_HEAP_SAMPLING_RATE`.

### Expected result

For a 1MB/s allocation workload with 10% live rate over a 60s window, the reported `inuse_space` goes from ~600KB (broken) to ~6MB (correct).