### PR TITLE
ci: use shared dockerhub-login action for Docker Hub auth

### DIFF
--- a/.github/workflows/publish_dev_images.yml
+++ b/.github/workflows/publish_dev_images.yml
@@ -46,17 +46,8 @@ jobs:
       - uses: actions/setup-dotnet@131b410979e0b49e2162c0718030257b22d6dc2c
         if: matrix.arch == 'aarch64'
       - run: make docker/build
-      - uses: grafana/shared-workflows/actions/get-vault-secrets@e7a3275d4c4978a3514801ec55708f1c599a6906
-        if: github.repository_owner == 'grafana'
-        with:
-          repo_secrets: |
-            DOCKERHUB_USERNAME=dockerhub:user
-            DOCKERHUB_PASSWORD=dockerhub:token
-      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
-        name: Login to Docker Hub
-        with:
-          username: ${{ env.DOCKERHUB_USERNAME || secrets.DOCKERHUB_USERNAME }}
-          password: ${{ env.DOCKERHUB_PASSWORD || secrets.DOCKERHUB_PASSWORD }}
+      - name: Login to DockerHub (from vault)
+        uses: grafana/shared-workflows/actions/dockerhub-login@081a366728379fd0426b9cfef190e9a21c2d5418 # dockerhub-login/v1.0.3
       - run: make docker/push
   publish-dev-manifest:
     permissions:
@@ -79,15 +70,6 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           submodules: 'true'
           persist-credentials: false
-      - uses: grafana/shared-workflows/actions/get-vault-secrets@e7a3275d4c4978a3514801ec55708f1c599a6906
-        if: github.repository_owner == 'grafana'
-        with:
-          repo_secrets: |
-            DOCKERHUB_USERNAME=dockerhub:user
-            DOCKERHUB_PASSWORD=dockerhub:token
-      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
-        name: Login to Docker Hub
-        with:
-          username: ${{ env.DOCKERHUB_USERNAME || secrets.DOCKERHUB_USERNAME }}
-          password: ${{ env.DOCKERHUB_PASSWORD || secrets.DOCKERHUB_PASSWORD }}
+      - name: Login to DockerHub (from vault)
+        uses: grafana/shared-workflows/actions/dockerhub-login@081a366728379fd0426b9cfef190e9a21c2d5418 # dockerhub-login/v1.0.3
       - run: make docker/manifest

--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -77,17 +77,8 @@ jobs:
           ref: ${{ github.event.pull_request.merge_commit_sha || github.sha }}
           submodules: 'true'
           persist-credentials: false
-      - uses: grafana/shared-workflows/actions/get-vault-secrets@e7a3275d4c4978a3514801ec55708f1c599a6906
-        if: github.repository_owner == 'grafana'
-        with:
-          repo_secrets: |
-            DOCKERHUB_USERNAME=dockerhub:user
-            DOCKERHUB_PASSWORD=dockerhub:token
-      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
-        name: Login to Docker Hub
-        with:
-          username: ${{ env.DOCKERHUB_USERNAME || secrets.DOCKERHUB_USERNAME }} # secrets used on forks
-          password: ${{ env.DOCKERHUB_PASSWORD || secrets.DOCKERHUB_PASSWORD }} # secrets used on forks
+      - name: Login to DockerHub (from vault)
+        uses: grafana/shared-workflows/actions/dockerhub-login@081a366728379fd0426b9cfef190e9a21c2d5418 # dockerhub-login/v1.0.3
       - name: Build, push, and upload artifacts
         run: |
           make docker/build
@@ -115,17 +106,8 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.merge_commit_sha || github.sha }}
           persist-credentials: false
-      - uses: grafana/shared-workflows/actions/get-vault-secrets@e7a3275d4c4978a3514801ec55708f1c599a6906
-        if: github.repository_owner == 'grafana'
-        with:
-          repo_secrets: |
-            DOCKERHUB_USERNAME=dockerhub:user
-            DOCKERHUB_PASSWORD=dockerhub:token
-      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
-        name: Login to Docker Hub
-        with:
-          username: ${{ env.DOCKERHUB_USERNAME || secrets.DOCKERHUB_USERNAME }} # secrets used on forks
-          password: ${{ env.DOCKERHUB_PASSWORD || secrets.DOCKERHUB_PASSWORD }} # secrets used on forks
+      - name: Login to DockerHub (from vault)
+        uses: grafana/shared-workflows/actions/dockerhub-login@081a366728379fd0426b9cfef190e9a21c2d5418 # dockerhub-login/v1.0.3
       - run: make docker/manifest
 
   build-managed-helper:

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -17,17 +17,8 @@ jobs:
       matrix:
         libc: ['glibc', 'musl']
     steps:
-      - uses: grafana/shared-workflows/actions/get-vault-secrets@e7a3275d4c4978a3514801ec55708f1c599a6906
-        if: github.repository_owner == 'grafana'
-        with:
-          repo_secrets: |
-            DOCKERHUB_USERNAME=dockerhub:user
-            DOCKERHUB_PASSWORD=dockerhub:token
-      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
-        name: Login to Docker Hub
-        with:
-          username: ${{ env.DOCKERHUB_USERNAME || secrets.DOCKERHUB_USERNAME }} # secrets used on forks
-          password: ${{ env.DOCKERHUB_PASSWORD || secrets.DOCKERHUB_PASSWORD }} # secrets used on forks
+      - name: Login to DockerHub (from vault)
+        uses: grafana/shared-workflows/actions/dockerhub-login@081a366728379fd0426b9cfef190e9a21c2d5418 # dockerhub-login/v1.0.3
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Promote draft Docker tags
         run: RELEASE_VERSION=$(.github/scripts/version.sh) make docker/promote


### PR DESCRIPTION
## Summary
- Replaces the hand-rolled `get-vault-secrets` + `docker/login-action` pair with `grafana/shared-workflows/actions/dockerhub-login` across `publish_dev_images.yml`, `release-draft.yml`, and `release-publish.yml`.
- Switches to the canonical `ci/common/dockerhub` vault path (matches the [DockerHub runbook](https://github.com/grafana/deployment_tools/blob/master/docs/platform/runbooks/dockerhub.md)) — the composite uses `common_secrets` internally with the bare `dockerhub:username|password` keys.
- Pinned at the same SHA used by `grafana/alloy` (`dockerhub-login/v1.0.3`).
- Drops the `secrets.DOCKERHUB_USERNAME` fork fallback; these workflows are already gated to the grafana org and forks don't realistically publish images here.

## Test plan
- [ ] Merge a labeled PR (or push to main) and confirm `Publish dev Docker images` logs in via vault and pushes successfully.
- [ ] On the next release, confirm `release-draft` and `release-publish` jobs authenticate and push/promote tags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Docker publishing authentication in multiple workflows; a misconfiguration or action change would break dev image pushes and release/promote jobs, but it’s a scoped CI-only change.
> 
> **Overview**
> Standardizes Docker Hub authentication across CI workflows by replacing the `get-vault-secrets` + `docker/login-action` steps with the shared `grafana/shared-workflows/actions/dockerhub-login` action (pinned to `dockerhub-login/v1.0.3`).
> 
> This update is applied to dev image publishing (`publish_dev_images.yml`) and release flows (`release-draft.yml`, `release-publish.yml`), removing the explicit Docker Hub username/password wiring (including the fork `secrets.*` fallback) in favor of the shared action’s vault-based login.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51b9693919f9b6b927430d73585a748b12709002. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->