### PR TITLE
Add integration test reproducing SIGSEGV on dynamic profiling toggle (#259)

### DIFF
--- a/IntegrationTest/Program.cs
+++ b/IntegrationTest/Program.cs
@@ -36,5 +36,22 @@ app.MapGet("/npe", () =>
     return "NPE work";
 });
 
+app.MapGet("/dynamic-toggle", () =>
+{
+    Pyroscope.Profiler.Instance.SetCPUTrackingEnabled(false);
+    Pyroscope.Profiler.Instance.SetAllocationTrackingEnabled(false);
+    Pyroscope.Profiler.Instance.SetContentionTrackingEnabled(false);
+    Pyroscope.Profiler.Instance.SetExceptionTrackingEnabled(false);
+
+    Thread.Sleep(100);
+
+    Pyroscope.Profiler.Instance.SetCPUTrackingEnabled(true);
+    Pyroscope.Profiler.Instance.SetAllocationTrackingEnabled(true);
+    Pyroscope.Profiler.Instance.SetContentionTrackingEnabled(true);
+    Pyroscope.Profiler.Instance.SetExceptionTrackingEnabled(true);
+
+    return "OK";
+});
+
 
 app.Run();

--- a/itest/Makefile
+++ b/itest/Makefile
@@ -233,3 +233,12 @@ itest/tls-profile-upload/glibc/8.0: build-app-main-profiler-glibc-8.0
 .PHONY: itest/tls-profile-upload/musl/8.0
 itest/tls-profile-upload/musl/8.0: build-app-main-profiler-musl-8.0
 	FLAVOUR=musl DOTNET_VERSION=8.0 go test -v -timeout 10m -count=1 ./... -run TestTLSProfileUpload
+
+# Dynamic profiling toggle tests — verifies disable/re-enable doesn't SIGSEGV (issue #259).
+.PHONY: itest/dynamic-toggle/glibc/8.0
+itest/dynamic-toggle/glibc/8.0: build-app-main-profiler-glibc-8.0
+	FLAVOUR=glibc DOTNET_VERSION=8.0 go test -v -timeout 15m -count=1 ./... -run TestDynamicProfilingToggle
+
+.PHONY: itest/dynamic-toggle/musl/8.0
+itest/dynamic-toggle/musl/8.0: build-app-main-profiler-musl-8.0
+	FLAVOUR=musl DOTNET_VERSION=8.0 go test -v -timeout 15m -count=1 ./... -run TestDynamicProfilingToggle

--- a/itest/integration_test.go
+++ b/itest/integration_test.go
@@ -488,6 +488,57 @@ func TestTLSProfileUpload(t *testing.T) {
 	}
 }
 
+// TestDynamicProfilingToggle verifies that dynamically disabling and re-enabling
+// profiling does not crash the process. This reproduces
+// https://github.com/grafana/pyroscope-dotnet/issues/259 where calling
+// SetCPUTrackingEnabled(true) after a disable would SIGSEGV because
+// StackSamplerLoop::ResetThreadsCpuConsumption dereferenced a null _targetThread.
+func TestDynamicProfilingToggle(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	net, err := network.New(ctx)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = net.Remove(ctx) })
+
+	pyroscopeURL := startPyroscope(ctx, t, net)
+	appBaseURL := startApp(ctx, t, net)
+
+	// Generate some load first so managed threads are registered.
+	runLoadGenerator(ctx, t, appBaseURL)
+	time.Sleep(3 * time.Second)
+
+	// Trigger the dynamic disable/re-enable cycle.
+	// Before the fix this would kill the process with SIGSEGV (exit 139).
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Get(appBaseURL + "/dynamic-toggle")
+	require.NoError(t, err, "dynamic-toggle request failed — the app likely crashed")
+	_ = resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	t.Log("dynamic-toggle succeeded — profiling re-enabled without crash")
+
+	// Verify profiles still arrive after re-enabling.
+	svcName := serviceName()
+	labelSelector := fmt.Sprintf(`{service_name="%s",vehicle="bike"}`, svcName)
+	var lastCollapsed string
+	var lastErr error
+	ok := assert.Eventually(t, func() bool {
+		lastCollapsed, lastErr = queryProfile(t, pyroscopeURL, labelSelector)
+		if lastErr != nil || lastCollapsed == "" {
+			return false
+		}
+		return frameContains(lastCollapsed, "OrderService", "FindNearestVehicle")
+	}, 3*time.Minute, 5*time.Second)
+
+	if !ok {
+		t.Logf("label selector: %s", labelSelector)
+		t.Logf("last profile query error: %v", lastErr)
+		t.Logf("last collapsed profile:\n%s", lastCollapsed)
+		t.FailNow()
+	}
+	t.Logf("profiles still collected after dynamic toggle")
+}
+
 // TestRideshareProfilesWithOTEL tests Pyroscope as a notification profiler
 // when OTEL .NET auto-instrumentation occupies the classic profiler slot.
 // This test is nearly identical to TestRideshareProfiles - the only difference

