### PR TITLE
Revert "chore(main): release pyroscope 1.0.0 (#326)"

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  ".": "1.0.0",
+  ".": "0.15.0",
   "Pyroscope/Pyroscope.OpenTracing": "0.4.0",
   "Pyroscope/Pyroscope.OpenTelemetry": "0.4.0"
 }

--- a/Pyroscope/Pyroscope/Pyroscope.csproj
+++ b/Pyroscope/Pyroscope/Pyroscope.csproj
@@ -2,9 +2,9 @@
 
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
-        <PackageVersion>1.0.0</PackageVersion>
-        <AssemblyVersion>1.0.0</AssemblyVersion>
-        <FileVersion>1.0.0</FileVersion>
+        <PackageVersion>0.15.0</PackageVersion>
+        <AssemblyVersion>0.15.0</AssemblyVersion>
+        <FileVersion>0.15.0</FileVersion>
         <PackageReadmeFile>README.md</PackageReadmeFile>
     </PropertyGroup>
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/PyroscopePprofSink.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/PyroscopePprofSink.h
@@ -10,7 +10,7 @@
 #include "httplib.h"
 #include "url.hpp"
 
-#define PYROSCOPE_SPY_VERSION "1.0.0" // x-release-please-version
+#define PYROSCOPE_SPY_VERSION "0.15.0" // x-release-please-version
 
 class PyroscopePprofSink : public PProfExportSink
 {


### PR DESCRIPTION
This reverts commit 447512a1b8a6caa88d1dd170f3d47cc921f7b2a8.

Otherwise release-please wants to release 2.0.0 instead of 1.0.0