### PR TITLE
feat(tracing): unify OpenTracing and OpenTelemetry into a single release

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -145,8 +145,11 @@ jobs:
         with:
           user: Pyroscope
       - name: Publish to nuget.org
+        env:
+          API_KEY: ${{ steps.nuget-login.outputs.NUGET_API_KEY }}
+          SOURCE: 'https://api.nuget.org/v3/index.json'
         run: |
-          dotnet nuget push ./Pyroscope/artifacts/package/release/Pyroscope.OpenTracing*.nupkg -k "${{ steps.nuget-login.outputs.NUGET_API_KEY }}" -s https://api.nuget.org/v3/index.json
-          dotnet nuget push ./Pyroscope/artifacts/package/release/Pyroscope.OpenTelemetry*.nupkg -k "${{ steps.nuget-login.outputs.NUGET_API_KEY }}" -s https://api.nuget.org/v3/index.json
+          dotnet nuget push "./Pyroscope/artifacts/package/release/Pyroscope.OpenTracing*.nupkg" -k "${API_KEY}" -s "${SOURCE}"
+          dotnet nuget push "./Pyroscope/artifacts/package/release/Pyroscope.OpenTelemetry*.nupkg" -k "${API_KEY}" -s "${SOURCE}"
       - name: Publish GitHub release
         run: gh release edit "$TAG" --draft=false

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,12 +16,9 @@ jobs:
       pyroscope_version: ${{ steps.release.outputs.version }}
       pyroscope_tag_name: ${{ steps.release.outputs.tag_name }}
       pyroscope_sha: ${{ steps.release.outputs.sha }}
-      opentracing_release_created: ${{ steps.release.outputs['Pyroscope/Pyroscope.OpenTracing--release_created'] }}
-      opentracing_tag_name: ${{ steps.release.outputs['Pyroscope/Pyroscope.OpenTracing--tag_name'] }}
-      opentracing_sha: ${{ steps.release.outputs['Pyroscope/Pyroscope.OpenTracing--sha'] }}
-      opentelemetry_release_created: ${{ steps.release.outputs['Pyroscope/Pyroscope.OpenTelemetry--release_created'] }}
-      opentelemetry_tag_name: ${{ steps.release.outputs['Pyroscope/Pyroscope.OpenTelemetry--tag_name'] }}
-      opentelemetry_sha: ${{ steps.release.outputs['Pyroscope/Pyroscope.OpenTelemetry--sha'] }}
+      tracing_release_created: ${{ steps.release.outputs['Pyroscope--release_created'] }}
+      tracing_tag_name: ${{ steps.release.outputs['Pyroscope--tag_name'] }}
+      tracing_sha: ${{ steps.release.outputs['Pyroscope--sha'] }}
     steps:
       - id: get-github-app-token
         uses: grafana/shared-workflows/actions/create-github-app-token@580590a644e82e79bb2598bdaba0be245a14dda0 # create-github-app-token/v0.2.2
@@ -112,67 +109,35 @@ jobs:
       - name: Publish GitHub release
         run: gh release edit "${{ needs.release-please.outputs.pyroscope_tag_name }}" --draft=false --repo "${{ github.repository }}"
 
-  build-opentracing:
+  build-tracing:
     permissions:
       contents: write
       id-token: write
     needs: release-please
-    if: ${{ needs.release-please.outputs.opentracing_release_created == 'true' }}
+    if: ${{ needs.release-please.outputs.tracing_release_created == 'true' }}
     runs-on: ${{ github.repository_owner == 'grafana' && 'ubuntu-x64-small' || 'ubuntu-latest' }}
     env:
       GH_TOKEN: ${{ github.token }}
