### PR TITLE
chore(renovate): vulnerabilities-only with openssl allowlist

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,28 +1,33 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended"],
+  "extends": [
+    "security:only-security-updates"
+  ],
   "packageRules": [
     {
-      "matchManagers": ["dockerfile"],
-      "matchUpdateTypes": ["major", "minor"],
-      "enabled": false
+      "description": "Always update openssl/openssl to latest. Overrides the wildcard enabled:false from security:only-security-updates.",
+      "matchPackageNames": ["openssl/openssl"],
+      "enabled": true
     },
     {
-      "matchDepNames": ["openssl/openssl"],
+      "description": "Split openssl/openssl patch updates into their own stream so they survive when minor/major are disabled below.",
+      "matchPackageNames": ["openssl/openssl"],
       "separateMinorPatch": true
     },
     {
-      "matchDepNames": ["openssl/openssl"],
+      "description": "Restrict openssl/openssl to patch-level updates only. Vulnerability alerts still bypass this and can produce minor/major bumps when needed for CVE fixes.",
+      "matchPackageNames": ["openssl/openssl"],
       "matchUpdateTypes": ["major", "minor"],
       "enabled": false
     }
   ],
   "customManagers": [
     {
+      "description": "Track the OpenSSL C library version pinned via ARG OPENSSL_VERSION in the Pyroscope Dockerfiles, resolved against openssl/openssl GitHub releases.",
       "customType": "regex",
       "managerFilePatterns": [
-        "/^Pyroscope\.Dockerfile$/",
-        "/^Pyroscope\.musl\.Dockerfile$/"
+        "/^Pyroscope\\.Dockerfile$/",
+        "/^Pyroscope\\.musl\\.Dockerfile$/"
       ],
       "matchStrings": ["ARG OPENSSL_VERSION=(?<currentValue>[\\d.]+)"],
       "depNameTemplate": "openssl/openssl",


### PR DESCRIPTION
Switches renovate to extend the built-in `security:only-security-updates` preset, then adds an explicit allowlist for `openssl/openssl` so it remains the only dep that gets routine update PRs; everything else (debian/busybox base images, dotnet monorepo, github-actions, etc.) only gets a PR in response to an OSV or GHSA advisory. The existing custom regex manager that pins the OpenSSL C library via `ARG OPENSSL_VERSION` in `Pyroscope.Dockerfile` and `Pyroscope.musl.Dockerfile` is preserved, and `openssl/openssl` is restricted to patch-level updates only (vulnerability alerts can still pull in minor/major bumps when needed for a CVE fix).

Mirrors grafana/pyroscope-ruby#71. The Ruby allowlist also kept `pyroscope`, `rbspy`, and `remoteprocess`; this fork has no equivalent third-party profiling-runtime dependency, since the profiler is built from C++ sources and submodules in-tree, so the allowlist reduces to `openssl/openssl` alone.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low code risk since this only changes Renovate configuration, but it will materially reduce routine dependency update PRs and could affect how/when OpenSSL updates are proposed.
> 
> **Overview**
> Renovate is reconfigured to use the `security:only-security-updates` preset so dependency update PRs are generally created only in response to security advisories.
> 
> Adds explicit `packageRules` to keep `openssl/openssl` updating routinely (with patch updates separated and minor/major updates disabled unless required by a vulnerability), and tightens the custom regex manager patterns for tracking `ARG OPENSSL_VERSION` in `Pyroscope.Dockerfile` and `Pyroscope.musl.Dockerfile`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit afac5876f370fe7bf26c9c12f8291c8ab5137e5c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->