### PR TITLE
prepare v0.14.3-pyroscope

### DIFF
--- a/Pyroscope/Pyroscope/Pyroscope.csproj
+++ b/Pyroscope/Pyroscope/Pyroscope.csproj
@@ -2,9 +2,9 @@
 
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
-        <PackageVersion>0.14.2</PackageVersion>
-        <AssemblyVersion>0.14.2</AssemblyVersion>
-        <FileVersion>0.14.2</FileVersion>
+        <PackageVersion>0.14.3</PackageVersion>
+        <AssemblyVersion>0.14.3</AssemblyVersion>
+        <FileVersion>0.14.3</FileVersion>
         <PackageReadmeFile>README.md</PackageReadmeFile>
     </PropertyGroup>
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/PyroscopePprofSink.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/PyroscopePprofSink.h
@@ -10,7 +10,7 @@
 #include "httplib.h"
 #include "url.hpp"
 
-#define PYROSCOPE_SPY_VERSION "0.14.2"
+#define PYROSCOPE_SPY_VERSION "0.14.3"
 
 class PyroscopePprofSink : public PProfExportSink
 {


### PR DESCRIPTION
## Summary

- Bumps `PackageVersion`, `AssemblyVersion`, `FileVersion` to `0.14.3` in `Pyroscope/Pyroscope/Pyroscope.csproj`
- Bumps `PYROSCOPE_SPY_VERSION` to `"0.14.3"` in `profiler/src/ProfilerEngine/Datadog.Profiler.Native/PyroscopePprofSink.h`

Required before tagging `v0.14.3-pyroscope` — CI verifies committed version matches the tag via `git diff --exit-code` after `make bump_version`.

## Motivation

Releasing `v0.14.3-pyroscope` to resolve CVE-2026-33186 (gRPC-Go authorization bypass, fixed in `main` via #248). Also includes 15 other improvements since `v0.14.2-pyroscope` (CA bundle fix, UB fix, .NET 9/10 itest support, TLS integration tests).

## Test plan

- [ ] PR merges cleanly to main
- [ ] Tag `v0.14.3-pyroscope` from merged commit
- [ ] `tag_linux.yml` and `tag_managed_helper.yml` CI passes