-      TAG: ${{ needs.release-please.outputs.opentracing_tag_name }}
+      TAG: ${{ needs.release-please.outputs.tracing_tag_name }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          ref: ${{ needs.release-please.outputs.opentracing_sha }}
+          ref: ${{ needs.release-please.outputs.tracing_sha }}
           persist-credentials: false
       - uses: actions/setup-dotnet@131b410979e0b49e2162c0718030257b22d6dc2c
         with:
           global-json-file: global.json
       - run: dotnet build -c Release
         working-directory: Pyroscope/Pyroscope.OpenTracing
-      - name: Upload artifacts to draft release
-        run: |
-          gh release upload --clobber "$TAG" \
-            ./Pyroscope/artifacts/bin/Pyroscope.OpenTracing/release/Pyroscope.OpenTracing.dll \
-            ./Pyroscope/artifacts/package/release/Pyroscope.OpenTracing*.nupkg
-      - name: NuGet login
-        id: nuget-login
-        uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # v1.2.0
-        with:
-          user: Pyroscope
-      - name: Publish to nuget.org
-        run: dotnet nuget push ./Pyroscope/artifacts/package/release/Pyroscope.OpenTracing*.nupkg -k "${{ steps.nuget-login.outputs.NUGET_API_KEY }}" -s https://api.nuget.org/v3/index.json
-      - name: Publish GitHub release
-        run: gh release edit "$TAG" --draft=false
-
-  build-opentelemetry:
-    permissions:
-      contents: write
-      id-token: write
-    needs: release-please
-    if: ${{ needs.release-please.outputs.opentelemetry_release_created == 'true' }}
-    runs-on: ${{ github.repository_owner == 'grafana' && 'ubuntu-x64-small' || 'ubuntu-latest' }}
-    env:
-      GH_TOKEN: ${{ github.token }}
-      TAG: ${{ needs.release-please.outputs.opentelemetry_tag_name }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          ref: ${{ needs.release-please.outputs.opentelemetry_sha }}
-          persist-credentials: false
-      - uses: actions/setup-dotnet@131b410979e0b49e2162c0718030257b22d6dc2c
-        with:
-          global-json-file: global.json
       - run: dotnet build -c Release
         working-directory: Pyroscope/Pyroscope.OpenTelemetry
       - name: Upload artifacts to draft release
         run: |
           gh release upload --clobber "$TAG" \
+            ./Pyroscope/artifacts/bin/Pyroscope.OpenTracing/release/Pyroscope.OpenTracing.dll \
             ./Pyroscope/artifacts/bin/Pyroscope.OpenTelemetry/release/Pyroscope.OpenTelemetry.dll \
+            ./Pyroscope/artifacts/package/release/Pyroscope.OpenTracing*.nupkg \
             ./Pyroscope/artifacts/package/release/Pyroscope.OpenTelemetry*.nupkg
       - name: NuGet login
         id: nuget-login
@@ -180,6 +145,8 @@ jobs:
         with:
           user: Pyroscope
       - name: Publish to nuget.org
-        run: dotnet nuget push ./Pyroscope/artifacts/package/release/Pyroscope.OpenTelemetry*.nupkg -k "${{ steps.nuget-login.outputs.NUGET_API_KEY }}" -s https://api.nuget.org/v3/index.json
+        run: |
+          dotnet nuget push ./Pyroscope/artifacts/package/release/Pyroscope.OpenTracing*.nupkg -k "${{ steps.nuget-login.outputs.NUGET_API_KEY }}" -s https://api.nuget.org/v3/index.json
+          dotnet nuget push ./Pyroscope/artifacts/package/release/Pyroscope.OpenTelemetry*.nupkg -k "${{ steps.nuget-login.outputs.NUGET_API_KEY }}" -s https://api.nuget.org/v3/index.json
       - name: Publish GitHub release
         run: gh release edit "$TAG" --draft=false

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,4 @@
 {
   ".": "1.0.0",
-  "Pyroscope/Pyroscope.OpenTracing": "0.4.1",
-  "Pyroscope/Pyroscope.OpenTelemetry": "0.4.0"
+  "Pyroscope": "0.4.1"
 }

--- a/Pyroscope/Pyroscope.OpenTelemetry/Pyroscope.OpenTelemetry.csproj
+++ b/Pyroscope/Pyroscope.OpenTelemetry/Pyroscope.OpenTelemetry.csproj
@@ -2,9 +2,9 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <PackageVersion>0.4.0</PackageVersion>
-    <AssemblyVersion>0.4.0</AssemblyVersion>
-    <FileVersion>0.4.0</FileVersion>
+    <PackageVersion>0.4.2</PackageVersion>
+    <AssemblyVersion>0.4.2</AssemblyVersion>
+    <FileVersion>0.4.2</FileVersion>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageTags>Grafana;OpenTelemetry;Profiles;Pyroscope</PackageTags>
   </PropertyGroup>

--- a/Pyroscope/Pyroscope.OpenTracing/Pyroscope.OpenTracing.csproj
+++ b/Pyroscope/Pyroscope.OpenTracing/Pyroscope.OpenTracing.csproj
@@ -2,9 +2,9 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <PackageVersion>0.4.1</PackageVersion>
-    <AssemblyVersion>0.4.1</AssemblyVersion>
-    <FileVersion>0.4.1</FileVersion>
+    <PackageVersion>0.4.2</PackageVersion>
+    <AssemblyVersion>0.4.2</AssemblyVersion>
+    <FileVersion>0.4.2</FileVersion>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageTags>Grafana;OpenTracing;Profiles;Pyroscope</PackageTags>
   </PropertyGroup>

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -21,10 +21,6 @@
       "package-name": "pyroscope",
       "include-v-in-tag": false,
       "include-component-in-tag": true,
-      "exclude-paths": [
-        "Pyroscope/Pyroscope.OpenTracing",
-        "Pyroscope/Pyroscope.OpenTelemetry"
-      ],
       "extra-files": [
         {
           "type": "xml",
@@ -47,50 +43,44 @@
         }
       ]
     },
-    "Pyroscope/Pyroscope.OpenTracing": {
-      "component": "opentracing",
-      "release-type": "simple",
-      "package-name": "pyroscope-opentracing",
-      "include-v-in-tag": false,
-      "include-component-in-tag": true,
-      "extra-files": [
-        {
-          "type": "xml",
-          "path": "Pyroscope.OpenTracing.csproj",
-          "xpath": "//PackageVersion"
-        },
-        {
-          "type": "xml",
-          "path": "Pyroscope.OpenTracing.csproj",
-          "xpath": "//AssemblyVersion"
-        },
-        {
-          "type": "xml",
-          "path": "Pyroscope.OpenTracing.csproj",
-          "xpath": "//FileVersion"
-        }
-      ]
-    },
-    "Pyroscope/Pyroscope.OpenTelemetry": {
+    "Pyroscope": {
       "component": "opentelemetry",
       "release-type": "simple",
       "package-name": "pyroscope-opentelemetry",
       "include-v-in-tag": false,
       "include-component-in-tag": true,
+      "exclude-paths": [
+        "Pyroscope/Pyroscope"
+      ],
       "extra-files": [
         {
           "type": "xml",
-          "path": "Pyroscope.OpenTelemetry.csproj",
+          "path": "Pyroscope.OpenTracing/Pyroscope.OpenTracing.csproj",
           "xpath": "//PackageVersion"
         },
         {
           "type": "xml",
-          "path": "Pyroscope.OpenTelemetry.csproj",
+          "path": "Pyroscope.OpenTracing/Pyroscope.OpenTracing.csproj",
           "xpath": "//AssemblyVersion"
         },
         {
           "type": "xml",
-          "path": "Pyroscope.OpenTelemetry.csproj",
+          "path": "Pyroscope.OpenTracing/Pyroscope.OpenTracing.csproj",
+          "xpath": "//FileVersion"
+        },
+        {
+          "type": "xml",
+          "path": "Pyroscope.OpenTelemetry/Pyroscope.OpenTelemetry.csproj",
+          "xpath": "//PackageVersion"
+        },
+        {
+          "type": "xml",
+          "path": "Pyroscope.OpenTelemetry/Pyroscope.OpenTelemetry.csproj",
+          "xpath": "//AssemblyVersion"
+        },
+        {
+          "type": "xml",
+          "path": "Pyroscope.OpenTelemetry/Pyroscope.OpenTelemetry.csproj",
           "xpath": "//FileVersion"
         }
       ]


### PR DESCRIPTION
## Summary

release-please currently treats the two tracing packages as **independent components**, each with its own version, tag, release PR, and GitHub release -- so `Pyroscope.OpenTracing` and `Pyroscope.OpenTelemetry` drift in version and ship at different times even though they are companion packages built and published together.

This PR collapses them into a **single release-please component** (`opentelemetry`, tag format `opentelemetry-X.Y.Z`) so both packages share one version, one release PR, one git tag, and one GitHub release, and are published to NuGet together.

## Changes

- **`release-please-config.json`**: replace the two `Pyroscope/Pyroscope.OpenTracing` and `Pyroscope/Pyroscope.OpenTelemetry` package entries with a single `Pyroscope` package. It is rooted at the shared `Pyroscope` parent and excludes `Pyroscope/Pyroscope` (the main managed lib, which stays with the root `.` package). Its `extra-files` bump both csproj files' `PackageVersion`/`AssemblyVersion`/`FileVersion` in lockstep. Removed the now-redundant tracing entries from the root package `exclude-paths`.
- **`.release-please-manifest.json`**: collapse the two tracing keys into a single `"Pyroscope": "0.4.1"` -- the highest version published to NuGet across both packages (`Pyroscope.OpenTracing` is at 0.4.1; `Pyroscope.OpenTelemetry` at 0.4.0).
- **csproj**: bump both tracing projects to `0.4.2`.
- **`.github/workflows/release-please.yml`**: replace the six `opentracing_*`/`opentelemetry_*` job outputs with one `tracing_*` set keyed off `Pyroscope--*`, and merge `build-opentracing` + `build-opentelemetry` into a single `build-tracing` job that builds both projects, uploads both DLLs + nupkgs to the one tag, pushes both to NuGet, and undrafts the release once.

The commit carries a `Release-As: 0.4.2` footer so the first unified release is tagged `opentelemetry-0.4.2`.

## Notes

- Stale **local-only** tags (`opentracing-0.5.0`, `opentelemetry-0.5.0`, `opentracing-0.4.0`, `opentelemetry-0.4.0`) from earlier experiments were never on origin/NuGet and have been cleaned up locally; only `opentracing-0.4.1` remains in the new format.
- The old `opentracing` release-please component is retired; existing `opentracing-*` tags/releases are left untouched.

## Verification

- `release-please-config.json` / `.release-please-manifest.json` parse cleanly; manifest now has only `.` and `Pyroscope` keys.
- Workflow YAML parses; no stale `opentracing_*`/old-path references remain.
- Both projects still build (covered by the existing `build_tracing_packages.yml` CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)