### PR TITLE
fix: make ProfilerSignalManager::_handler atomic

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/ProfilerSignalManager.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/ProfilerSignalManager.cpp
@@ -28,7 +28,7 @@ ProfilerSignalManager::~ProfilerSignalManager() noexcept
         _isHandlerInPlace = false;
         sigaction(_signalToSend, &_previousAction, nullptr);
     }
-    _handler = nullptr;
+    _handler.store(nullptr, std::memory_order_relaxed);
 }
 
 ProfilerSignalManager* ProfilerSignalManager::Get(int signal)
@@ -49,7 +49,7 @@ ProfilerSignalManager* ProfilerSignalManager::Get(int signal)
 
 bool ProfilerSignalManager::RegisterHandler(HandlerFn_t handler)
 {
-    HandlerFn_t current = _handler;
+    HandlerFn_t current = _handler.load(std::memory_order_acquire);
 
     if (current != nullptr)
     {
@@ -58,6 +58,7 @@ bool ProfilerSignalManager::RegisterHandler(HandlerFn_t handler)
     }
     std::unique_lock<std::mutex> lock(_handlerRegisterMutex);
 
+    current = _handler.load(std::memory_order_acquire);
     if (current != nullptr)
     {
         assert(current == handler);
@@ -68,7 +69,7 @@ bool ProfilerSignalManager::RegisterHandler(HandlerFn_t handler)
 
     if (_isHandlerInPlace)
     {
-        _handler = handler;
+        _handler.store(handler, std::memory_order_release);
     }
 
     return _isHandlerInPlace;
@@ -204,7 +205,7 @@ void ProfilerSignalManager::SignalHandler(int signal, siginfo_t* info, void* con
 
 bool ProfilerSignalManager::CallCustomHandler(int32_t signal, siginfo_t* info, void* context)
 {
-    HandlerFn_t handler = _handler;
+    HandlerFn_t handler = _handler.load(std::memory_order_acquire);
     return handler != nullptr && handler(signal, info, context);
 }
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/ProfilerSignalManager.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/ProfilerSignalManager.h
@@ -27,7 +27,7 @@ public:
 #ifdef DD_TEST
     void Reset()
     {
-        _handler = nullptr;
+        _handler.store(nullptr, std::memory_order_relaxed);
         sigaction(_signalToSend, &_previousAction, nullptr);
         _isHandlerInPlace = false;
         _canReplaceSignalHandler = true;
@@ -56,7 +56,7 @@ private:
 private:
     bool _canReplaceSignalHandler;
     int32_t _signalToSend;
-    HandlerFn_t _handler;
+    std::atomic<HandlerFn_t> _handler;
     pid_t _processId;
     bool _isHandlerInPlace;
     struct sigaction _previousAction;


### PR DESCRIPTION
`_handler` is a plain function pointer that is written on a normal thread in `RegisterHandler` and read inside a signal handler in `CallCustomHandler`. Without atomics this is a data race — undefined behavior in C++. The C++ standard ([support.signal]/3) requires lock-free atomics for signal-safe access, and `std::atomic<T*>` is lock-free on all relevant platforms.

Changes:
- Declare `_handler` as `std::atomic<HandlerFn_t>` instead of plain `HandlerFn_t`
- Use explicit `load`/`store` with appropriate memory ordering at every access site
- Fix broken double-checked locking in `RegisterHandler`: the second check after acquiring the mutex was comparing a stale local copy instead of re-loading `_handler`

Note: `_isHandlerInPlace` has a similar (less critical) data race, left for a follow-up.

Co-Reviewed-By: Claude Opus 4.6 (1M context)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Linux signal-handling code and changes synchronization semantics; while small, mistakes here can cause hard-to-debug crashes or missed samples at runtime.
> 
> **Overview**
> **Fixes a data race between the normal thread and the signal handler** by making `ProfilerSignalManager::_handler` an `std::atomic<HandlerFn_t>`.
> 
> All accesses to `_handler` now use explicit atomic `load`/`store` with memory ordering, including teardown/test reset, and `RegisterHandler` re-checks `_handler` after taking the mutex (fixing the prior stale double-check).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c42db5f26c86037ecdffa0f0f27f3b17a42e253. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->