### PR TITLE
fix: use-after-free in  dynamic tag key storage

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/JavaProfilerTags.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/JavaProfilerTags.cpp
@@ -154,6 +154,7 @@ bool Tags::Init() {
     }
     empty_async_string = new AsyncRefCountedString();
     keys = new std::vector<std::string>();
+    keys->reserve(kMaxNumTags);
     key_to_id = new std::unordered_map<std::string, int32_t>();
     empty_tags = new Tags();
   }


### PR DESCRIPTION
## Summary
- Reserve the global dynamic tag key vector to `kMaxNumTags` during initialization.
- Prevent `std::string_view` label keys captured in samples from dangling after later dynamic tag key registrations trigger vector growth.

## Test plan
- `git diff --check`