### PR TITLE
test(itest): reproduce dynamic wall-time restart crash on musl .NET 10

### DIFF
--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -36,6 +36,10 @@ jobs:
       - name: Run main profiler integration test
         run: make itest/main-profiler/${{ matrix.flavour }}/${{ matrix.dotnet_version }}
         working-directory: itest
+      - name: Run dynamic profiling integration test
+        if: matrix.flavour == 'musl' && matrix.dotnet_version == '10.0'
+        run: make itest/dynamic-profiling/musl/10.0
+        working-directory: itest
 
   run-integration-test-notification-profiler:
     name: itest notification-profiler ${{ matrix.flavour }} .NET ${{ matrix.dotnet_version }}
@@ -86,18 +90,3 @@ jobs:
         run: make itest/tls-profile-upload/${{ matrix.flavour }}/8.0
         working-directory: itest
 
-  run-integration-test-dynamic-profiling:
-    name: itest dynamic-profiling musl .NET 10.0
-    runs-on: ubuntu-x64-large
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          submodules: true
-      - name: Set up Go
-        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5
-        with:
-          go-version: 'stable'
-          cache-dependency-path: itest/go.sum
-      - name: Run dynamic profiling integration test
-        run: make itest/dynamic-profiling/musl/10.0
-        working-directory: itest

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -85,3 +85,19 @@ jobs:
       - name: Run TLS profile upload integration test
         run: make itest/tls-profile-upload/${{ matrix.flavour }}/8.0
         working-directory: itest
+
+  run-integration-test-dynamic-profiling:
+    name: itest dynamic-profiling musl .NET 10.0
+    runs-on: ubuntu-x64-large
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          submodules: true
+      - name: Set up Go
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5
+        with:
+          go-version: 'stable'
+          cache-dependency-path: itest/go.sum
+      - name: Run dynamic profiling integration test
+        run: make itest/dynamic-profiling/musl/10.0
+        working-directory: itest

--- a/IntegrationTest/Program.cs
+++ b/IntegrationTest/Program.cs
@@ -1,4 +1,5 @@
 using Example;
+using Pyroscope;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -8,6 +9,14 @@ builder.Services.AddSingleton<OrderService>();
 builder.Services.AddSingleton<ScooterService>();
 
 var app = builder.Build();
