### PR TITLE
fix(ci): authenticate nuget.org publish via Trusted Publishing

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -92,8 +92,13 @@ jobs:
         working-directory: Pyroscope
       - name: Upload artifacts to draft release
         run: gh release upload --clobber "$TAG" ./Pyroscope/artifacts/bin/Pyroscope/release/Pyroscope.dll ./Pyroscope/artifacts/package/release/Pyroscope*.nupkg
+      - name: NuGet login
+        id: nuget-login
+        uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # v1.2.0
+        with:
+          user: Pyroscope
       - name: Publish to nuget.org
-        run: dotnet nuget push ./Pyroscope/artifacts/package/release/Pyroscope*.nupkg -s https://api.nuget.org/v3/index.json
+        run: dotnet nuget push ./Pyroscope/artifacts/package/release/Pyroscope*.nupkg -k "${{ steps.nuget-login.outputs.NUGET_API_KEY }}" -s https://api.nuget.org/v3/index.json
 
   publish-pyroscope-release:
     permissions:
@@ -133,8 +138,13 @@ jobs:
           gh release upload --clobber "$TAG" \
             ./Pyroscope/artifacts/bin/Pyroscope.OpenTracing/release/Pyroscope.OpenTracing.dll \
             ./Pyroscope/artifacts/package/release/Pyroscope.OpenTracing*.nupkg
+      - name: NuGet login
+        id: nuget-login
+        uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # v1.2.0
+        with:
+          user: Pyroscope
       - name: Publish to nuget.org
-        run: dotnet nuget push ./Pyroscope/artifacts/package/release/Pyroscope.OpenTracing*.nupkg -s https://api.nuget.org/v3/index.json
+        run: dotnet nuget push ./Pyroscope/artifacts/package/release/Pyroscope.OpenTracing*.nupkg -k "${{ steps.nuget-login.outputs.NUGET_API_KEY }}" -s https://api.nuget.org/v3/index.json
       - name: Publish GitHub release
         run: gh release edit "$TAG" --draft=false
 
@@ -164,7 +174,12 @@ jobs:
           gh release upload --clobber "$TAG" \
             ./Pyroscope/artifacts/bin/Pyroscope.OpenTelemetry/release/Pyroscope.OpenTelemetry.dll \
             ./Pyroscope/artifacts/package/release/Pyroscope.OpenTelemetry*.nupkg
+      - name: NuGet login
+        id: nuget-login
+        uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # v1.2.0
+        with:
+          user: Pyroscope
       - name: Publish to nuget.org
-        run: dotnet nuget push ./Pyroscope/artifacts/package/release/Pyroscope.OpenTelemetry*.nupkg -s https://api.nuget.org/v3/index.json
+        run: dotnet nuget push ./Pyroscope/artifacts/package/release/Pyroscope.OpenTelemetry*.nupkg -k "${{ steps.nuget-login.outputs.NUGET_API_KEY }}" -s https://api.nuget.org/v3/index.json
       - name: Publish GitHub release
         run: gh release edit "$TAG" --draft=false


### PR DESCRIPTION
## Problem

The `release-please` workflow's three "Publish to nuget.org" steps run `dotnet nuget push` **without any API key**, so they fail with a 401:

```
Unauthorized https://www.nuget.org/api/v2/package/
error: Response status code does not indicate success: 401
(An API key must be provided in the 'X-NuGet-ApiKey' header to use this service).
```

Example failed run: https://github.com/grafana/pyroscope-dotnet/actions/runs/26861307221/job/79215587249

This regressed in #325, which dropped the old secret-fetch + `-k "${NUGET_API_KEY}"` flag when migrating to release-please.

## Fix

A Trusted Publishing policy is now configured on nuget.org for this workflow (publisher GitHubActions, owner grafana, repo pyroscope-dotnet, workflow `release-please.yml`). This adds a `NuGet/login` step to each of the three publish jobs (`build-managed-helper`, `build-opentracing`, `build-opentelemetry`) that exchanges the workflow's OIDC token for a short-lived API key, and passes it to `dotnet nuget push`. No long-lived secret needed.

All three jobs already had `id-token: write`, so OIDC works as-is. The action SHA (`NuGet/login@8d196754... # v1.2.0`) matches what Polly and ReactiveUI pin to.

## Note

1.0.0 already shipped its GitHub release before this fix, so it never landed on nuget.org -- it will need a manual push separately. This fix covers all future releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)