### PR TITLE
fix: normalize pyroscope push endpoint path

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/PyroscopePprofSink.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/PyroscopePprofSink.cpp
@@ -10,6 +10,16 @@
 #include "gen/push/v1/push.pb.h"
 #include "gen/types/v1/types.pb.h"
 
+namespace
+{
+std::string BuildPushPath(const Url& url)
+{
+    Url pushUrl;
+    pushUrl.path(url.path() + "/push.v1.PusherService/Push");
+    return pushUrl.str();
+}
+}
+
 PyroscopePprofSink::PyroscopePprofSink(
     std::string server,
     std::string appName,
@@ -137,7 +147,7 @@ void PyroscopePprofSink::upload(Pprof pprof)
     sample->set_raw_profile(std::move(pprof.bytes));
 
     std::string body = request.SerializeAsString();
-    std::string path = _url.path() + "/push.v1.PusherService/Push";
+    std::string path = BuildPushPath(_url);
 
     httplib::Headers headers = getHeaders();
     auto res = _client.Post(path, headers, body, "application/proto");

--- a/profiler/test/Datadog.Profiler.Native.Tests/PyroscopePprofSinkTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/PyroscopePprofSinkTest.cpp
@@ -1,0 +1,105 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
+
+#include "gtest/gtest.h"
+
+#include <chrono>
+#include <condition_variable>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "PyroscopePprofSink.h"
+
+using namespace std::chrono_literals;
+
+namespace
+{
+struct ObservedRequest
+{
+    void Set(std::string requestPath, int responseStatus)
+    {
+        std::lock_guard<std::mutex> lock(Mutex);
+        if (Seen)
+        {
+            return;
+        }
+
+        Path = std::move(requestPath);
+        Status = responseStatus;
+        Seen = true;
+        Cv.notify_one();
+    }
+
+    bool WaitForRequest(std::chrono::milliseconds timeout)
+    {
+        std::unique_lock<std::mutex> lock(Mutex);
+        return Cv.wait_for(lock, timeout, [this] { return Seen; });
+    }
+
+    std::string Path;
+    int Status = -1;
+
+private:
+    std::mutex Mutex;
+    std::condition_variable Cv;
+    bool Seen = false;
+};
+
+void ValidatePushPath(const std::string& serverPath, const std::string& expectedPath)
+{
+    httplib::Server server;
+    ObservedRequest observed;
+
+    server.Post(expectedPath, [](const httplib::Request&, httplib::Response& res) { res.status = 200; });
+    server.set_logger([&observed](const httplib::Request& req, const httplib::Response& res) {
+        observed.Set(req.path, res.status);
+    });
+
+    auto port = server.bind_to_any_port("127.0.0.1");
+    ASSERT_GT(port, 0);
+
+    std::thread serverThread([&server]() {
+        server.listen_after_bind();
+    });
+    server.wait_until_ready();
+
+    {
+        const auto url = "http://127.0.0.1:" + std::to_string(port) + serverPath;
+        PyroscopePprofSink sink(url, "service", "", "", "", "", {}, {});
+
+        Pprof pprof;
+        pprof.bytes = "fake-pprof";
+        pprof.profileType = ProfileType::ProcessCpu;
+
+        sink.Export({std::move(pprof)});
+
+        const bool requestReceived = observed.WaitForRequest(2s);
+        EXPECT_TRUE(requestReceived);
+        if (requestReceived)
+        {
+            EXPECT_EQ(observed.Path, expectedPath);
+            EXPECT_EQ(observed.Status, 200);
+        }
+    }
+
+    server.stop();
+    serverThread.join();
+}
+} // namespace
+
+TEST(PyroscopePprofSinkTest, UploadUsesNormalizedPathWhenBasePathHasTrailingSlash)
+{
+    ValidatePushPath("/tenant/", "/tenant/push.v1.PusherService/Push");
+}
+
+TEST(PyroscopePprofSinkTest, UploadUsesNormalizedPathWhenBasePathContainsDotSegments)
+{
+    ValidatePushPath("/tenant/./profiles/../", "/tenant/push.v1.PusherService/Push");
+}
+
+TEST(PyroscopePprofSinkTest, UploadUsesNormalizedPathForNestedPaths)
+{
+    ValidatePushPath("/api/profiles/", "/api/profiles/push.v1.PusherService/Push");
+}


### PR DESCRIPTION
## Summary
- Normalize the configured base path before appending `/push.v1.PusherService/Push` in `PyroscopePprofSink`.
- Prevent malformed upload URLs when the server URL includes trailing slashes or path traversal-like segments.
- Addresses issue #247.

## Test plan
- [x] Configure debug build with Unix Makefiles and clang.
- [x] Build `Pyroscope.Profiler.Native` successfully.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the upload URL path construction for Pyroscope profile pushes; a mistake here could break profile uploads for some configurations, but the change is small and covered by new unit tests.
> 
> **Overview**
> Fixes Pyroscope profile uploads when the configured server URL includes trailing slashes or dot-segments by building the push endpoint via a normalized `Url::path()` instead of raw string concatenation.
> 
> Adds native unit tests that spin up a local `httplib::Server` and assert `PyroscopePprofSink::Export` posts to the normalized `/push.v1.PusherService/Push` path for several base-path variants.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb094f54faf2fa64832bb82c15b8d4b192a2ad46. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->