### PR TITLE
ci: add release-prepare workflow

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -74,7 +74,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-          BRANCH="prepare/v${VERSION}-pyroscope"
+          BRANCH="prepare-release/v${VERSION}-pyroscope"
           git checkout -b "${BRANCH}"
           git add Pyroscope/Pyroscope/Pyroscope.csproj \
                   profiler/src/ProfilerEngine/Datadog.Profiler.Native/PyroscopePprofSink.h
@@ -89,7 +89,7 @@ jobs:
               --base main \
               --head "${BRANCH}" \
               --title "Release v${VERSION}-pyroscope" \
-              --label "release" \
+              --label "prepare-release" \
               --body "Automated release PR for version ${VERSION}.
 
           Once this PR is merged, tag the merge commit and push it to trigger the release workflows:
@@ -104,7 +104,7 @@ jobs:
     if: >-
       github.event_name == 'pull_request'
       && github.event.pull_request.merged == true
-      && contains(github.event.pull_request.labels.*.name, 'release')
+      && contains(github.event.pull_request.labels.*.name, 'prepare-release')
     runs-on: ubuntu-x64-small
     steps:
       - name: Checkout code

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -37,8 +37,7 @@ jobs:
         env:
           VERSION_BUMP: ${{ inputs.version_bump || 'patch' }}
         run: |
-          current_version=$(grep '<PackageVersion>' Pyroscope/Pyroscope/Pyroscope.csproj \
-            | sed 's/.*<PackageVersion>\(.*\)<\/PackageVersion>.*/\1/')
+          current_version=$(make version)
           echo "Current version: $current_version"
           IFS='.' read -r major minor patch <<< "$current_version"
 
@@ -117,8 +116,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
           MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
         run: |
-          version=$(grep '<PackageVersion>' Pyroscope/Pyroscope/Pyroscope.csproj \
-            | sed 's/.*<PackageVersion>\(.*\)<\/PackageVersion>.*/\1/')
+          version=$(make version)
           tag="v${version}-pyroscope"
           echo "Creating draft release ${tag} at ${MERGE_SHA}"
           gh release create "${tag}" \

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -3,6 +3,9 @@ name: Prepare Release
 on:
   push:
     branches: [main]
+  pull_request:
+    branches: [main]
+    types: [closed]
   workflow_dispatch:
     inputs:
       version_bump:
@@ -21,6 +24,7 @@ permissions:
 
 jobs:
   prepare:
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-x64-small
     steps:
       - name: Checkout code
