### PR TITLE
integration-test: add allocation, exception, and lock profile stacktrace tests

### DIFF
--- a/IntegrationTest/AllocWork.cs
+++ b/IntegrationTest/AllocWork.cs
@@ -1,0 +1,21 @@
+using System.Runtime.CompilerServices;
+
+namespace Example;
+
+public class AllocWork
+{
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static void Work()
+    {
+        for (int i = 0; i < 1000; i++)
+        {
+            Allocate();
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static byte[] Allocate()
+    {
+        return new byte[10240];
+    }
+}

--- a/IntegrationTest/Program.cs
+++ b/IntegrationTest/Program.cs
@@ -38,6 +38,12 @@ app.MapGet("/npe", () =>
     return "NPE work";
 });
 
+app.MapGet("/alloc", () =>
+{
+    AllocWork.Work();
+    return "alloc work";
+});
+
 // Example: POST /profiling?cpu=true&allocation=false&contention=true&exception=false
 app.MapPost("/profiling", (bool? cpu, bool? allocation, bool? contention, bool? exception, ILoggerFactory loggerFactory) =>
 {

--- a/integration-test/integration_test.go
+++ b/integration-test/integration_test.go
@@ -126,7 +126,7 @@ func runLoadGenerator(ctx context.Context, t *testing.T, appBaseURL string) {
 	}()
 }
 
-func queryProfile(t *testing.T, pyroscopeURL string, labelSelector string) (string, error) {
+func queryProfile(t *testing.T, pyroscopeURL string, labelSelector string, profileTypeID string) (string, error) {
 	t.Helper()
 	qc := querierv1connect.NewQuerierServiceClient(http.DefaultClient, pyroscopeURL)
 
@@ -135,7 +135,7 @@ func queryProfile(t *testing.T, pyroscopeURL string, labelSelector string) (stri
 	maxNodes := int64(65536)
 	resp, err := qc.SelectMergeStacktraces(context.Background(),
 		connect.NewRequest(&querierv1.SelectMergeStacktracesRequest{
-			ProfileTypeID: "process_cpu:cpu:nanoseconds:cpu:nanoseconds",
+			ProfileTypeID: profileTypeID,
 			Start:         from.UnixMilli(),
 			End:           to.UnixMilli(),
 			LabelSelector: labelSelector,
@@ -224,7 +224,7 @@ func runRideshareProfileTest(t *testing.T, libcType, version string, otel bool) 
 			var lastCollapsed string
 			var lastErr error
 			ok := assert.Eventually(t, func() bool {
-				lastCollapsed, lastErr = queryProfile(t, pyroscopeURL, labelSelector)
+				lastCollapsed, lastErr = queryProfile(t, pyroscopeURL, labelSelector, "process_cpu:cpu:nanoseconds:cpu:nanoseconds")
 				if lastErr != nil || lastCollapsed == "" {
 					return false
 				}
@@ -342,7 +342,7 @@ func TestDynamicCpuProfilingToggleAffectsProfileData(t *testing.T) {
 			return false
 		}
 
-		collapsed, err := queryProfile(t, pyroscopeURL, labelSelector)
+		collapsed, err := queryProfile(t, pyroscopeURL, labelSelector, "process_cpu:cpu:nanoseconds:cpu:nanoseconds")
 		if err != nil {
 			t.Logf("profile query failed while CPU disabled: %v", err)
 			return false
@@ -369,7 +369,7 @@ func TestDynamicCpuProfilingToggleAffectsProfileData(t *testing.T) {
 			return false
 		}
 
-		lastCollapsed, lastErr = queryProfile(t, pyroscopeURL, labelSelector)
+		lastCollapsed, lastErr = queryProfile(t, pyroscopeURL, labelSelector, "process_cpu:cpu:nanoseconds:cpu:nanoseconds")
 		if lastErr != nil || lastCollapsed == "" {
 			return false
 		}

--- a/integration-test/profile_stacktrace_test.go
+++ b/integration-test/profile_stacktrace_test.go
@@ -1,0 +1,204 @@
+package integrationtest
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	"pyroscope-dotnet-integration-test/dockertest"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// stackContainsChain checks that at least one stack in the collapsed output
+// contains the given frames in caller→callee order.  Each entry is
+// [className, methodName] using the same matching rules as frameContains.
+func stackContainsChain(collapsed string, chain [][2]string) bool {
+	patterns := make([]*regexp.Regexp, len(chain))
+	for i, f := range chain {
+		patterns[i] = regexp.MustCompile(
+			`(?:^|!)` + regexp.QuoteMeta(f[0]) + `(?:<[^>]*>)?\.` + regexp.QuoteMeta(f[1]) + `(?:<|;|\s|$)`)
+	}
+	for _, line := range strings.Split(collapsed, "\n") {
+		frames := strings.Split(line, ";")
+		pi := 0
+		for _, frame := range frames {
+			if pi >= len(patterns) {
+				break
+			}
+			if patterns[pi].MatchString(frame) {
+				pi++
+			}
+		}
+		if pi == len(patterns) {
+			return true
+		}
+	}
+	return false
+}
+
+func runAllocLoadGenerator(ctx context.Context, t *testing.T, appBaseURL string) {
+	t.Helper()
+	go func() {
+		client := &http.Client{Timeout: 60 * time.Second}
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
+			resp, err := client.Get(appBaseURL + "/alloc")
+			if err == nil {
+				_ = resp.Body.Close()
+			}
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(200 * time.Millisecond):
+			}
+		}
+	}()
+}
+
+func runNPELoadGenerator(ctx context.Context, t *testing.T, appBaseURL string) {
+	t.Helper()
+	go func() {
+		client := &http.Client{Timeout: 60 * time.Second}
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
+			resp, err := client.Get(appBaseURL + "/npe")
+			if err == nil {
+				_ = resp.Body.Close()
+			}
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(500 * time.Millisecond):
+			}
+		}
+	}()
+}
+
+func TestAllocationProfileStacktraces(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	net := dockertest.CreateNetwork(t)
+	pyroscopeURL := startPyroscope(t, net)
+	appName := fmt.Sprintf("rideshare.alloc-test.%d", time.Now().UnixNano())
+	appBaseURL := startAppWithEnv(t, net, envLibcType(), envDotnetVersion(), false, map[string]string{
+		"PYROSCOPE_APPLICATION_NAME":             appName,
+		"PYROSCOPE_PROFILING_ENABLED":            "true",
+		"PYROSCOPE_PROFILING_ALLOCATION_ENABLED": "true",
+	})
+	runAllocLoadGenerator(ctx, t, appBaseURL)
+
+	labelSelector := fmt.Sprintf(`{service_name="%s"}`, appName)
+	expectedChain := [][2]string{
+		{"AllocWork", "Work"},
+		{"AllocWork", "Allocate"},
+	}
+	var lastCollapsed string
+	var lastErr error
+	ok := assert.Eventually(t, func() bool {
+		lastCollapsed, lastErr = queryProfile(t, pyroscopeURL, labelSelector, "alloc:alloc_samples:count:cpu:nanoseconds")
+		if lastErr != nil || lastCollapsed == "" {
+			return false
+		}
+		return stackContainsChain(lastCollapsed, expectedChain)
+	}, 3*time.Minute, 5*time.Second)
+
+	if !ok {
+		t.Logf("label selector: %s", labelSelector)
+		t.Logf("last profile query error: %v", lastErr)
+		t.Logf("last collapsed profile:\n%s", lastCollapsed)
+		t.FailNow()
+	}
+	t.Logf("collapsed allocation profile:\n%s", lastCollapsed)
+}
+
+func TestExceptionProfileStacktraces(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	net := dockertest.CreateNetwork(t)
+	pyroscopeURL := startPyroscope(t, net)
+	appName := fmt.Sprintf("rideshare.exception-test.%d", time.Now().UnixNano())
+	appBaseURL := startAppWithEnv(t, net, envLibcType(), envDotnetVersion(), false, map[string]string{
+		"PYROSCOPE_APPLICATION_NAME":            appName,
+		"PYROSCOPE_PROFILING_ENABLED":           "true",
+		"PYROSCOPE_PROFILING_EXCEPTION_ENABLED": "true",
+	})
+	runNPELoadGenerator(ctx, t, appBaseURL)
+
+	labelSelector := fmt.Sprintf(`{service_name="%s"}`, appName)
+	expectedChain := [][2]string{
+		{"EndpointMiddleware", "Invoke"},
+		{"NPE", "Work"},
+	}
+	var lastCollapsed string
+	var lastErr error
+	ok := assert.Eventually(t, func() bool {
+		lastCollapsed, lastErr = queryProfile(t, pyroscopeURL, labelSelector, "exception:exception:count:cpu:nanoseconds")
+		if lastErr != nil || lastCollapsed == "" {
+			return false
+		}
+		return stackContainsChain(lastCollapsed, expectedChain)
+	}, 3*time.Minute, 5*time.Second)
+
+	if !ok {
+		t.Logf("label selector: %s", labelSelector)
+		t.Logf("last profile query error: %v", lastErr)
+		t.Logf("last collapsed profile:\n%s", lastCollapsed)
+		t.FailNow()
+	}
+	t.Logf("collapsed exception profile:\n%s", lastCollapsed)
+}
+
+func TestLockProfileStacktraces(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	net := dockertest.CreateNetwork(t)
+	pyroscopeURL := startPyroscope(t, net)
+	appName := fmt.Sprintf("rideshare.lock-test.%d", time.Now().UnixNano())
+	appBaseURL := startAppWithEnv(t, net, envLibcType(), envDotnetVersion(), false, map[string]string{
+		"PYROSCOPE_APPLICATION_NAME":             appName,
+		"PYROSCOPE_PROFILING_ENABLED":            "true",
+		"PYROSCOPE_PROFILING_CONTENTION_ENABLED": "true",
+	})
+	for i := 0; i < 3; i++ {
+		runLoadGenerator(ctx, t, appBaseURL)
+	}
+
+	labelSelector := fmt.Sprintf(`{service_name="%s"}`, appName)
+	expectedChain := [][2]string{
+		{"EndpointMiddleware", "Invoke"},
+		{"OrderService", "FindNearestVehicle"},
+	}
+	var lastCollapsed string
+	var lastErr error
+	ok := assert.Eventually(t, func() bool {
+		lastCollapsed, lastErr = queryProfile(t, pyroscopeURL, labelSelector, "lock:lock_count:count:cpu:nanoseconds")
+		if lastErr != nil || lastCollapsed == "" {
+			return false
+		}
+		return stackContainsChain(lastCollapsed, expectedChain)
+	}, 3*time.Minute, 5*time.Second)
+
+	if !ok {
+		t.Logf("label selector: %s", labelSelector)
+		t.Logf("last profile query error: %v", lastErr)
+		t.Logf("last collapsed profile:\n%s", lastCollapsed)
+		t.FailNow()
+	}
+	t.Logf("collapsed lock profile:\n%s", lastCollapsed)
+}


### PR DESCRIPTION
## Summary
- Adds three new integration tests that verify the profiler produces correct stacktraces for allocation, exception, and lock (contention) profile types end-to-end through Pyroscope.
- Each test asserts an ordered frame chain (caller→callee), not just a single frame: `AllocWork.Work → AllocWork.Allocate` for allocation, `EndpointMiddleware.Invoke → NPE.Work` for exception, `EndpointMiddleware.Invoke → OrderService.FindNearestVehicle` for lock.
- Adds `AllocWork.cs` with `[NoInlining]` methods and a `/alloc` endpoint to the integration test app for reliable allocation sampling (1000 × 10KB arrays per request).
- Refactors `queryProfile` to accept a `profileTypeID` parameter and moves the new tests into a separate `profile_stacktrace_test.go` file.

## Test plan
- [x] All three tests pass locally on glibc/.NET 10.0
- [ ] CI runs across glibc/musl × .NET 8.0/9.0/10.0 matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it adds new end-to-end integration tests and a new load-generating `/alloc` endpoint, which may increase CI runtime and introduce flakiness due to timing/sampling-dependent assertions.
> 
> **Overview**
> Adds new end-to-end integration tests that query Pyroscope stacktrace data for **allocation**, **exception**, and **lock/contention** profiles and assert an ordered caller→callee frame chain (not just single-frame presence).
> 
> Extends the integration test app with an allocation workload (`AllocWork` with `NoInlining`) and a `/alloc` route to reliably generate allocation samples, and refactors `queryProfile` to accept a `profileTypeID` so tests can target non-CPU profile types.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ffe93be78b986a16fe5f7d919c72b659681238b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->