### PR TITLE
prepare v0.14.5-pyroscope

### DIFF
--- a/Pyroscope/Pyroscope/Pyroscope.csproj
+++ b/Pyroscope/Pyroscope/Pyroscope.csproj
@@ -2,9 +2,9 @@
 
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
-        <PackageVersion>0.14.4</PackageVersion>
-        <AssemblyVersion>0.14.4</AssemblyVersion>
-        <FileVersion>0.14.4</FileVersion>
+        <PackageVersion>0.14.5</PackageVersion>
+        <AssemblyVersion>0.14.5</AssemblyVersion>
+        <FileVersion>0.14.5</FileVersion>
         <PackageReadmeFile>README.md</PackageReadmeFile>
     </PropertyGroup>
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/PyroscopePprofSink.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/PyroscopePprofSink.h
@@ -10,7 +10,7 @@
 #include "httplib.h"
 #include "url.hpp"
 
-#define PYROSCOPE_SPY_VERSION "0.14.4"
+#define PYROSCOPE_SPY_VERSION "0.14.5"
 
 class PyroscopePprofSink : public PProfExportSink
 {


### PR DESCRIPTION
Bump version from 0.14.4 to 0.14.5 in preparation for the next release.

Files changed:
- `Pyroscope/Pyroscope/Pyroscope.csproj` — PackageVersion, AssemblyVersion, FileVersion
- `profiler/src/ProfilerEngine/Datadog.Profiler.Native/PyroscopePprofSink.h` — PYROSCOPE_SPY_VERSION

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a version bump only, with no functional or behavioral code changes.
> 
> **Overview**
> Prepares the `0.14.5` release by bumping version identifiers from `0.14.4` to `0.14.5`.
> 
> Updates the .NET package/assembly/file versions in `Pyroscope.csproj` and the native profiler `PYROSCOPE_SPY_VERSION` constant in `PyroscopePprofSink.h`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad8dbe2f8db1ac8fa5e9286498029140ddc5eadf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->