### PR TITLE
ci: publish Docker images to grafana/pyroscope-dotnet

### DIFF
--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -56,7 +56,6 @@ jobs:
     env:
       GH_TOKEN: ${{ github.token }}
       DOCKER_BUILDKIT: 1
-      DOCKER_IMAGE: pyroscope/pyroscope-dotnet
       ARCH: ${{ matrix.arch }}
       LIBC: ${{ matrix.libc }}
       RELEASE_VERSION: ${{ needs.create-draft.outputs.version }}
@@ -104,7 +103,6 @@ jobs:
     runs-on: ${{ github.repository_owner == 'grafana' && 'ubuntu-x64-small' || 'ubuntu-latest' }}
     env:
       DOCKER_BUILDKIT: 1
-      DOCKER_IMAGE: pyroscope/pyroscope-dotnet
       LIBC: ${{ matrix.name }}
       RELEASE_VERSION: ${{ needs.create-draft.outputs.version }}
       DOCKER_TAG_VERSION: ${{ needs.create-draft.outputs.version }}-draft

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -12,7 +12,6 @@ jobs:
     if: contains(github.event.release.tag_name, '-pyroscope')
     runs-on: ${{ github.repository_owner == 'grafana' && 'ubuntu-x64-small' || 'ubuntu-latest' }}
     env:
-      DOCKER_IMAGE: pyroscope/pyroscope-dotnet
       LIBC: ${{ matrix.libc }}
     strategy:
       matrix:

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ LIBC ?= glibc
 ARCH ?= x86_64
 RELEASE_VERSION ?=
 DOCKER_TAG_VERSION ?= $(RELEASE_VERSION)
-DOCKER_IMAGE ?= pyroscope/pyroscope-dotnet
+DOCKER_IMAGE ?= grafana/pyroscope-dotnet
 
 ifeq ($(RELEASE_VERSION),)
   $(error RELEASE_VERSION is required)


### PR DESCRIPTION
## Summary
- Change the Docker Hub publishing target from `pyroscope/pyroscope-dotnet` to `grafana/pyroscope-dotnet` (Makefile default).
- Remove now-redundant `DOCKER_IMAGE` overrides from `release-draft.yml` and `release-publish.yml` so the Makefile is the single source of truth. `publish_dev_images.yml` already relied on the default and inherits the new value automatically.

## Test plan
- [ ] Verify the `DOCKERHUB_USERNAME` / `DOCKERHUB_PASSWORD` vault secrets have push rights to `grafana/pyroscope-dotnet` on Docker Hub before merging.
- [ ] After merge, confirm the `Publish dev Docker images` workflow pushes to the new repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the Docker Hub repository target for release builds/promotions, so misconfigured credentials or repo permissions could break publishing. Otherwise the diff is small and limited to CI/Makefile defaults.
> 
> **Overview**
> Publishes release Docker images to `grafana/pyroscope-dotnet` by updating the Makefile default `DOCKER_IMAGE`.
> 
> Removes explicit `DOCKER_IMAGE` env overrides from `release-draft.yml` and `release-publish.yml` so workflows inherit the Makefile default for build/push/manifest/promote steps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3cb166b68edd2ff9c287df273b1b7c12e6fd4259. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->