### PR TITLE
chore(renovate): restrict dockerfile dependencies to patch-only updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,11 @@
   "extends": ["config:recommended"],
   "packageRules": [
     {
+      "matchManagers": ["dockerfile"],
+      "matchUpdateTypes": ["major", "minor"],
+      "enabled": false
+    },
+    {
       "matchDepNames": ["openssl/openssl"],
       "separateMinorPatch": true
     },


### PR DESCRIPTION
## Summary
- Adds a Renovate package rule that disables major and minor updates for the `dockerfile` manager.
- Only patch-level bumps will be proposed for Docker base image tags (Debian, Alpine, etc.).

## Test plan
- Verify Renovate dashboard no longer proposes major/minor Docker image updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that only affects Renovate’s update proposals for Docker base images. Main impact is potentially delaying major/minor image upgrades if they’re desired.
> 
> **Overview**
> Renovate is now configured to **disable major and minor updates for the `dockerfile` manager**, effectively limiting Docker base image bumps to patch-level updates.
> 
> All other existing Renovate rules (e.g., OpenSSL handling) remain unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2da7d3fddcfc8ea124b79c7c661f659e691d624. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->