### PR TITLE
chore: add pyroscope-dotnet-maintainers to CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @grafana/pyroscope-dotnet @grafana/pyroscope-team
+* @grafana/pyroscope-dotnet @grafana/pyroscope-dotnet-maintainers @grafana/pyroscope-team


### PR DESCRIPTION
## Summary
- Add `@grafana/pyroscope-dotnet-maintainers` to `CODEOWNERS` so the maintainers team is requested on all PRs.

## Test plan
- [ ] Verify the `pyroscope-dotnet-maintainers` team exists in the Grafana org and has appropriate members
- [ ] Confirm GitHub requests review from the new team on a test PR