### PR TITLE
fix: wire SetCPUTrackingEnabled to start/stop TimerCreateCpuProfiler

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,8 @@ cmake .. \
 make -j$(nproc) Pyroscope.Profiler.Native Datadog.Linux.ApiWrapper.x64
 ```
 
+On hosts that ship only dynamic OpenSSL (e.g. Fedora's `openssl-devel`), add `-DUSE_STATIC_OPENSSL=OFF` to the `cmake` invocation.
+
 Output artifacts:
 - `profiler/_build/DDProf-Deploy/linux/Pyroscope.Profiler.Native.so`
 - `profiler/_build/DDProf-Deploy/linux/Datadog.Linux.ApiWrapper.x64.so`

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/ProfilerSignalManager.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/ProfilerSignalManager.cpp
@@ -28,7 +28,7 @@ ProfilerSignalManager::~ProfilerSignalManager() noexcept
         _isHandlerInPlace = false;
         sigaction(_signalToSend, &_previousAction, nullptr);
     }
-    _handler = nullptr;
+    _handler.store(nullptr, std::memory_order_relaxed);
 }
 
 ProfilerSignalManager* ProfilerSignalManager::Get(int signal)
@@ -49,7 +49,7 @@ ProfilerSignalManager* ProfilerSignalManager::Get(int signal)
 
 bool ProfilerSignalManager::RegisterHandler(HandlerFn_t handler)
 {
-    HandlerFn_t current = _handler;
+    HandlerFn_t current = _handler.load(std::memory_order_acquire);
 
     if (current != nullptr)
     {
@@ -58,6 +58,7 @@ bool ProfilerSignalManager::RegisterHandler(HandlerFn_t handler)
     }
     std::unique_lock<std::mutex> lock(_handlerRegisterMutex);
 
+    current = _handler.load(std::memory_order_acquire);
     if (current != nullptr)
     {
         assert(current == handler);
@@ -68,7 +69,7 @@ bool ProfilerSignalManager::RegisterHandler(HandlerFn_t handler)
 
     if (_isHandlerInPlace)
     {
-        _handler = handler;
+        _handler.store(handler, std::memory_order_release);
     }
 
     return _isHandlerInPlace;
@@ -204,7 +205,7 @@ void ProfilerSignalManager::SignalHandler(int signal, siginfo_t* info, void* con
 
 bool ProfilerSignalManager::CallCustomHandler(int32_t signal, siginfo_t* info, void* context)
 {
-    HandlerFn_t handler = _handler;
+    HandlerFn_t handler = _handler.load(std::memory_order_acquire);
     return handler != nullptr && handler(signal, info, context);
 }
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/ProfilerSignalManager.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/ProfilerSignalManager.cpp
@@ -49,20 +49,18 @@ ProfilerSignalManager* ProfilerSignalManager::Get(int signal)
 
 bool ProfilerSignalManager::RegisterHandler(HandlerFn_t handler)
 {
-    HandlerFn_t current = _handler.load(std::memory_order_acquire);
-
-    if (current != nullptr)
+    if (_isHandlerInPlace)
     {
-        assert(current == handler);
-        return current == handler;
+        assert(_handler.load(std::memory_order_acquire) == handler);
+        return true;
     }
+
     std::unique_lock<std::mutex> lock(_handlerRegisterMutex);
 
-    current = _handler.load(std::memory_order_acquire);
-    if (current != nullptr)
+    if (_isHandlerInPlace)
     {
-        assert(current == handler);
-        return current == handler;
+        assert(_handler.load(std::memory_order_acquire) == handler);
+        return true;
     }
 
     _isHandlerInPlace = SetupSignalHandler();
@@ -109,7 +107,6 @@ bool ProfilerSignalManager::IgnoreSignal() {
                    strerror(errno), ".");
         return false;
     }
-    _handler = nullptr;
     _isHandlerInPlace = false;
     return true;
 }

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/ProfilerSignalManager.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/ProfilerSignalManager.cpp
@@ -74,6 +74,7 @@ bool ProfilerSignalManager::RegisterHandler(HandlerFn_t handler)
     return _isHandlerInPlace;
 }
 
+#ifdef DD_TEST
 bool ProfilerSignalManager::UnRegisterHandler()
 {
     if (!IsProfilerSignalHandlerInstalled())
@@ -92,6 +93,7 @@ bool ProfilerSignalManager::UnRegisterHandler()
     _isHandlerInPlace = false;
     return true;
 }
+#endif
 
 bool ProfilerSignalManager::IgnoreSignal() {
     struct sigaction sampleAction;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/ProfilerSignalManager.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/ProfilerSignalManager.cpp
@@ -177,12 +177,18 @@ bool ProfilerSignalManager::SetupSignalHandler()
     sigemptyset(&sampleAction.sa_mask);
     sigaddset(&sampleAction.sa_mask, _signalToSend);
 
-    int32_t result = sigaction(_signalToSend, &sampleAction, &_previousAction);
+    struct sigaction oldAction;
+    int32_t result = sigaction(_signalToSend, &sampleAction, &oldAction);
     if (result != 0)
     {
         Log::Error("ProfilerSignalManager::SetupSignalHandler: Failed to setup signal handler for ", strsignal(_signalToSend), " signals. Reason: ",
                    strerror(errno), ".");
         return false;
+    }
+
+    if (oldAction.sa_handler != SIG_IGN)
+    {
+        _previousAction = oldAction;
     }
 
     Log::Info("ProfilerSignalManager::SetupSignalHandler: Successfully setup signal handler for ", strsignal(_signalToSend), " signal.");

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/ProfilerSignalManager.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/ProfilerSignalManager.cpp
@@ -106,6 +106,8 @@ bool ProfilerSignalManager::IgnoreSignal() {
                    strerror(errno), ".");
         return false;
     }
+    _handler = nullptr;
+    _isHandlerInPlace = false;
     return true;
 }
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/ProfilerSignalManager.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/ProfilerSignalManager.cpp
@@ -16,6 +16,7 @@ ProfilerSignalManager::ProfilerSignalManager() noexcept :
     _handler{nullptr},
     _processId{OpSysTools::GetProcId()},
     _isHandlerInPlace{false},
+    _previousActionCaptured{false},
     _previousAction{},
     _handlerRegisterMutex{}
 {
@@ -177,13 +178,15 @@ bool ProfilerSignalManager::SetupSignalHandler()
     sigemptyset(&sampleAction.sa_mask);
     sigaddset(&sampleAction.sa_mask, _signalToSend);
 
-    int32_t result = sigaction(_signalToSend, &sampleAction, &_previousAction);
+    struct sigaction* oldAction = _previousActionCaptured ? nullptr : &_previousAction;
+    int32_t result = sigaction(_signalToSend, &sampleAction, oldAction);
     if (result != 0)
     {
         Log::Error("ProfilerSignalManager::SetupSignalHandler: Failed to setup signal handler for ", strsignal(_signalToSend), " signals. Reason: ",
                    strerror(errno), ".");
         return false;
     }
+    _previousActionCaptured = true;
 
     Log::Info("ProfilerSignalManager::SetupSignalHandler: Successfully setup signal handler for ", strsignal(_signalToSend), " signal.");
     return true;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/ProfilerSignalManager.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/ProfilerSignalManager.cpp
@@ -64,14 +64,19 @@ bool ProfilerSignalManager::RegisterHandler(HandlerFn_t handler)
         return true;
     }
 
-    _isHandlerInPlace = SetupSignalHandler();
+    _handler.store(handler, std::memory_order_release);
 
-    if (_isHandlerInPlace)
+    bool installed = SetupSignalHandler();
+    if (installed)
     {
-        _handler.store(handler, std::memory_order_release);
+        _isHandlerInPlace = true;
+    }
+    else
+    {
+        _handler.store(nullptr, std::memory_order_release);
     }
 
-    return _isHandlerInPlace;
+    return installed;
 }
 
 #ifdef DD_TEST

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/ProfilerSignalManager.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/ProfilerSignalManager.cpp
@@ -16,7 +16,6 @@ ProfilerSignalManager::ProfilerSignalManager() noexcept :
     _handler{nullptr},
     _processId{OpSysTools::GetProcId()},
     _isHandlerInPlace{false},
-    _previousActionCaptured{false},
     _previousAction{},
     _handlerRegisterMutex{}
 {
@@ -29,7 +28,7 @@ ProfilerSignalManager::~ProfilerSignalManager() noexcept
         _isHandlerInPlace = false;
         sigaction(_signalToSend, &_previousAction, nullptr);
     }
-    _handler.store(nullptr, std::memory_order_relaxed);
+    _handler = nullptr;
 }
 
 ProfilerSignalManager* ProfilerSignalManager::Get(int signal)
@@ -50,36 +49,31 @@ ProfilerSignalManager* ProfilerSignalManager::Get(int signal)
 
 bool ProfilerSignalManager::RegisterHandler(HandlerFn_t handler)
 {
-    if (_isHandlerInPlace)
-    {
-        assert(_handler.load(std::memory_order_acquire) == handler);
-        return true;
-    }
+    HandlerFn_t current = _handler;
 
+    if (current != nullptr)
+    {
+        assert(current == handler);
+        return current == handler;
+    }
     std::unique_lock<std::mutex> lock(_handlerRegisterMutex);
 
+    if (current != nullptr)
+    {
+        assert(current == handler);
+        return current == handler;
+    }
+
+    _isHandlerInPlace = SetupSignalHandler();
+
     if (_isHandlerInPlace)
     {
-        assert(_handler.load(std::memory_order_acquire) == handler);
-        return true;
+        _handler = handler;
     }
 
-    _handler.store(handler, std::memory_order_release);
-
-    bool installed = SetupSignalHandler();
-    if (installed)
-    {
-        _isHandlerInPlace = true;
-    }
-    else
-    {
-        _handler.store(nullptr, std::memory_order_release);
-    }
-
-    return installed;
+    return _isHandlerInPlace;
 }
 
-#ifdef DD_TEST
 bool ProfilerSignalManager::UnRegisterHandler()
 {
     if (!IsProfilerSignalHandlerInstalled())
@@ -98,7 +92,6 @@ bool ProfilerSignalManager::UnRegisterHandler()
     _isHandlerInPlace = false;
     return true;
 }
-#endif
 
 bool ProfilerSignalManager::IgnoreSignal() {
     struct sigaction sampleAction;
@@ -113,7 +106,6 @@ bool ProfilerSignalManager::IgnoreSignal() {
                    strerror(errno), ".");
         return false;
     }
-    _isHandlerInPlace = false;
     return true;
 }
 
@@ -148,7 +140,7 @@ bool ProfilerSignalManager::CheckSignalHandler()
 
     Log::Info("Profiler signal handler has been replaced. Restoring it.");
 
-    _previousActionCaptured = false;
+    // restore profiler handler
     _isHandlerInPlace = SetupSignalHandler();
 
     if (!_isHandlerInPlace)
@@ -183,15 +175,13 @@ bool ProfilerSignalManager::SetupSignalHandler()
     sigemptyset(&sampleAction.sa_mask);
     sigaddset(&sampleAction.sa_mask, _signalToSend);
 
-    struct sigaction* oldAction = _previousActionCaptured ? nullptr : &_previousAction;
-    int32_t result = sigaction(_signalToSend, &sampleAction, oldAction);
+    int32_t result = sigaction(_signalToSend, &sampleAction, &_previousAction);
     if (result != 0)
     {
         Log::Error("ProfilerSignalManager::SetupSignalHandler: Failed to setup signal handler for ", strsignal(_signalToSend), " signals. Reason: ",
                    strerror(errno), ".");
         return false;
     }
-    _previousActionCaptured = true;
 
     Log::Info("ProfilerSignalManager::SetupSignalHandler: Successfully setup signal handler for ", strsignal(_signalToSend), " signal.");
     return true;
@@ -214,7 +204,7 @@ void ProfilerSignalManager::SignalHandler(int signal, siginfo_t* info, void* con
 
 bool ProfilerSignalManager::CallCustomHandler(int32_t signal, siginfo_t* info, void* context)
 {
-    HandlerFn_t handler = _handler.load(std::memory_order_acquire);
+    HandlerFn_t handler = _handler;
     return handler != nullptr && handler(signal, info, context);
 }
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/ProfilerSignalManager.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/ProfilerSignalManager.cpp
@@ -28,7 +28,7 @@ ProfilerSignalManager::~ProfilerSignalManager() noexcept
         _isHandlerInPlace = false;
         sigaction(_signalToSend, &_previousAction, nullptr);
     }
-    _handler = nullptr;
+    _handler.store(nullptr, std::memory_order_relaxed);
 }
 
 ProfilerSignalManager* ProfilerSignalManager::Get(int signal)
@@ -49,7 +49,7 @@ ProfilerSignalManager* ProfilerSignalManager::Get(int signal)
 
 bool ProfilerSignalManager::RegisterHandler(HandlerFn_t handler)
 {
-    HandlerFn_t current = _handler;
+    HandlerFn_t current = _handler.load(std::memory_order_acquire);
 
     if (current != nullptr)
     {
@@ -58,6 +58,7 @@ bool ProfilerSignalManager::RegisterHandler(HandlerFn_t handler)
     }
     std::unique_lock<std::mutex> lock(_handlerRegisterMutex);
 
+    current = _handler.load(std::memory_order_acquire);
     if (current != nullptr)
     {
         assert(current == handler);
@@ -68,7 +69,7 @@ bool ProfilerSignalManager::RegisterHandler(HandlerFn_t handler)
 
     if (_isHandlerInPlace)
     {
-        _handler = handler;
+        _handler.store(handler, std::memory_order_release);
     }
 
     return _isHandlerInPlace;
@@ -208,7 +209,7 @@ void ProfilerSignalManager::SignalHandler(int signal, siginfo_t* info, void* con
 
 bool ProfilerSignalManager::CallCustomHandler(int32_t signal, siginfo_t* info, void* context)
 {
-    HandlerFn_t handler = _handler;
+    HandlerFn_t handler = _handler.load(std::memory_order_acquire);
     return handler != nullptr && handler(signal, info, context);
 }
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/ProfilerSignalManager.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/ProfilerSignalManager.cpp
@@ -148,7 +148,7 @@ bool ProfilerSignalManager::CheckSignalHandler()
 
     Log::Info("Profiler signal handler has been replaced. Restoring it.");
 
-    // restore profiler handler
+    _previousActionCaptured = false;
     _isHandlerInPlace = SetupSignalHandler();
 
     if (!_isHandlerInPlace)

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/ProfilerSignalManager.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/ProfilerSignalManager.cpp
@@ -51,7 +51,7 @@ bool ProfilerSignalManager::RegisterHandler(HandlerFn_t handler)
 {
     HandlerFn_t current = _handler.load(std::memory_order_acquire);
 
-    if (current != nullptr)
+    if (current != nullptr && _isHandlerInPlace)
     {
         assert(current == handler);
         return current == handler;
@@ -59,7 +59,7 @@ bool ProfilerSignalManager::RegisterHandler(HandlerFn_t handler)
     std::unique_lock<std::mutex> lock(_handlerRegisterMutex);
 
     current = _handler.load(std::memory_order_acquire);
-    if (current != nullptr)
+    if (current != nullptr && _isHandlerInPlace)
     {
         assert(current == handler);
         return current == handler;
@@ -107,6 +107,7 @@ bool ProfilerSignalManager::IgnoreSignal() {
                    strerror(errno), ".");
         return false;
     }
+    _isHandlerInPlace = false;
     return true;
 }
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/ProfilerSignalManager.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/ProfilerSignalManager.h
@@ -27,7 +27,7 @@ public:
 #ifdef DD_TEST
     void Reset()
     {
-        _handler = nullptr;
+        _handler.store(nullptr, std::memory_order_relaxed);
         sigaction(_signalToSend, &_previousAction, nullptr);
         _isHandlerInPlace = false;
         _canReplaceSignalHandler = true;
@@ -56,7 +56,7 @@ private:
 private:
     bool _canReplaceSignalHandler;
     int32_t _signalToSend;
-    HandlerFn_t _handler;
+    std::atomic<HandlerFn_t> _handler;
     pid_t _processId;
     bool _isHandlerInPlace;
     struct sigaction _previousAction;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/ProfilerSignalManager.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/ProfilerSignalManager.h
@@ -30,8 +30,12 @@ public:
     void Reset()
     {
         _handler.store(nullptr, std::memory_order_relaxed);
-        sigaction(_signalToSend, &_previousAction, nullptr);
+        if (_previousActionCaptured)
+        {
+            sigaction(_signalToSend, &_previousAction, nullptr);
+        }
         _isHandlerInPlace = false;
+        _previousActionCaptured = false;
         _canReplaceSignalHandler = true;
     }
 #endif
@@ -61,6 +65,7 @@ private:
     std::atomic<HandlerFn_t> _handler;
     pid_t _processId;
     std::atomic<bool> _isHandlerInPlace;
+    bool _previousActionCaptured;
     struct sigaction _previousAction;
     std::mutex _handlerRegisterMutex;
 };

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/ProfilerSignalManager.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/ProfilerSignalManager.h
@@ -17,10 +17,8 @@ public:
     static ProfilerSignalManager* Get(int signal);
 
     bool RegisterHandler(HandlerFn_t handler);
-    bool IgnoreSignal();
-#ifdef DD_TEST
     bool UnRegisterHandler();
-#endif
+    bool IgnoreSignal();
     int32_t SendSignal(pid_t threadId);
     bool CheckSignalHandler();
     bool IsHandlerInPlace() const;
@@ -29,13 +27,9 @@ public:
 #ifdef DD_TEST
     void Reset()
     {
-        _handler.store(nullptr, std::memory_order_relaxed);
-        if (_previousActionCaptured)
-        {
-            sigaction(_signalToSend, &_previousAction, nullptr);
-        }
+        _handler = nullptr;
+        sigaction(_signalToSend, &_previousAction, nullptr);
         _isHandlerInPlace = false;
-        _previousActionCaptured = false;
         _canReplaceSignalHandler = true;
     }
 #endif
@@ -62,10 +56,9 @@ private:
 private:
     bool _canReplaceSignalHandler;
     int32_t _signalToSend;
-    std::atomic<HandlerFn_t> _handler;
+    HandlerFn_t _handler;
     pid_t _processId;
-    std::atomic<bool> _isHandlerInPlace;
-    bool _previousActionCaptured;
+    bool _isHandlerInPlace;
     struct sigaction _previousAction;
     std::mutex _handlerRegisterMutex;
 };

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/ProfilerSignalManager.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/ProfilerSignalManager.h
@@ -29,7 +29,7 @@ public:
 #ifdef DD_TEST
     void Reset()
     {
-        _handler = nullptr;
+        _handler.store(nullptr, std::memory_order_relaxed);
         sigaction(_signalToSend, &_previousAction, nullptr);
         _isHandlerInPlace = false;
         _canReplaceSignalHandler = true;
@@ -58,7 +58,7 @@ private:
 private:
     bool _canReplaceSignalHandler;
     int32_t _signalToSend;
-    HandlerFn_t _handler;
+    std::atomic<HandlerFn_t> _handler;
     pid_t _processId;
     bool _isHandlerInPlace;
     struct sigaction _previousAction;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/ProfilerSignalManager.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/ProfilerSignalManager.h
@@ -60,7 +60,7 @@ private:
     int32_t _signalToSend;
     std::atomic<HandlerFn_t> _handler;
     pid_t _processId;
-    bool _isHandlerInPlace;
+    std::atomic<bool> _isHandlerInPlace;
     struct sigaction _previousAction;
     std::mutex _handlerRegisterMutex;
 };

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/ProfilerSignalManager.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/ProfilerSignalManager.h
@@ -17,8 +17,10 @@ public:
     static ProfilerSignalManager* Get(int signal);
 
     bool RegisterHandler(HandlerFn_t handler);
-    bool UnRegisterHandler();
     bool IgnoreSignal();
+#ifdef DD_TEST
+    bool UnRegisterHandler();
+#endif
     int32_t SendSignal(pid_t threadId);
     bool CheckSignalHandler();
     bool IsHandlerInPlace() const;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.cpp
@@ -2738,9 +2738,21 @@ void CorProfilerCallback::SetStackSamplerEnabled(bool enabled)
     if (enabled)
     {
         _pStackSamplerLoopManager->Start();
+#ifdef LINUX
+        if (_pCpuProfiler != nullptr)
+        {
+            _pCpuProfiler->Start();
+        }
+#endif
     }
     else
     {
+#ifdef LINUX
+        if (_pCpuProfiler != nullptr)
+        {
+            _pCpuProfiler->StopWithState(ServiceBase::State::Init);
+        }
+#endif
         _pStackSamplerLoopManager->StopWithState(ServiceBase::State::Init);
     }
 }


### PR DESCRIPTION
## Summary

Fixes #259 — dynamic CPU profiling toggle was not working on Linux.

- **`SetStackSamplerEnabled`** only controlled `StackSamplerLoopManager` (wall-time + manual CPU loop), but on Linux the actual CPU profiler is `TimerCreateCpuProfiler` — a completely independent service that was never started/stopped by the toggle API.
- **`ProfilerSignalManager::IgnoreSignal()`** set `SIGPROF` to `SIG_IGN` but did not reset its internal `_handler` and `_isHandlerInPlace` state, so `RegisterHandler()` would short-circuit on re-start and the signal handler was never re-registered.

## Changes

- **`CorProfilerCallback::SetStackSamplerEnabled`** — start/stop `_pCpuProfiler` alongside `_pStackSamplerLoopManager` on Linux
- **`ProfilerSignalManager::IgnoreSignal`** — reset `_handler` and `_isHandlerInPlace` after successfully ignoring the signal, so a subsequent `RegisterHandler()` call re-installs the handler

## Test plan

- [ ] `make -C itest itest/dynamic-cpu/glibc/8.0` — integration test from #278

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Linux CPU profiling lifecycle and signal handler registration, where regressions could disable profiling or affect process signal behavior. Changes are small but in concurrency/signal-sensitive code paths.
> 
> **Overview**
> Fixes Linux dynamic CPU profiling toggling by wiring `CorProfilerCallback::SetStackSamplerEnabled` to also start/stop the `TimerCreateCpuProfiler` service when present.
> 
> Hardens `ProfilerSignalManager` handler management by making `_handler` atomic, ensuring `IgnoreSignal()` clears internal installed-state, and avoiding overwriting `_previousAction` when the prior action was `SIG_IGN`, so SIGPROF can be cleanly ignored and later re-registered.
> 
> Updates `CLAUDE.md` build docs with a note for distros that only provide dynamic OpenSSL (`-DUSE_STATIC_OPENSSL=OFF`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7cbc90a3d4dd66cc78da4f60ed759775d4e9a221. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->