### PR TITLE
Pyroscope: fix 'occured' -> 'occurred' in EnvironmentHelpers doc comment

### DIFF
--- a/Pyroscope/Pyroscope/EnvironmentHelpers.cs
+++ b/Pyroscope/Pyroscope/EnvironmentHelpers.cs
@@ -17,7 +17,7 @@ namespace Pyroscope
         /// </summary>
         /// <param name="key">Name of the environment variable to fetch</param>
         /// <param name="defaultValue">Value to return in case of error</param>
-        /// <returns>The value of the environment variable, or the default value if an error occured</returns>
+        /// <returns>The value of the environment variable, or the default value if an error occurred</returns>
         public static string? GetEnvironmentVariable(string key, string? defaultValue = null)
         {
             var keys = new List<string>();


### PR DESCRIPTION
XML doc comment in `Pyroscope/Pyroscope/EnvironmentHelpers.cs` line 20 reads `if an error occured`. Fixed to `occurred`. Comment-only change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 3dc76803d6f8568006b01586184a6011e4d74a48. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->