### PR TITLE
chore(renovate): restrict dockerfile dependencies to patch-only updates

### DIFF
--- a/Pyroscope.musl.Dockerfile
+++ b/Pyroscope.musl.Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.18.11 AS builder
+FROM alpine:3.18.11@sha256:dd60c75fba961ecc5e918961c713f3c42dd5665171c58f9b2ef5aafe081ad5a0 AS builder
 
 RUN apk add \
             clang \

--- a/Pyroscope.musl.Dockerfile
+++ b/Pyroscope.musl.Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.18.11@sha256:dd60c75fba961ecc5e918961c713f3c42dd5665171c58f9b2ef5aafe081ad5a0 AS builder
+FROM alpine:3.18.12@sha256:de0eb0b3f2a47ba1eb89389859a9bd88b28e82f5826b6969ad604979713c2d4f AS builder
 
 RUN apk add \
             clang \

--- a/Pyroscope.musl.Dockerfile
+++ b/Pyroscope.musl.Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.18.12@sha256:de0eb0b3f2a47ba1eb89389859a9bd88b28e82f5826b6969ad604979713c2d4f AS builder
+FROM alpine:3.18.11@sha256:dd60c75fba961ecc5e918961c713f3c42dd5665171c58f9b2ef5aafe081ad5a0 AS builder
 
 RUN apk add \
             clang \

--- a/Pyroscope.musl.Dockerfile
+++ b/Pyroscope.musl.Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.18 AS builder
+FROM alpine:3.18.11 AS builder
 
 RUN apk add \
             clang \

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended"],
+  "extends": ["config:recommended", "docker:pinDigests"],
   "packageRules": [
     {
       "matchManagers": ["dockerfile"],

--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,10 @@
   "packageRules": [
     {
       "matchManagers": ["dockerfile"],
+      "separateMinorPatch": true
+    },
+    {
+      "matchManagers": ["dockerfile"],
       "matchUpdateTypes": ["major", "minor"],
       "enabled": false
     },


### PR DESCRIPTION
## Summary
- Pin Alpine base image to `3.18.11` (previous patch) so Renovate can manage patch bumps
- Enable `separateMinorPatch` for the `dockerfile` manager so patch updates aren't lumped with minor and accidentally disabled
- Enable `docker:pinDigests` preset so Renovate pins all Docker base images to their SHA256 digest
- Disable major and minor updates for all `dockerfile`-managed dependencies, allowing only patch-level bumps

## Test plan
- Ran `renovate --platform=local --dry-run` locally and verified:
  - Alpine `3.18.11 → 3.18.12` patch update is proposed
  - Alpine digest pinning (`pinDigest`) is proposed
  - Debian `bullseye-20260406 → bullseye-20260421` patch update is proposed
  - Alpine minor (`3.23.4`) and Debian major (`trixie`) updates are correctly disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to dependency update automation (Renovate rules) and a pinned Docker base image digest, with no runtime logic changes beyond base image immutability.
> 
> **Overview**
> Pins the `Pyroscope.musl.Dockerfile` builder base image to `alpine:3.18.11` **with a SHA256 digest** for reproducible builds.
> 
> Updates `renovate.json` to apply `docker:pinDigests`, split patch vs minor updates for Dockerfiles (`separateMinorPatch`), and **disable Dockerfile major/minor updates** so Renovate only proposes patch-level bumps (while keeping OpenSSL version updates similarly constrained).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12834cb9e171a5ec79151c434abb2f7864090fc9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->