### PR TITLE
Use unique_ptr for IUnwinder ownership in TimerCreateCpuProfiler

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/TimerCreateCpuProfiler.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/TimerCreateCpuProfiler.cpp
@@ -25,14 +25,14 @@ TimerCreateCpuProfiler::TimerCreateCpuProfiler(
     IManagedThreadList* pManagedThreadsList,
     CpuSampleProvider* pProvider,
     MetricsRegistry& metricsRegistry,
-    IUnwinder* pUnwinder) noexcept
+    std::unique_ptr<IUnwinder> pUnwinder) noexcept
     :
     _pSignalManager{pSignalManager}, // put it as parameter for better testing
     _pManagedThreadsList{pManagedThreadsList},
     _pProvider{pProvider},
     _samplingInterval{pConfiguration->GetCpuProfilingInterval()},
     _nbThreadsInSignalHandler{0},
-    _pUnwinder{pUnwinder}
+    _pUnwinder{std::move(pUnwinder)}
 {
     Log::Info("Cpu profiling interval: ", _samplingInterval.count(), "ms");
     Log::Info("timer_create Cpu profiler is enabled");

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/TimerCreateCpuProfiler.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/TimerCreateCpuProfiler.h
@@ -33,7 +33,7 @@ public:
         IManagedThreadList* pManagedThreadsList,
         CpuSampleProvider* pProvider,
         MetricsRegistry& metricsRegistry,
-        IUnwinder* pUnwinder) noexcept;
+        std::unique_ptr<IUnwinder> pUnwinder) noexcept;
 
     ~TimerCreateCpuProfiler();
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.cpp
@@ -637,7 +637,7 @@ void CorProfilerCallback::InitializeServices()
 #ifdef LINUX
     if (_pConfiguration->IsCpuProfilingEnabled() && _pConfiguration->GetCpuProfilerType() == CpuProfilerType::TimerCreate)
     {
-        _pUnwinder = std::make_unique<Backtrace2Unwinder>();
+        auto pUnwinder = std::make_unique<Backtrace2Unwinder>();
         // Other alternative in case of crash-at-shutdown, do not register it as a service
         // we will have to start it by hand (already stopped by hand)
         _pCpuProfiler = std::make_unique<TimerCreateCpuProfiler>(
@@ -646,7 +646,7 @@ void CorProfilerCallback::InitializeServices()
             _pManagedThreadList,
             _pCpuSampleProvider,
             _metricsRegistry,
-            std::move(_pUnwinder));
+            std::move(pUnwinder));
     }
 #endif
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.cpp
@@ -646,7 +646,7 @@ void CorProfilerCallback::InitializeServices()
             _pManagedThreadList,
             _pCpuSampleProvider,
             _metricsRegistry,
-            _pUnwinder.get());
+            std::move(_pUnwinder));
     }
 #endif
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.h
@@ -42,7 +42,6 @@
 #endif
 #include "IEtwEventsManager.h"
 #include "ISsiLifetime.h"
-#include "IUnwinder.h"
 #include "HeapSnapshotManager.h"
 #include "GCThreadsCpuProvider.h"
 #include "PInvoke.h"
@@ -276,7 +275,6 @@ private :
 #ifdef LINUX
     SystemCallsShield* _systemCallsShield = nullptr;
     std::unique_ptr<TimerCreateCpuProfiler> _pCpuProfiler = nullptr;
-    std::unique_ptr<IUnwinder> _pUnwinder = nullptr;
     CpuSampleProvider* _pCpuSampleProvider = nullptr;
     std::unique_ptr<RingBuffer> _pCpuProfilerRb = nullptr;
 #endif


### PR DESCRIPTION
## Summary
Refactor the `TimerCreateCpuProfiler` to take ownership of the `IUnwinder` instance via `std::unique_ptr` instead of a raw pointer, improving memory safety and clarifying ownership semantics.

## Key Changes
- Changed `TimerCreateCpuProfiler` constructor parameter from `IUnwinder*` to `std::unique_ptr<IUnwinder>` in both header and implementation
- Updated the member variable initialization to use `std::move()` for the unique_ptr parameter
- Removed the separate `_pUnwinder` member variable from `CorProfilerCallback` class, as ownership is now transferred to `TimerCreateCpuProfiler`
- Updated `CorProfilerCallback::InitializeServices()` to create a local `unique_ptr` and move it to the profiler instead of storing it as a class member
- Removed the now-unnecessary `#include "IUnwinder.h"` from `CorProfilerCallback.h`

## Implementation Details
This change makes the ownership model explicit: `TimerCreateCpuProfiler` now owns the unwinder's lifetime rather than relying on external management. The unwinder is created in `CorProfilerCallback::InitializeServices()` and immediately transferred to the profiler via move semantics, eliminating the need for the callback class to maintain a reference to it.

https://claude.ai/code/session_01AinnkGTwDAsyFNorcYC9h8