### PR TITLE
ci: open version-bump PR as draft, rerun CI on ready-for-review

### DIFF
--- a/.github/scripts/version-bump-pr.sh
+++ b/.github/scripts/version-bump-pr.sh
@@ -49,6 +49,7 @@ if [ -n "$existing_pr" ]; then
   echo "PR #${existing_pr} already exists for ${BRANCH}, branch has been force-pushed"
 else
   gh pr create \
+    --draft \
     --base main \
     --head "${BRANCH}" \
     --title "Release v${VERSION}-pyroscope" \

--- a/.github/workflows/build_linux_profiler.yml
+++ b/.github/workflows/build_linux_profiler.yml
@@ -2,6 +2,7 @@ name: Build linux profiler
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [main]
 
 permissions:

--- a/.github/workflows/build_tracing_packages.yml
+++ b/.github/workflows/build_tracing_packages.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [main]
 
 

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [main]
 
 permissions:

--- a/.github/workflows/publish_dev_images.yml
+++ b/.github/workflows/publish_dev_images.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    types: [opened, synchronize, reopened, labeled]
+    types: [opened, synchronize, reopened, labeled, ready_for_review]
     branches: [main]
 
 permissions:

--- a/.github/workflows/test_cpp_profiler.yml
+++ b/.github/workflows/test_cpp_profiler.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [main]
 
 permissions:


### PR DESCRIPTION
The Release Version Bump PR workflow auto-creates a Release vX.Y.Z-pyroscope PR whenever main moves. Today the bot opens it as a normal PR; this change opens it as a draft so a maintainer must explicitly mark it ready before it becomes review-eligible.

By default the pull_request trigger fires on [opened, synchronize, reopened] and does not include ready_for_review, so flipping a draft to ready did not re-run any CI. To make CI re-run on that transition, ready_for_review is added to the types list of every PR-triggered workflow (build_linux_profiler, build_tracing_packages, integration_test, test_cpp_profiler, publish_dev_images). The four workflows that previously omitted types now spell out the default trio explicitly so opened/synchronize/reopened coverage is preserved.

publish_dev_images stays gated on the pr-publish-dev-docker label via its job-level if; the new ready_for_review action satisfies the action != 'labeled' clause, so the existing label-presence check governs whether the job runs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow/script changes that mainly affect when CI runs and how release bump PRs are created; primary risk is unintended CI triggering frequency or missed runs due to event-type filtering.
> 
> **Overview**
> Automated version-bump release PRs are now created as **drafts** (via `--draft` in `.github/scripts/version-bump-pr.sh`), requiring an explicit “ready for review” action before normal review flow.
> 
> Several GitHub Actions workflows now explicitly include the `ready_for_review` pull request event type (and spell out the default PR event types) so CI and related jobs rerun when a draft PR is marked ready, including the dev image publish workflow while keeping its label-based gating intact.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6165c0ab7c6f990bef06d3819341f70258bbf847. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->