### PR TITLE
chore: target Pyroscope tracing packages at net8.0

### DIFF
--- a/Pyroscope/Pyroscope.OpenTelemetry/Pyroscope.OpenTelemetry.csproj
+++ b/Pyroscope/Pyroscope.OpenTelemetry/Pyroscope.OpenTelemetry.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <PackageVersion>0.4.0</PackageVersion>
     <AssemblyVersion>0.4.0</AssemblyVersion>
     <FileVersion>0.4.0</FileVersion>

--- a/Pyroscope/Pyroscope.OpenTracing/Pyroscope.OpenTracing.csproj
+++ b/Pyroscope/Pyroscope.OpenTracing/Pyroscope.OpenTracing.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <PackageVersion>0.4.1</PackageVersion>
     <AssemblyVersion>0.4.1</AssemblyVersion>
     <FileVersion>0.4.1</FileVersion>

--- a/Pyroscope/Pyroscope/Pyroscope.csproj
+++ b/Pyroscope/Pyroscope/Pyroscope.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <PackageVersion>1.0.0</PackageVersion>
         <AssemblyVersion>1.0.0</AssemblyVersion>
         <FileVersion>1.0.0</FileVersion>


### PR DESCRIPTION
## Summary
- Bump `TargetFramework` from `net6.0` to `net8.0` for the three Pyroscope NuGet projects: `Pyroscope`, `Pyroscope.OpenTracing`, and `Pyroscope.OpenTelemetry`.
- .NET 6 is out of support; this aligns published tracing packages with a supported LTS runtime.

## Test plan
- [ ] CI: `Build OpenTelemetry and OpenTracing libraries` workflow passes
- [ ] `dotnet build -c Release` succeeds for each project under `Pyroscope/`