### PR TITLE
fix: avoid double-freeing timer_create unwinder

### DIFF
--- a/Pyroscope.Dockerfile
+++ b/Pyroscope.Dockerfile
@@ -54,7 +54,7 @@ RUN WRAPPER_SO=$(find /profiler/profiler/_build -name "Datadog.Linux.ApiWrapper.
     cd build-${CMAKE_BUILD_TYPE}/profiler && \
     LD_PRELOAD="${WRAPPER_SO}" ctest --output-on-failure -R "WrappedFunctionsTest"
 
-FROM busybox:1.37.0-glibc@sha256:3f9777e7e82e8591542f72b965ec7db7e8b3bdb59692976af1bb9b2850b05a4e
+FROM busybox:1.38.0-glibc@sha256:3ba030337caebbfc2232b22b1e435eb213b28e5844a34942c74555bf904a265a
 COPY --from=build /profiler/profiler/_build/DDProf-Deploy/linux/Pyroscope.Profiler.Native.so /Pyroscope.Profiler.Native.so
 COPY --from=build /profiler/profiler/_build/DDProf-Deploy/linux/Datadog.Linux.ApiWrapper.x64.so /Pyroscope.Linux.ApiWrapper.x64.so
 

--- a/Pyroscope.musl.Dockerfile
+++ b/Pyroscope.musl.Dockerfile
@@ -63,7 +63,7 @@ RUN WRAPPER_SO=$(find /profiler/profiler/_build/DDProf-Deploy/linux-musl -name "
     cd build-${CMAKE_BUILD_TYPE}/profiler && \
     LD_PRELOAD="${WRAPPER_SO}" ctest --output-on-failure -R "WrappedFunctionsTest"
 
-FROM busybox:1.37.0-musl@sha256:19b646668802469d968a05342a601e78da4322a414a7c09b1c9ee25165042138
+FROM busybox:1.38.0-musl@sha256:8635836765b0c4c43970660219739baa58b0883c2e429e4b8918f7dd1519455c
 COPY --from=build /profiler/profiler/_build/DDProf-Deploy/linux-musl/Pyroscope.Profiler.Native.so /Pyroscope.Profiler.Native.so
 COPY --from=build /profiler/profiler/_build/DDProf-Deploy/linux-musl/Datadog.Linux.ApiWrapper.x64.so /Pyroscope.Linux.ApiWrapper.x64.so
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/TimerCreateCpuProfiler.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/TimerCreateCpuProfiler.h
@@ -62,5 +62,5 @@ private:
     std::shared_ptr<CounterMetric> _totalSampling;
     std::shared_ptr<DiscardMetrics> _discardMetrics;
     std::atomic<std::uint64_t> _nbThreadsInSignalHandler;
-    std::unique_ptr<IUnwinder> _pUnwinder;
+    IUnwinder* _pUnwinder;
 };

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.h
@@ -275,8 +275,10 @@ private :
 
 #ifdef LINUX
     SystemCallsShield* _systemCallsShield = nullptr;
-    std::unique_ptr<TimerCreateCpuProfiler> _pCpuProfiler = nullptr;
+    // _pCpuProfiler borrows _pUnwinder. Keep this declaration order so reverse member destruction
+    // destroys the borrower before the unwinder it uses.
     std::unique_ptr<IUnwinder> _pUnwinder = nullptr;
+    std::unique_ptr<TimerCreateCpuProfiler> _pCpuProfiler = nullptr;
     CpuSampleProvider* _pCpuSampleProvider = nullptr;
     std::unique_ptr<RingBuffer> _pCpuProfilerRb = nullptr;
 #endif


### PR DESCRIPTION

- Keep `CorProfilerCallback` as the sole owner of the timer-create unwinder.
- Make `TimerCreateCpuProfiler` store a borrowed `IUnwinder*` instead of creating a second `unique_ptr` owner.
- Document the member declaration order that ensures the borrower is destroyed before the unwinder.
- Bump busybx(unrelated)