@@ -95,3 +99,30 @@ jobs:
           git push upstream v${VERSION}-pyroscope
           \`\`\`"
           fi
+
+  publish:
+    if: >-
+      github.event_name == 'pull_request'
+      && github.event.pull_request.merged == true
+      && contains(github.event.pull_request.labels.*.name, 'release')
+    runs-on: ubuntu-x64-small
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
+
+      - name: Read version and create draft release
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+        run: |
+          version=$(grep '<PackageVersion>' Pyroscope/Pyroscope/Pyroscope.csproj \
+            | sed 's/.*<PackageVersion>\(.*\)<\/PackageVersion>.*/\1/')
+          tag="v${version}-pyroscope"
+          echo "Creating draft release ${tag} at ${MERGE_SHA}"
+          gh release create "${tag}" \
+            --target "${MERGE_SHA}" \
+            --title "${tag}" \
+            --draft \
+            --generate-notes

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -80,7 +80,7 @@ jobs:
           git commit -m "version ${VERSION}"
           git push --force origin "${BRANCH}"
 
-          existing_pr=$(gh pr list --head "${BRANCH}" --json number --jq '.[0].number')
+          existing_pr=$(gh pr list --head "${BRANCH}" --json number --jq '.[0].number // empty')
           if [ -n "$existing_pr" ]; then
             echo "PR #${existing_pr} already exists for ${BRANCH}, branch has been force-pushed"
           else

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -1,0 +1,97 @@
+name: Prepare Release
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      version_bump:
+        description: 'Version Bump Type'
+        required: true
+        default: 'patch'
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  prepare:
+    runs-on: ubuntu-x64-small
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: true
+
+      - name: Compute new version
+        id: bump_version
+        env:
+          VERSION_BUMP: ${{ inputs.version_bump || 'patch' }}
+        run: |
+          current_version=$(grep '<PackageVersion>' Pyroscope/Pyroscope/Pyroscope.csproj \
+            | sed 's/.*<PackageVersion>\(.*\)<\/PackageVersion>.*/\1/')
+          echo "Current version: $current_version"
+          IFS='.' read -r major minor patch <<< "$current_version"
+
+          case "$VERSION_BUMP" in
+            "major")
+              major=$((major + 1))
+              minor=0
+              patch=0
+              ;;
+            "minor")
+              minor=$((minor + 1))
+              patch=0
+              ;;
+            "patch")
+              patch=$((patch + 1))
+              ;;
+          esac
+
+          new_version="${major}.${minor}.${patch}"
+          echo "New version: $new_version"
+          echo "version=$new_version" >> "$GITHUB_OUTPUT"
+
+      - name: Bump version in source files
+        env:
+          RELEASE_VERSION: ${{ steps.bump_version.outputs.version }}
+        run: make bump_version
+
+      - name: Create release branch and PR
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.bump_version.outputs.version }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          BRANCH="prepare/v${VERSION}-pyroscope"
+          git checkout -b "${BRANCH}"
+          git add Pyroscope/Pyroscope/Pyroscope.csproj \
+                  profiler/src/ProfilerEngine/Datadog.Profiler.Native/PyroscopePprofSink.h
+          git commit -m "version ${VERSION}"
+          git push --force origin "${BRANCH}"
+
+          existing_pr=$(gh pr list --head "${BRANCH}" --json number --jq '.[0].number')
+          if [ -n "$existing_pr" ]; then
+            echo "PR #${existing_pr} already exists for ${BRANCH}, branch has been force-pushed"
+          else
+            gh pr create \
+              --base main \
+              --head "${BRANCH}" \
+              --title "Release v${VERSION}-pyroscope" \
+              --label "release" \
+              --body "Automated release PR for version ${VERSION}.
+
+          Once this PR is merged, tag the merge commit and push it to trigger the release workflows:
+
+          \`\`\`
+          git tag v${VERSION}-pyroscope
+          git push upstream v${VERSION}-pyroscope
+          \`\`\`"
+          fi

--- a/.github/workflows/tag_linux.yml
+++ b/.github/workflows/tag_linux.yml
@@ -1,124 +1,35 @@
 name: Release linux profiler
 
 on:
-  push:
-    tags:
-      - 'v*'
-      - '!v*opentelemetry'
-      - '!v*opentracing'
+  release:
+    types: [created]
+
 jobs:
-  release-linux-profiler-x86_64:
-    permissions:
-      contents: write
-      id-token: write
-    runs-on: ubuntu-x64-large
-    env:
-      DOCKER_BUILDKIT: 1
-      ARCH: x86_64
-      LIBC: ${{ matrix.name }}
-      RELEASE_VERSION: ${{  github.ref_name }}
-    strategy:
-      matrix:
-        name: ['glibc', 'musl']
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          submodules: 'true'
-          persist-credentials: false
-      - uses: grafana/shared-workflows/actions/get-vault-secrets@e7a3275d4c4978a3514801ec55708f1c599a6906
-        with:
-          repo_secrets: |
-            DOCKERHUB_USERNAME=dockerhub:user
-            DOCKERHUB_PASSWORD=dockerhub:token
-      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
-        name: Login to Docker Hub
-        with:
-          username: ${{ env.DOCKERHUB_USERNAME }}
-          password: ${{ env.DOCKERHUB_PASSWORD }}
-      - run: make bump_version
-      - name: Check version matches committed version
-        if: ${{ !contains(github.ref_name, '-rc') }}
-        run: git diff --exit-code
-      - run: make docker/build
-      - run: make docker/push
-      - run: make docker/archive
-      - name: Release
-        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
-        with:
-          files: ./*.tar.gz
-          make_latest: ${{ !contains(github.ref_name, '-rc') }}
-  release-linux-profiler-aarch64:
-    permissions:
-      contents: write
-      id-token: write
-    runs-on: ubuntu-arm64-large
-    env:
-      DOCKER_BUILDKIT: 1
-      ARCH: aarch64
-      LIBC: ${{ matrix.name }}
-      RELEASE_VERSION: ${{  github.ref_name }}
-    strategy:
-      matrix:
-        name: ['glibc', 'musl']
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          submodules: 'true'
-          persist-credentials: false
-      - uses: grafana/shared-workflows/actions/get-vault-secrets@e7a3275d4c4978a3514801ec55708f1c599a6906
-        with:
-          repo_secrets: |
-            DOCKERHUB_USERNAME=dockerhub:user
-            DOCKERHUB_PASSWORD=dockerhub:token
-      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
-        name: Login to Docker Hub
-        with:
-          username: ${{ env.DOCKERHUB_USERNAME }}
-          password: ${{ env.DOCKERHUB_PASSWORD }}
-      - run: make bump_version
-      - name: Check version matches committed version
-        if: ${{ !contains(github.ref_name, '-rc') }}
-        run: git diff --exit-code
-      - run: make docker/build
-      - run: make docker/push
-      - run: make docker/archive
-      - name: Release
-        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
-        with:
-          files: ./*.tar.gz
-          make_latest: ${{ !contains(github.ref_name, '-rc') }}
   release-linux-profiler:
     permissions:
-      contents: read
-      id-token: write
-    needs: ['release-linux-profiler-x86_64', 'release-linux-profiler-aarch64']
-    runs-on: ubuntu-x64-small
+      contents: write
+    runs-on: ${{ matrix.arch == 'aarch64' && 'ubuntu-arm64-large' || 'ubuntu-x64-large' }}
     env:
       DOCKER_BUILDKIT: 1
-      LIBC: ${{ matrix.name }}
-      RELEASE_VERSION: ${{  github.ref_name }}
+      ARCH: ${{ matrix.arch }}
+      LIBC: ${{ matrix.libc }}
+      RELEASE_VERSION: ${{ github.event.release.tag_name }}
     strategy:
       matrix:
-        name: ['glibc', 'musl']
+        arch: ['x86_64', 'aarch64']
+        libc: ['glibc', 'musl']
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           submodules: 'true'
           persist-credentials: false
-      - uses: grafana/shared-workflows/actions/get-vault-secrets@e7a3275d4c4978a3514801ec55708f1c599a6906
+      - run: make bump_version
+      - name: Check version matches committed version
+        if: ${{ !contains(github.event.release.tag_name, '-rc') }}
+        run: git diff --exit-code
+      - run: make docker/archive
+      - name: Upload artifacts to release
+        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
         with:
-          repo_secrets: |
-            DOCKERHUB_USERNAME=dockerhub:user
-            DOCKERHUB_PASSWORD=dockerhub:token
-      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
-        name: Login to Docker Hub
-        with:
-          username: ${{ env.DOCKERHUB_USERNAME }}
-          password: ${{ env.DOCKERHUB_PASSWORD }}
-      - run: make docker/manifest
-      - name: Push latest manifest
-        if: ${{ !contains(github.ref_name, '-rc') }}
-        run: make docker/manifest-latest
+          files: ./*.tar.gz

--- a/.github/workflows/tag_managed_helper.yml
+++ b/.github/workflows/tag_managed_helper.yml
@@ -1,21 +1,17 @@
 name: Release managed helper
 
 on:
-  push:
-    tags:
-      - 'v*'
-      - '!v*opentelemetry'
-      - '!v*opentracing'
+  release:
+    types: [created]
 
 permissions:
   contents: write
-  id-token: write
 
 jobs:
   release-managed-helper:
     runs-on: ubuntu-x64-small
     env:
-      RELEASE_VERSION: ${{  github.ref_name }}
+      RELEASE_VERSION: ${{ github.event.release.tag_name }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -27,7 +23,7 @@ jobs:
           global-json-file: global.json
       - run: make bump_version
       - name: Check version matches committed version
-        if: ${{ !contains(github.ref_name, '-rc') }}
+        if: ${{ !contains(github.event.release.tag_name, '-rc') }}
         run: git diff --exit-code
       - run: dotnet build -c Release ./Pyroscope
         working-directory: Pyroscope
@@ -37,21 +33,9 @@ jobs:
           name: packages
           path: ./Pyroscope/artifacts/package/release
           if-no-files-found: error
-      - uses: grafana/shared-workflows/actions/get-vault-secrets@e7a3275d4c4978a3514801ec55708f1c599a6906
-        if: ${{ !contains(github.ref_name, '-rc') }}
-        with:
-          repo_secrets: |
-            NUGET_API_KEY=nuget:api_key
-      - name: Publish the package to nuget.org
-        if: ${{ !contains(github.ref_name, '-rc') }}
-        run: dotnet nuget push ./Pyroscope/artifacts/package/release/*.nupkg -k "${NUGET_API_KEY}" -s https://api.nuget.org/v3/index.json
-        env:
-          NUGET_API_KEY: ${{ env.NUGET_API_KEY }}
-      - name: Release
+      - name: Upload artifacts to release
         uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
-        if: startsWith(github.ref, 'refs/tags/')
         with:
           files: |
             ./Pyroscope/artifacts/bin/Pyroscope/release/Pyroscope.dll
             ./Pyroscope/artifacts/package/release/Pyroscope*.nupkg
-          make_latest: ${{ !contains(github.ref_name, '-rc') }}

--- a/Makefile
+++ b/Makefile
@@ -3,12 +3,13 @@ ARCH ?= x86_64
 RELEASE_VERSION ?=
 DOCKER_IMAGE ?= pyroscope/pyroscope-dotnet
 
+ifneq ($(MAKECMDGOALS),version)
 ifeq ($(RELEASE_VERSION),)
   $(error "no release version specified")
 endif
 RELEASE_VERSION_TMP := $(shell echo $(RELEASE_VERSION) | sed -E 's/^v([0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?)(-pyroscope)?$$/\1/')
-#$(error "debug $(RELEASE_VERSION_TMP)")
 RELEASE_VERSION := $(RELEASE_VERSION_TMP)
+endif
 
 ifeq ($(LIBC),musl)
 	DOCKERFILE := Pyroscope.musl.Dockerfile
@@ -56,6 +57,10 @@ docker/manifest-latest:
 		--amend $(DOCKER_IMAGE):$(RELEASE_VERSION)-$(LIBC)-aarch64
 	docker manifest push $(DOCKER_IMAGE):latest-$(LIBC)
 
+
+.phony: version
+version:
+	@grep '<PackageVersion>' Pyroscope/Pyroscope/Pyroscope.csproj | sed 's/.*<PackageVersion>\(.*\)<\/PackageVersion>.*/\1/'
 
 .phony: bump_version
 bump_version:


### PR DESCRIPTION
## Summary

- Adds a `release-prepare.yml` GitHub Actions workflow that automatically creates a patch-bump release PR on every push to `main`
- Can also be triggered manually from the Actions tab with a patch/minor/major choice
- Force-pushes the release branch (`prepare/vX.Y.Z-pyroscope`) to keep it always one commit ahead of latest main
- Reuses existing `make bump_version` to update all version files
- Labels PRs with `release` for easy filtering

## Test plan

- [ ] Verify workflow appears in Actions tab as manually dispatchable
- [ ] Trigger manually with "patch" and confirm PR is created with correct version bump
- [ ] Push to main and confirm the workflow auto-triggers and creates/updates the release PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the release automation flow (new auto-created release PRs and draft GitHub releases) and significantly modifies existing release workflows’ triggers and outputs, which could break artifact publishing if misconfigured. No runtime product code changes, but CI/CD behavior and release cadence are impacted.
> 
> **Overview**
> Adds a new `release-prepare.yml` workflow that *auto-bumps* the Pyroscope version (patch by default, or manual patch/minor/major), force-pushes a `prepare-release/vX.Y.Z-pyroscope` branch, and opens/updates a labeled release PR; when that PR is merged, it creates a **draft GitHub release** for the merge commit.
> 
> Updates the Linux profiler and managed helper release workflows to run on `release: created` (using `github.event.release.tag_name`) and to **upload built artifacts to the GitHub release**, while removing DockerHub/NuGet secret usage and Docker push/manifest steps. The `Makefile` now exposes `make version` and skips requiring `RELEASE_VERSION` for that target.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f738c56aea92daabb8b3ec134eb3e7a452e9f316. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->