--- a/itest/integration_test.go
+++ b/itest/integration_test.go
@@ -93,8 +93,19 @@ func startPyroscope(ctx context.Context, t *testing.T, net *testcontainers.Docke
 	return fmt.Sprintf("http://%s:%s", host, port.Port())
 }
 
-func startApp(ctx context.Context, t *testing.T, net *testcontainers.DockerNetwork) string {
+func startApp(ctx context.Context, t *testing.T, net *testcontainers.DockerNetwork, extraEnv ...map[string]string) string {
 	t.Helper()
+	env := map[string]string{
+		"REGION":                     "us-east",
+		"PYROSCOPE_APPLICATION_NAME": serviceName(),
+		"PYROSCOPE_SERVER_ADDRESS":   "http://pyroscope:4040",
+		"DD_TRACE_DEBUG":             "true",
+	}
+	for _, extra := range extraEnv {
+		for k, v := range extra {
+			env[k] = v
+		}
+	}
 	c, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
 		ContainerRequest: testcontainers.ContainerRequest{
 			Image:         rideshareImage(),
@@ -103,12 +114,7 @@ func startApp(ctx context.Context, t *testing.T, net *testcontainers.DockerNetwo
 			NetworkAliases: map[string][]string{
 				net.Name: {"rideshare"},
 			},
-			Env: map[string]string{
-				"REGION":                     "us-east",
-				"PYROSCOPE_APPLICATION_NAME": serviceName(),
-				"PYROSCOPE_SERVER_ADDRESS":   "http://pyroscope:4040",
-				"DD_TRACE_DEBUG":             "true",
-			},
+			Env:          env,
 			ExposedPorts: []string{"5000/tcp"},
 			WaitingFor:   wait.ForListeningPort("5000/tcp").WithStartupTimeout(120 * time.Second),
 		},
@@ -502,7 +508,9 @@ func TestDynamicProfilingToggle(t *testing.T) {
 	t.Cleanup(func() { _ = net.Remove(ctx) })
 
 	pyroscopeURL := startPyroscope(ctx, t, net)
-	appBaseURL := startApp(ctx, t, net)
+	appBaseURL := startApp(ctx, t, net, map[string]string{
+		"DD_PROFILING_WALLTIME_ENABLED": "1",
+	})
 
 	// Generate some load first so managed threads are registered.
 	runLoadGenerator(ctx, t, appBaseURL)
@@ -515,6 +523,13 @@ func TestDynamicProfilingToggle(t *testing.T) {
 	require.NoError(t, err, "dynamic-toggle request failed — the app likely crashed")
 	_ = resp.Body.Close()
 	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	// The SIGSEGV happens on a background thread after the HTTP response.
+	// Give it a moment, then verify the app is still alive.
+	time.Sleep(2 * time.Second)
+	resp2, err := client.Get(appBaseURL + "/bike")
+	require.NoError(t, err, "app crashed after dynamic-toggle (SIGSEGV on background thread)")
+	_ = resp2.Body.Close()
 	t.Log("dynamic-toggle succeeded — profiling re-enabled without crash")
 
 	// Verify profiles still arrive after re-enabling.

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoop.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoop.cpp
@@ -609,7 +609,7 @@ void StackSamplerLoop::ResetThreadsCpuConsumption()
         std::shared_ptr<ManagedThreadInfo> it = _pManagedThreadList->LoopNext(_iteratorCpuTime);
         if (it != nullptr)
         {
-            auto [isRunning, currentConsumption, failure] = OsSpecificApi::IsRunning(it.get());
+            auto [isRunning, currentConsumption, failure] = OsSpecificApi::IsRunning(_targetThread.get());
             if (!failure)
             {
                 it->SetCpuConsumption(currentConsumption, t1);

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoop.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoop.cpp
@@ -609,7 +609,7 @@ void StackSamplerLoop::ResetThreadsCpuConsumption()
         std::shared_ptr<ManagedThreadInfo> it = _pManagedThreadList->LoopNext(_iteratorCpuTime);
         if (it != nullptr)
         {
-            auto [isRunning, currentConsumption, failure] = OsSpecificApi::IsRunning(_targetThread.get());
+            auto [isRunning, currentConsumption, failure] = OsSpecificApi::IsRunning(it.get());
             if (!failure)
             {
                 it->SetCpuConsumption(currentConsumption, t1);


### PR DESCRIPTION
## Summary

- Adds a `/dynamic-toggle` HTTP endpoint to the rideshare test app that disables all profiling, sleeps briefly, then re-enables everything
- Adds `TestDynamicProfilingToggle` Go integration test that exercises this endpoint and verifies the app survives
- Requires `DD_PROFILING_WALLTIME_ENABLED=1` — the crash only occurs when the wall-time profiler is active (so `StackSamplerLoopManager` actually creates a `StackSamplerLoop` on re-enable)
- Includes a post-toggle liveness check to detect the async SIGSEGV on the `DD_StackSampler` background thread

## Root cause

`StackSamplerLoop::ResetThreadsCpuConsumption()` passes the class member `_targetThread` (always `nullptr` at that point) to `OsSpecificApi::IsRunning()` instead of the loop variable `it`. On first startup this is harmless because no managed threads exist yet, so the loop body never executes. On dynamic re-enable the thread list is populated, the null dereference fires, and the process dies with SIGSEGV (exit 139).

## GDB stack trace from reproduction

```
Thread 42 "DD_StackSampler" received signal SIGSEGV, Segmentation fault.
#0  OsSpecificApi::IsRunning (pThreadInfo=0x0) at OsSpecificApi.cpp:195
#1  StackSamplerLoop::ResetThreadsCpuConsumption() at StackSamplerLoop.cpp:612
#2  StackSamplerLoop::MainLoop() at StackSamplerLoop.cpp:154
#3  StackSamplerLoop::StartImpl()::$_0::operator()() at StackSamplerLoop.cpp:116
```

## Test plan

- [ ] `make itest/dynamic-toggle/glibc/8.0` — should fail on this branch (no fix yet)
- [ ] After applying the one-line fix (`_targetThread` → `it` at StackSamplerLoop.cpp:612), the test should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk since changes are limited to the integration-test app and Go integration tests/Makefile targets, with no production profiler logic modified.
> 
> **Overview**
> Adds a new `/dynamic-toggle` endpoint in the integration test app that disables all Pyroscope profiling modes, waits briefly, then re-enables them.
> 
> Extends the Go integration suite with `TestDynamicProfilingToggle`, which reproduces issue #259 by exercising the toggle under `DD_PROFILING_WALLTIME_ENABLED=1`, asserts the app stays alive after the async crash window, and verifies profiles are still collected afterward.
> 
> Updates the itest harness to support passing extra container env vars and adds Makefile targets to run the new toggle test for `glibc` and `musl` .NET 8.0 images.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01c9a6b945938e8edc9e1df690a5ff98ae858cef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->