### PR TITLE
fix(tracing): trigger release of OpenTracing and OpenTelemetry packages

### DIFF
--- a/Pyroscope/Pyroscope.OpenTelemetry/PyroscopeSpanProcessor.cs
+++ b/Pyroscope/Pyroscope.OpenTelemetry/PyroscopeSpanProcessor.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics;
+﻿// No-op change to trigger a release of the Pyroscope.OpenTelemetry package.
+using System.Diagnostics;
 using OpenTelemetry;
 
 namespace Pyroscope.OpenTelemetry;

--- a/Pyroscope/Pyroscope.OpenTracing/PyroscopeTracer.cs
+++ b/Pyroscope/Pyroscope.OpenTracing/PyroscopeTracer.cs
@@ -1,3 +1,4 @@
+// No-op change to trigger a release of the Pyroscope.OpenTracing package.
 using OpenTracing;
 using OpenTracing.Propagation;
 


### PR DESCRIPTION
## Why

release-please did not open release PRs for the `pyroscope-opentracing` and `pyroscope-opentelemetry` packages because there were no releasable (`fix:`/`feat:`) commits touching their paths since their `opentracing-0.4.0` / `opentelemetry-0.4.0` tags.

## What

A no-op change to each package's source so release-please opens patch release PRs (0.4.0 -> 0.4.1) for both:

- `Pyroscope/Pyroscope.OpenTracing/PyroscopeTracer.cs`
- `Pyroscope/Pyroscope.OpenTelemetry/PyroscopeSpanProcessor.cs`

Committed as `fix:` so it triggers a patch bump under the `release-type: simple` config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)