+
+if (IsEnabled("RIDESHARE_DISABLE_PROFILING_AT_STARTUP"))
+{
+    Profiler.Instance.SetCPUTrackingEnabled(false);
+    Profiler.Instance.SetAllocationTrackingEnabled(false);
+    Profiler.Instance.SetContentionTrackingEnabled(false);
+    Profiler.Instance.SetExceptionTrackingEnabled(false);
+}
 
 app.MapGet("/bike", (BikeService service) =>
 {
@@ -36,5 +45,24 @@ app.MapGet("/npe", () =>
     return "NPE work";
 });
 
+app.MapPost("/profiling/cpu/{enabled:bool}", (bool enabled) =>
+{
+    Profiler.Instance.SetCPUTrackingEnabled(enabled);
+    return Results.Ok(new { cpuTrackingEnabled = enabled });
+});
+
+app.MapPost("/profiling/all/{enabled:bool}", (bool enabled) =>
+{
+    Profiler.Instance.SetCPUTrackingEnabled(enabled);
+    Profiler.Instance.SetAllocationTrackingEnabled(enabled);
+    Profiler.Instance.SetContentionTrackingEnabled(enabled);
+    Profiler.Instance.SetExceptionTrackingEnabled(enabled);
+    return Results.Ok(new { profilingEnabled = enabled });
+});
 
 app.Run();
+
+static bool IsEnabled(string variableName)
+{
+    return bool.TryParse(Environment.GetEnvironmentVariable(variableName), out var isEnabled) && isEnabled;
+}

--- a/itest/Makefile
+++ b/itest/Makefile
@@ -192,6 +192,10 @@ itest/main-profiler/musl/9.0: build-app-main-profiler-musl-9.0
 itest/main-profiler/musl/10.0: build-app-main-profiler-musl-10.0
 	FLAVOUR=musl DOTNET_VERSION=10.0 go test -v -timeout 15m -count=1 ./... -run TestRideshareProfiles
 
+.PHONY: itest/dynamic-profiling/musl/10.0
+itest/dynamic-profiling/musl/10.0: build-app-main-profiler-musl-10.0
+	FLAVOUR=musl DOTNET_VERSION=10.0 go test -v -timeout 15m -count=1 ./... -run TestDynamicCPUProfilingCanBeReenabledAfterStartupDisable
+
 # Integration test targets - notification profiler (with OTEL)
 .PHONY: itest/notification-profiler/glibc/6.0
 itest/notification-profiler/glibc/6.0: build-app-notification-profiler-glibc-6.0

--- a/itest/integration_test.go
+++ b/itest/integration_test.go
@@ -69,6 +69,12 @@ func serviceName() string {
 	return base
 }
 
+type appInstance struct {
+	container       testcontainers.Container
+	baseURL         string
+	applicationName string
+}
+
 func startPyroscope(ctx context.Context, t *testing.T, net *testcontainers.DockerNetwork) string {
 	t.Helper()
 	c, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
@@ -95,6 +101,22 @@ func startPyroscope(ctx context.Context, t *testing.T, net *testcontainers.Docke
 
 func startApp(ctx context.Context, t *testing.T, net *testcontainers.DockerNetwork) string {
 	t.Helper()
+	return startAppWithOptions(ctx, t, net, serviceName(), nil).baseURL
+}
+
+func startAppWithOptions(ctx context.Context, t *testing.T, net *testcontainers.DockerNetwork, applicationName string, extraEnv map[string]string) appInstance {
+	t.Helper()
+
+	env := map[string]string{
+		"REGION":                     "us-east",
+		"PYROSCOPE_APPLICATION_NAME": applicationName,
+		"PYROSCOPE_SERVER_ADDRESS":   "http://pyroscope:4040",
+		"DD_TRACE_DEBUG":             "true",
+	}
+	for key, value := range extraEnv {
+		env[key] = value
+	}
+
 	c, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
 		ContainerRequest: testcontainers.ContainerRequest{
 			Image:         rideshareImage(),
@@ -103,12 +125,7 @@ func startApp(ctx context.Context, t *testing.T, net *testcontainers.DockerNetwo
 			NetworkAliases: map[string][]string{
 				net.Name: {"rideshare"},
 			},
-			Env: map[string]string{
-				"REGION":                     "us-east",
-				"PYROSCOPE_APPLICATION_NAME": serviceName(),
-				"PYROSCOPE_SERVER_ADDRESS":   "http://pyroscope:4040",
-				"DD_TRACE_DEBUG":             "true",
-			},
+			Env:          env,
 			ExposedPorts: []string{"5000/tcp"},
 			WaitingFor:   wait.ForListeningPort("5000/tcp").WithStartupTimeout(120 * time.Second),
 		},
@@ -121,7 +138,11 @@ func startApp(ctx context.Context, t *testing.T, net *testcontainers.DockerNetwo
 	require.NoError(t, err)
 	port, err := c.MappedPort(ctx, "5000/tcp")
 	require.NoError(t, err)
-	return fmt.Sprintf("http://%s:%s", host, port.Port())
+	return appInstance{
+		container:       c,
+		baseURL:         fmt.Sprintf("http://%s:%s", host, port.Port()),
+		applicationName: applicationName,
+	}
 }
 
 // runLoadGenerator cycles through /bike, /scooter, /car requests in a goroutine
@@ -154,16 +175,75 @@ func runLoadGenerator(ctx context.Context, t *testing.T, appBaseURL string) {
 	}()
 }
 
-func queryProfile(t *testing.T, pyroscopeURL string, labelSelector string) (string, error) {
+func setCPUTrackingEnabled(t *testing.T, appBaseURL string, enabled bool) {
+	t.Helper()
+
+	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/profiling/cpu/%t", appBaseURL, enabled), nil)
+	require.NoError(t, err)
+
+	resp, err := (&http.Client{Timeout: 10 * time.Second}).Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+func setAllTrackingEnabled(t *testing.T, appBaseURL string, enabled bool) {
+	t.Helper()
+
+	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/profiling/all/%t", appBaseURL, enabled), nil)
+	require.NoError(t, err)
+
+	resp, err := (&http.Client{Timeout: 10 * time.Second}).Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+func profileTypeID(t *testing.T, pyroscopeURL string, profileName string) (string, error) {
 	t.Helper()
 	qc := querierv1connect.NewQuerierServiceClient(http.DefaultClient, pyroscopeURL)
+
+	to := time.Now()
+	from := to.Add(-1 * time.Hour)
+	resp, err := qc.ProfileTypes(context.Background(),
+		connect.NewRequest(&querierv1.ProfileTypesRequest{
+			Start: from.UnixMilli(),
+			End:   to.UnixMilli(),
+		}))
+	if err != nil {
+		return "", err
+	}
+
+	for _, profileType := range resp.Msg.ProfileTypes {
+		if profileType.GetName() == profileName {
+			return profileType.GetID(), nil
+		}
+	}
+
+	return "", nil
+}
+
+func queryProfile(t *testing.T, pyroscopeURL string, labelSelector string) (string, error) {
+	return queryProfileByName(t, pyroscopeURL, labelSelector, "process_cpu")
+}
+
+func queryProfileByName(t *testing.T, pyroscopeURL string, labelSelector string, profileName string) (string, error) {
+	t.Helper()
+	qc := querierv1connect.NewQuerierServiceClient(http.DefaultClient, pyroscopeURL)
+
+	profileTypeID, err := profileTypeID(t, pyroscopeURL, profileName)
+	if err != nil || profileTypeID == "" {
+		return "", err
+	}
 
 	to := time.Now()
 	from := to.Add(-1 * time.Hour)
 	maxNodes := int64(65536)
 	resp, err := qc.SelectMergeStacktraces(context.Background(),
 		connect.NewRequest(&querierv1.SelectMergeStacktracesRequest{
-			ProfileTypeID: "process_cpu:cpu:nanoseconds:cpu:nanoseconds",
+			ProfileTypeID: profileTypeID,
 			Start:         from.UnixMilli(),
 			End:           to.UnixMilli(),
 			LabelSelector: labelSelector,
@@ -274,6 +354,64 @@ func TestRideshareProfiles(t *testing.T) {
 			}
 			t.Logf("collapsed profile for %s:\n%s", check.vehicle, lastCollapsed)
 		})
+	}
+}
+
+func TestDynamicCPUProfilingCanBeReenabledAfterStartupDisable(t *testing.T) {
+	if flavour() != "musl" || dotnetVersion() != "10.0" {
+		t.Skip("targets the reported musl/.NET 10 environment")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	net, err := network.New(ctx)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = net.Remove(ctx) })
+
+	pyroscopeURL := startPyroscope(ctx, t, net)
+	app := startAppWithOptions(ctx, t, net, serviceName()+".dynamic-reenable", map[string]string{
+		"DD_PROFILING_CPU_ENABLED":      "false",
+		"DD_PROFILING_WALLTIME_ENABLED": "true",
+	})
+
+	setAllTrackingEnabled(t, app.baseURL, false)
+	time.Sleep(7 * time.Second)
+	setCPUTrackingEnabled(t, app.baseURL, true)
+	runLoadGenerator(ctx, t, app.baseURL)
+
+	labelSelector := fmt.Sprintf(`{service_name="%s",vehicle="bike"}`, app.applicationName)
+	var lastCollapsed string
+	var lastQueryErr error
+	var lastProbeErr error
+
+	ok := assert.Eventually(t, func() bool {
+		resp, err := (&http.Client{Timeout: 10 * time.Second}).Get(app.baseURL + "/bike")
+		if err != nil {
+			lastProbeErr = err
+			return false
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			lastProbeErr = fmt.Errorf("unexpected app status: %s", resp.Status)
+			return false
+		}
+		lastProbeErr = nil
+
+		lastCollapsed, lastQueryErr = queryProfileByName(t, pyroscopeURL, labelSelector, "wall")
+		if lastQueryErr != nil || lastCollapsed == "" {
+			return false
+		}
+
+		return frameContains(lastCollapsed, "OrderService", "FindNearestVehicle")
+	}, 3*time.Minute, 5*time.Second)
+
+	if !ok {
+		t.Logf("label selector: %s", labelSelector)
+		t.Logf("last app probe error: %v", lastProbeErr)
+		t.Logf("last profile query error: %v", lastQueryErr)
+		t.Logf("last collapsed profile:\n%s", lastCollapsed)
+		t.FailNow()
 	}
 }
 

--- a/itest/issue-259-sigsegv-stacktrace.md
+++ b/itest/issue-259-sigsegv-stacktrace.md
@@ -1,0 +1,62 @@
+# Issue 259 SIGSEGV stacktrace
+
+Captured from the reproducer branch by rebuilding `rideshare-app-musl:net10.0` from this tree and running the app under `gdb` inside the container.
+
+## Repro sequence
+
+1. Start the musl `.NET 10` rideshare image under `gdb`:
+
+```sh
+docker run -d --name pyroscope-dotnet-gdb --cap-add SYS_PTRACE -p 5006:5000 \
+  -e ASPNETCORE_URLS=http://*:5000 \
+  -e DD_TRACE_DEBUG=true \
+  -e DD_PROFILING_CPU_ENABLED=false \
+  -e DD_PROFILING_WALLTIME_ENABLED=true \
+  -e PYROSCOPE_APPLICATION_NAME=repro.walltime.gdb \
+  rideshare-app-musl:net10.0 \
+  sh -c "apk add --no-cache gdb >/dev/null && exec gdb -batch \
+    -ex 'handle SIGUSR1 nostop noprint pass' \
+    -ex 'handle SIGPROF nostop noprint pass' \
+    -ex 'run' \
+    -ex 'bt full' \
+    --args dotnet /dotnet/rideshare.dll"
+```
+
+2. Hit the runtime toggle endpoints and then generate load:
+
+```sh
+curl -X POST http://localhost:5006/profiling/all/false
+sleep 7
+curl -X POST http://localhost:5006/profiling/cpu/true
+curl http://localhost:5006/bike
+```
+
+The first `GET /bike` after re-enabling CPU tracking triggered the crash while the restarted wall-time sampler thread was entering `ResetThreadsCpuConsumption()`.
+
+## Captured backtrace
+
+```text
+Thread 40 "DD_StackSampler" received signal SIGSEGV, Segmentation fault.
+[Switching to LWP 60]
+0x000078b54febb668 in OsSpecificApi::IsRunning (pThreadInfo=0x0) at /profiler/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/OsSpecificApi.cpp:195
+#0  0x000078b54febb668 in OsSpecificApi::IsRunning (pThreadInfo=0x0) at /profiler/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/OsSpecificApi.cpp:195
+        isRunning = false
+        cpuTime = 0
+#1  0x000078b55003bb8a in StackSamplerLoop::ResetThreadsCpuConsumption (this=0x7874b611d6a0) at /profiler/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoop.cpp:612
+        it = {<std::__shared_ptr<ManagedThreadInfo, (__gnu_cxx::_Lock_policy)2>> = {<std::__shared_ptr_access<ManagedThreadInfo, (__gnu_cxx::_Lock_policy)2, false, false>> = {<No data fields>}, _M_ptr = 0x78b54fc641d0, _M_refcount = {_M_pi = 0x78b54fc641c0}}, <No data fields>}
+        i = 0
+        managedThreadsCount = 13
+#2  0x000078b55003b91d in StackSamplerLoop::MainLoop (this=0x7874b611d6a0) at /profiler/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoop.cpp:154
+#3  0x000078b55003e15c in StackSamplerLoop::StartImpl()::$_0::operator()() const (this=0x7874b966cf28) at /profiler/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoop.cpp:116
+#4  0x000078b55003e125 in std::__invoke_impl<void, StackSamplerLoop::StartImpl()::$_0>(std::__invoke_other, StackSamplerLoop::StartImpl()::$_0&&) (__f=...) at /usr/bin/../lib/gcc/x86_64-alpine-linux-musl/12.2.1/../../../../include/c++/12.2.1/bits/invoke.h:61
+#5  0x000078b55003e0e5 in std::__invoke<StackSamplerLoop::StartImpl()::$_0>(StackSamplerLoop::StartImpl()::$_0&&) (__fn=...) at /usr/bin/../lib/gcc/x86_64-alpine-linux-musl/12.2.1/../../../../include/c++/12.2.1/bits/invoke.h:96
+#6  0x000078b55003e0bd in std::thread::_Invoker<std::tuple<StackSamplerLoop::StartImpl()::$_0> >::_M_invoke<0ul> (this=0x7874b966cf28) at /usr/bin/../lib/gcc/x86_64-alpine-linux-musl/12.2.1/../../../../include/c++/12.2.1/bits/std_thread.h:258
+#7  0x000078b55003e095 in std::thread::_Invoker<std::tuple<StackSamplerLoop::StartImpl()::$_0> >::operator() (this=0x7874b966cf28) at /usr/bin/../lib/gcc/x86_64-alpine-linux-musl/12.2.1/../../../../include/c++/12.2.1/bits/std_thread.h:265
+#8  0x000078b55003dff9 in std::thread::_State_impl<std::thread::_Invoker<std::tuple<StackSamplerLoop::StartImpl()::$_0> > >::_M_run (this=0x7874b966cf20) at /usr/bin/../lib/gcc/x86_64-alpine-linux-musl/12.2.1/../../../../include/c++/12.2.1/bits/std_thread.h:210
+#9  0x000078b550779de3 in std::execute_native_thread_routine (__p=0x7874b966cf20) at /home/buildozer/aports/main/gcc/src/gcc-12-20220924/libstdc++-v3/src/c++11/thread.cc:82
+#10 0x000078b5d0fac305 in dd_pthread_entry (arg=0x7874b966cf60) at /profiler/profiler/src/ProfilerEngine/Datadog.Linux.ApiWrapper/functions_to_wrap.c:599
+#11 0x000078b5d102043a in start (p=<optimized out>) at src/thread/pthread_create.c:207
+#12 0x000078b5d1021d88 in __clone () at src/thread/x86_64/clone.s:22
+```
+
+This confirms the reproducer is hitting a null dereference in the restarted stack sampler path, not just an HTTP-level failure.


### PR DESCRIPTION
## Summary
- add runtime profiling toggle endpoints to the rideshare integration app used by `itest`
- add a dedicated musl/.NET 10 wall-time-only integration test that reproduces issue #259 by disabling profiling and re-enabling CPU tracking through the public API
- add a `make itest/dynamic-profiling/musl/10.0` target and run it in the existing integration-test matrix for musl/.NET 10
- preserve a symbolized `gdb` backtrace in `itest/issue-259-sigsegv-stacktrace.md` so the reproducer PR includes direct SIGSEGV proof

## Test plan
- [x] `make itest/dynamic-profiling/musl/10.0`
- [x] manual `gdb` repro against `rideshare-app-musl:net10.0` built from this branch:
  - `POST /profiling/all/false`
  - `sleep 7`
  - `POST /profiling/cpu/true`
  - `GET /bike`

## SIGSEGV proof
Captured on this branch under `gdb`. Full transcript: `itest/issue-259-sigsegv-stacktrace.md`.

```text
Thread 40 "DD_StackSampler" received signal SIGSEGV, Segmentation fault.
0x000078b54febb668 in OsSpecificApi::IsRunning (pThreadInfo=0x0)
#0  OsSpecificApi::IsRunning (pThreadInfo=0x0)
#1  StackSamplerLoop::ResetThreadsCpuConsumption
#2  StackSamplerLoop::MainLoop
#3  StackSamplerLoop::StartImpl()::$_0::operator()() const
```