### PR TITLE
fix(ci): use package-relative paths in release-please tracing extra-files

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -56,17 +56,17 @@
       "extra-files": [
         {
           "type": "xml",
-          "path": "Pyroscope/Pyroscope.OpenTracing/Pyroscope.OpenTracing.csproj",
+          "path": "Pyroscope.OpenTracing.csproj",
           "xpath": "//PackageVersion"
         },
         {
           "type": "xml",
-          "path": "Pyroscope/Pyroscope.OpenTracing/Pyroscope.OpenTracing.csproj",
+          "path": "Pyroscope.OpenTracing.csproj",
           "xpath": "//AssemblyVersion"
         },
         {
           "type": "xml",
-          "path": "Pyroscope/Pyroscope.OpenTracing/Pyroscope.OpenTracing.csproj",
+          "path": "Pyroscope.OpenTracing.csproj",
           "xpath": "//FileVersion"
         }
       ]
@@ -80,17 +80,17 @@
       "extra-files": [
         {
           "type": "xml",
-          "path": "Pyroscope/Pyroscope.OpenTelemetry/Pyroscope.OpenTelemetry.csproj",
+          "path": "Pyroscope.OpenTelemetry.csproj",
           "xpath": "//PackageVersion"
         },
         {
           "type": "xml",
-          "path": "Pyroscope/Pyroscope.OpenTelemetry/Pyroscope.OpenTelemetry.csproj",
+          "path": "Pyroscope.OpenTelemetry.csproj",
           "xpath": "//AssemblyVersion"
         },
         {
           "type": "xml",
-          "path": "Pyroscope/Pyroscope.OpenTelemetry/Pyroscope.OpenTelemetry.csproj",
+          "path": "Pyroscope.OpenTelemetry.csproj",
           "xpath": "//FileVersion"
         }
       ]


### PR DESCRIPTION
## Summary

- Fix `extra-files` paths for `Pyroscope.OpenTracing` and `Pyroscope.OpenTelemetry` in `release-please-config.json`.
- Release-please resolves `extra-files` relative to each package path for non-root packages; repo-root csproj paths were joined incorrectly (e.g. `Pyroscope/Pyroscope.OpenTelemetry/Pyroscope/Pyroscope.OpenTelemetry/...`), so tracing release PRs (#333, #334) only bumped `.release-please-manifest.json` and not the `.csproj` versions.

## Test plan

- [ ] Merge this PR
- [ ] After the next release-please run, verify open tracing release PRs (#333, #334) are updated to also bump `PackageVersion`, `AssemblyVersion`, and `FileVersion` in the respective `.csproj` files
- [ ] Do not merge #333 / #334 until those csproj bumps appear