### PR TITLE
ci: use public GitHub runners on forks

### DIFF
--- a/.github/workflows/build_linux_profiler.yml
+++ b/.github/workflows/build_linux_profiler.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   build-linux-profiler-x86_64:
-    runs-on: ubuntu-x64-large
+    runs-on: ${{ github.repository_owner == 'grafana' && 'ubuntu-x64-large' || 'ubuntu-latest' }}
     env:
       DOCKER_BUILDKIT: 1
     strategy:
@@ -27,7 +27,7 @@ jobs:
           persist-credentials: false
       - run: RELEASE_VERSION=dev-$(git rev-parse --short HEAD) ARCH=x86_64 LIBC=${{ matrix.name }}  make docker/build
   build-linux-profiler-aarch64:
-    runs-on: ubuntu-arm64-large
+    runs-on: ${{ github.repository_owner == 'grafana' && 'ubuntu-arm64-large' || 'ubuntu-24.04-arm' }}
     env:
       DOCKER_BUILDKIT: 1
     strategy:

--- a/.github/workflows/build_linux_profiler.yml
+++ b/.github/workflows/build_linux_profiler.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   build-linux-profiler-x86_64:
-    runs-on: ${{ github.repository_owner == 'grafana' && 'ubuntu-x64-large' || 'ubuntu-latest' }}
+    runs-on: ubuntu-x64-large
     env:
       DOCKER_BUILDKIT: 1
     strategy:
@@ -27,7 +27,7 @@ jobs:
           persist-credentials: false
       - run: RELEASE_VERSION=dev-$(git rev-parse --short HEAD) ARCH=x86_64 LIBC=${{ matrix.name }}  make docker/build
   build-linux-profiler-aarch64:
-    runs-on: ${{ github.repository_owner == 'grafana' && 'ubuntu-arm64-large' || 'ubuntu-24.04-arm' }}
+    runs-on: ubuntu-arm64-large
     env:
       DOCKER_BUILDKIT: 1
     strategy:

