### PR TITLE
fix: avoid null thread dereference when resetting cpu consumption

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoop.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoop.cpp
@@ -609,7 +609,7 @@ void StackSamplerLoop::ResetThreadsCpuConsumption()
         std::shared_ptr<ManagedThreadInfo> it = _pManagedThreadList->LoopNext(_iteratorCpuTime);
         if (it != nullptr)
         {
-            auto [isRunning, currentConsumption, failure] = OsSpecificApi::IsRunning(_targetThread.get());
+            auto [isRunning, currentConsumption, failure] = OsSpecificApi::IsRunning(it.get());
             if (!failure)
             {
                 it->SetCpuConsumption(currentConsumption, t1);


### PR DESCRIPTION
## Summary
- Fix dynamic profiling restart crash path by using the iterated managed thread in `StackSamplerLoop::ResetThreadsCpuConsumption` instead of `_targetThread`.
- This prevents passing a null `IThreadInfo*` into Linux `OsSpecificApi::IsRunning` during re-enable/restart flows.
- Keep scope intentionally minimal (production fix only, no new repro test in this PR).

## Linked reports
- Original user report: https://github.com/grafana/pyroscope-dotnet/issues/259
- Draft reproducer PR: https://github.com/grafana/pyroscope-dotnet/pull/265
- Draft reproducer PR: https://github.com/grafana/pyroscope-dotnet/pull/266

## Test plan
- [x] `cmake -S . -B build-claude-Debug -G "Unix Makefiles" -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS_DEBUG="-g -O0" -DCMAKE_C_FLAGS_DEBUG="-g -O0"`
- [x] `make -C build-claude-Debug -j$(nproc) Pyroscope.Profiler.Native Datadog.Linux.ApiWrapper.x64`

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, single-line change in CPU-consumption reset logic to avoid passing a potentially null thread pointer during profiling restarts.
> 
> **Overview**
> Fixes a crash path during profiling restart by updating `StackSamplerLoop::ResetThreadsCpuConsumption` to call `OsSpecificApi::IsRunning` with the currently iterated `ManagedThreadInfo` (`it.get()`) instead of `_targetThread.get()`, preventing a possible null dereference while initializing per-thread CPU consumption.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de786b2bec700bbf85f3ea3ddf63e04b3bcd2bc5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->