--- a/.github/workflows/build_managed_helper.yml
+++ b/.github/workflows/build_managed_helper.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   build-managed-helper:
-    runs-on: ubuntu-x64-small
+    runs-on: ${{ github.repository_owner == 'grafana' && 'ubuntu-x64-small' || 'ubuntu-latest' }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/build_managed_helper.yml
+++ b/.github/workflows/build_managed_helper.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   build-managed-helper:
-    runs-on: ${{ github.repository_owner == 'grafana' && 'ubuntu-x64-small' || 'ubuntu-latest' }}
+    runs-on: ubuntu-x64-small
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/build_tracing_packages.yml
+++ b/.github/workflows/build_tracing_packages.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   build-opentracing-lib:
-    runs-on: ubuntu-x64-small
+    runs-on: ${{ github.repository_owner == 'grafana' && 'ubuntu-x64-small' || 'ubuntu-latest' }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -31,7 +31,7 @@ jobs:
           path: ./Pyroscope/artifacts/package/release
           if-no-files-found: error
   build-opentelemetry-lib:
-    runs-on: ubuntu-x64-small
+    runs-on: ${{ github.repository_owner == 'grafana' && 'ubuntu-x64-small' || 'ubuntu-latest' }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/build_tracing_packages.yml
+++ b/.github/workflows/build_tracing_packages.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   build-opentracing-lib:
-    runs-on: ${{ github.repository_owner == 'grafana' && 'ubuntu-x64-small' || 'ubuntu-latest' }}
+    runs-on: ubuntu-x64-small
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -31,7 +31,7 @@ jobs:
           path: ./Pyroscope/artifacts/package/release
           if-no-files-found: error
   build-opentelemetry-lib:
-    runs-on: ${{ github.repository_owner == 'grafana' && 'ubuntu-x64-small' || 'ubuntu-latest' }}
+    runs-on: ubuntu-x64-small
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -44,7 +44,7 @@ jobs:
   test:
     name: integration-test ${{ matrix.test }} ${{ matrix.libc_type }} .NET ${{ matrix.version }}
     needs: discover
-    runs-on: ubuntu-x64-large
+    runs-on: ${{ github.repository_owner == 'grafana' && 'ubuntu-x64-large' || 'ubuntu-latest' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/tag_linux.yml
+++ b/.github/workflows/tag_linux.yml
@@ -11,7 +11,7 @@ jobs:
     permissions:
       contents: write
       id-token: write
-    runs-on: ${{ github.repository_owner == 'grafana' && 'ubuntu-x64-large' || 'ubuntu-latest' }}
+    runs-on: ubuntu-x64-large
     env:
       DOCKER_BUILDKIT: 1
       ARCH: x86_64
@@ -52,7 +52,7 @@ jobs:
     permissions:
       contents: write
       id-token: write
-    runs-on: ${{ github.repository_owner == 'grafana' && 'ubuntu-arm64-large' || 'ubuntu-24.04-arm' }}
+    runs-on: ubuntu-arm64-large
     env:
       DOCKER_BUILDKIT: 1
       ARCH: aarch64
@@ -94,7 +94,7 @@ jobs:
       contents: read
       id-token: write
     needs: ['release-linux-profiler-x86_64', 'release-linux-profiler-aarch64']
-    runs-on: ${{ github.repository_owner == 'grafana' && 'ubuntu-x64-small' || 'ubuntu-latest' }}
+    runs-on: ubuntu-x64-small
     env:
       DOCKER_BUILDKIT: 1
       LIBC: ${{ matrix.name }}

--- a/.github/workflows/tag_linux.yml
+++ b/.github/workflows/tag_linux.yml
@@ -11,7 +11,7 @@ jobs:
     permissions:
       contents: write
       id-token: write
-    runs-on: ubuntu-x64-large
+    runs-on: ${{ github.repository_owner == 'grafana' && 'ubuntu-x64-large' || 'ubuntu-latest' }}
     env:
       DOCKER_BUILDKIT: 1
       ARCH: x86_64
@@ -52,7 +52,7 @@ jobs:
     permissions:
       contents: write
       id-token: write
-    runs-on: ubuntu-arm64-large
+    runs-on: ${{ github.repository_owner == 'grafana' && 'ubuntu-arm64-large' || 'ubuntu-24.04-arm' }}
     env:
       DOCKER_BUILDKIT: 1
       ARCH: aarch64
@@ -94,7 +94,7 @@ jobs:
       contents: read
       id-token: write
     needs: ['release-linux-profiler-x86_64', 'release-linux-profiler-aarch64']
-    runs-on: ubuntu-x64-small
+    runs-on: ${{ github.repository_owner == 'grafana' && 'ubuntu-x64-small' || 'ubuntu-latest' }}
     env:
       DOCKER_BUILDKIT: 1
       LIBC: ${{ matrix.name }}

--- a/.github/workflows/tag_managed_helper.yml
+++ b/.github/workflows/tag_managed_helper.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   release-managed-helper:
-    runs-on: ${{ github.repository_owner == 'grafana' && 'ubuntu-x64-small' || 'ubuntu-latest' }}
+    runs-on: ubuntu-x64-small
     env:
       RELEASE_VERSION: ${{  github.ref_name }}
     steps:

--- a/.github/workflows/tag_managed_helper.yml
+++ b/.github/workflows/tag_managed_helper.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   release-managed-helper:
-    runs-on: ubuntu-x64-small
+    runs-on: ${{ github.repository_owner == 'grafana' && 'ubuntu-x64-small' || 'ubuntu-latest' }}
     env:
       RELEASE_VERSION: ${{  github.ref_name }}
     steps:

--- a/.github/workflows/tag_tracing_opentelemetry_helper.yml
+++ b/.github/workflows/tag_tracing_opentelemetry_helper.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   release-opentelemetry-lib:
-    runs-on: ubuntu-x64-small
+    runs-on: ${{ github.repository_owner == 'grafana' && 'ubuntu-x64-small' || 'ubuntu-latest' }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/tag_tracing_opentelemetry_helper.yml
+++ b/.github/workflows/tag_tracing_opentelemetry_helper.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   release-opentelemetry-lib:
-    runs-on: ${{ github.repository_owner == 'grafana' && 'ubuntu-x64-small' || 'ubuntu-latest' }}
+    runs-on: ubuntu-x64-small
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/tag_tracing_opentracing_helper.yml
+++ b/.github/workflows/tag_tracing_opentracing_helper.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   release-opentracing-lib:
-    runs-on: ubuntu-x64-small
+    runs-on: ${{ github.repository_owner == 'grafana' && 'ubuntu-x64-small' || 'ubuntu-latest' }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/tag_tracing_opentracing_helper.yml
+++ b/.github/workflows/tag_tracing_opentracing_helper.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   release-opentracing-lib:
-    runs-on: ${{ github.repository_owner == 'grafana' && 'ubuntu-x64-small' || 'ubuntu-latest' }}
+    runs-on: ubuntu-x64-small
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/test_cpp_profiler.yml
+++ b/.github/workflows/test_cpp_profiler.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   test-cpp-profiler:
-    runs-on: ubuntu-x64-large
+    runs-on: ${{ github.repository_owner == 'grafana' && 'ubuntu-x64-large' || 'ubuntu-latest' }}
     env:
       DOCKER_BUILDKIT: 1
     strategy:

--- a/.github/workflows/test_cpp_profiler.yml
+++ b/.github/workflows/test_cpp_profiler.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   test-cpp-profiler:
-    runs-on: ${{ github.repository_owner == 'grafana' && 'ubuntu-x64-large' || 'ubuntu-latest' }}
+    runs-on: ubuntu-x64-large
     env:
       DOCKER_BUILDKIT: 1
     strategy:


### PR DESCRIPTION
## Summary
- All 9 workflow files now select runners conditionally based on `github.repository_owner`
- On the `grafana` org: Grafana-hosted runners (`ubuntu-x64-large`, `ubuntu-x64-small`, `ubuntu-arm64-large`)
- On forks: public GitHub runners (`ubuntu-latest`, `ubuntu-24.04-arm`)
- No behavior change for the grafana org — only forks are affected

## Test plan
- [ ] CI passes on this PR (confirms Grafana runners still selected on the grafana org)
- [ ] Fork contributor can verify workflows run on public runners on their fork

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI execution environment by switching fork runs to GitHub-hosted runners, which may surface new build/test failures due to runner image/architecture differences. Grafana-org behavior should remain unchanged but mis-detection of `github.repository_owner` would impact CI capacity and performance.
> 
> **Overview**
> **CI runner selection is now conditional across workflows.** All affected GitHub Actions jobs replace hardcoded Grafana-hosted `runs-on` labels with expressions that use Grafana-hosted runners when `github.repository_owner == 'grafana'`, otherwise falling back to GitHub-hosted runners.
> 
> This applies to build, test, and release workflows (including ARM jobs using `ubuntu-24.04-arm` on forks), enabling forked PRs/tags to run without access to Grafana’s private runner fleet.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef56fb08ac681a75db18a382dfcd4a650c82376a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->