### PR TITLE
Extend integration tests with ASAN and non-ASAN profiler builds

### DIFF
--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -44,7 +44,7 @@ jobs:
         working-directory: integration-test
 
   test:
-    name: integration-test ${{ matrix.test }} ${{ matrix.libc_type }} .NET ${{ matrix.version }}
+    name: integration-test ${{ matrix.test }} ${{ matrix.libc_type }} .NET ${{ matrix.version }} ASAN ${{ matrix.run_asan }}
     needs: discover
     runs-on: ${{ github.repository_owner == 'grafana' && 'ubuntu-x64-large' || 'ubuntu-latest' }}
     strategy:
@@ -53,6 +53,7 @@ jobs:
         test: ${{ fromJSON(needs.discover.outputs.tests) }}
         libc_type: [glibc, musl]
         version: ['8.0', '9.0', '10.0']
+        run_asan: ['OFF', 'ON']
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -67,4 +68,5 @@ jobs:
         env:
           LIBC_TYPE: ${{ matrix.libc_type }}
           DOTNET_VERSION: ${{ matrix.version }}
+          RUN_ASAN: ${{ matrix.run_asan }}
         working-directory: integration-test

--- a/Pyroscope.Dockerfile
+++ b/Pyroscope.Dockerfile
@@ -1,4 +1,6 @@
+ARG LLVM_VERSION=22
 FROM debian:bullseye-20260406@sha256:bf53effcacca31b60ce97dabc67578f37e43075d716dc90804d3da3a80d2996c AS builder
+ARG LLVM_VERSION
 
 RUN apt-get update && apt-get -y install cmake make git curl golang libtool wget perl
 
@@ -13,13 +15,10 @@ RUN wget -q "https://github.com/openssl/openssl/releases/download/openssl-${OPEN
     ln -s /usr/local/openssl/lib64 /usr/local/openssl/lib && \
     cd .. && rm -rf openssl-${OPENSSL_VERSION} openssl-${OPENSSL_VERSION}.tar.gz
 
-RUN apt-get -y install lsb-release wget software-properties-common gnupg
+COPY build/install-llvm.sh /tmp/install-llvm.sh
+RUN sh /tmp/install-llvm.sh "${LLVM_VERSION}" && rm -f /tmp/install-llvm.sh
 
-RUN wget https://apt.llvm.org/llvm.sh && \
-  chmod +x llvm.sh && \
-  ./llvm.sh 18
-
-ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/lib/llvm-18/bin/
+ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/lib/llvm-${LLVM_VERSION}/bin/
 
 FROM builder as build
 
@@ -32,6 +31,7 @@ ADD CMakeLists.txt CMakeLists.txt
 
 # Allow build type to be passed as build arg, default to Release
 ARG CMAKE_BUILD_TYPE=Release
+ARG RUN_ASAN=OFF
 
 RUN mkdir build-${CMAKE_BUILD_TYPE} && \
     cd build-${CMAKE_BUILD_TYPE} && \
@@ -41,6 +41,7 @@ RUN mkdir build-${CMAKE_BUILD_TYPE} && \
         -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} \
         -DCMAKE_CXX_FLAGS_DEBUG="-g -O0" \
         -DCMAKE_C_FLAGS_DEBUG="-g -O0" \
+        -DRUN_ASAN=${RUN_ASAN} \
         -DOPENSSL_ROOT_DIR=/usr/local/openssl
 
 RUN cd build-${CMAKE_BUILD_TYPE} && make -j16 Pyroscope.Profiler.Native Datadog.Linux.ApiWrapper.x64

--- a/Pyroscope.musl.Dockerfile
+++ b/Pyroscope.musl.Dockerfile
@@ -1,7 +1,8 @@
+ARG LLVM_VERSION=22
 FROM alpine:3.18 AS builder
+ARG LLVM_VERSION
 
 RUN apk add \
-            clang \
             cmake \
             git \
             bash \
@@ -16,7 +17,8 @@ RUN apk add \
             perl \
             linux-headers
 
-RUN apk add wget
+COPY build/install-llvm.sh /tmp/install-llvm.sh
+RUN sh /tmp/install-llvm.sh "${LLVM_VERSION}" && rm -f /tmp/install-llvm.sh
 RUN apk add go
 
 # Build OpenSSL from source with static libs
@@ -42,6 +44,7 @@ ADD CMakeLists.txt CMakeLists.txt
 
 # Allow build type to be passed as build arg, default to Release
 ARG CMAKE_BUILD_TYPE=Release
+ARG RUN_ASAN=OFF
 RUN mkdir build-${CMAKE_BUILD_TYPE} && \
     cd build-${CMAKE_BUILD_TYPE} && \
     cmake .. \
@@ -50,6 +53,7 @@ RUN mkdir build-${CMAKE_BUILD_TYPE} && \
         -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} \
         -DCMAKE_CXX_FLAGS_DEBUG="-g -O0" \
         -DCMAKE_C_FLAGS_DEBUG="-g -O0" \
+        -DRUN_ASAN=${RUN_ASAN} \
         -DOPENSSL_ROOT_DIR=/usr/local/openssl
 
 RUN cd build-${CMAKE_BUILD_TYPE} && make -j16 Pyroscope.Profiler.Native Datadog.Linux.ApiWrapper.x64

--- a/build/install-llvm.sh
+++ b/build/install-llvm.sh
@@ -2,7 +2,19 @@
 set -eu
 
 LLVM_VERSION="${1:-22}"
+LINK_ASAN_RUNTIME="${LINK_ASAN_RUNTIME:-OFF}"
 ASAN_RUNTIME_DIR="${ASAN_RUNTIME_DIR:-/opt/llvm-asan}"
+
+asan_runtime_arch() {
+    case "$(uname -m)" in
+        x86_64) echo "x86_64" ;;
+        aarch64|arm64) echo "aarch64" ;;
+        *)
+            echo "unsupported architecture for ASAN runtime: $(uname -m)" >&2
+            exit 1
+            ;;
+    esac
+}
 
 prefer_versioned_clang() {
     if command -v "clang-${LLVM_VERSION}" >/dev/null 2>&1; then
@@ -26,12 +38,13 @@ link_asan_runtime() {
         exit 1
     fi
 
-    runtime="$("${compiler}" -print-file-name=libclang_rt.asan-x86_64.so)"
+    asan_arch="$(asan_runtime_arch)"
+    runtime="$("${compiler}" -print-file-name=libclang_rt.asan-${asan_arch}.so)"
     if [ ! -f "${runtime}" ]; then
-        runtime="$(find /usr /opt -name libclang_rt.asan-x86_64.so -type f 2>/dev/null | sort | tail -n 1 || true)"
+        runtime="$(find /usr /opt -name "libclang_rt.asan-${asan_arch}.so" -type f 2>/dev/null | sort | tail -n 1 || true)"
     fi
     if [ -z "${runtime}" ] || [ ! -f "${runtime}" ]; then
-        echo "libclang_rt.asan-x86_64.so was not found after installing LLVM" >&2
+        echo "libclang_rt.asan-${asan_arch}.so was not found after installing LLVM" >&2
         exit 1
     fi
 
@@ -46,7 +59,6 @@ install_debian_llvm() {
     chmod +x /tmp/llvm.sh
     /tmp/llvm.sh "${LLVM_VERSION}"
     apt-get install -y --no-install-recommends "clang-${LLVM_VERSION}" "libclang-rt-${LLVM_VERSION}-dev"
-    link_asan_runtime
     rm -rf /var/lib/apt/lists/* /tmp/llvm.sh
 }
 
@@ -58,10 +70,9 @@ install_alpine_llvm() {
     # apt.llvm.org's script is Debian/Ubuntu-oriented. Try it first so Alpine
     # picks up support automatically if the script grows it, then fall back.
     if bash /tmp/llvm.sh "${LLVM_VERSION}"; then
-        link_asan_runtime
+        :
     else
         apk add --no-cache clang llvm compiler-rt
-        link_asan_runtime
     fi
 
     rm -f /tmp/llvm.sh
@@ -75,3 +86,9 @@ else
     echo "unsupported package manager: expected apt-get or apk" >&2
     exit 1
 fi
+
+case "${LINK_ASAN_RUNTIME}" in
+    ON|on|1|true|TRUE|yes|YES)
+        link_asan_runtime
+        ;;
+esac

--- a/build/install-llvm.sh
+++ b/build/install-llvm.sh
@@ -1,0 +1,77 @@
+#!/bin/sh
+set -eu
+
+LLVM_VERSION="${1:-22}"
+ASAN_RUNTIME_DIR="${ASAN_RUNTIME_DIR:-/opt/llvm-asan}"
+
+prefer_versioned_clang() {
+    if command -v "clang-${LLVM_VERSION}" >/dev/null 2>&1; then
+        ln -sf "$(command -v "clang-${LLVM_VERSION}")" /usr/local/bin/clang
+    fi
+    if command -v "clang++-${LLVM_VERSION}" >/dev/null 2>&1; then
+        ln -sf "$(command -v "clang++-${LLVM_VERSION}")" /usr/local/bin/clang++
+    fi
+}
+
+link_asan_runtime() {
+    prefer_versioned_clang
+
+    compiler=""
+    if command -v "clang-${LLVM_VERSION}" >/dev/null 2>&1; then
+        compiler="clang-${LLVM_VERSION}"
+    elif command -v clang >/dev/null 2>&1; then
+        compiler="clang"
+    else
+        echo "clang was not installed" >&2
+        exit 1
+    fi
+
+    runtime="$("${compiler}" -print-file-name=libclang_rt.asan-x86_64.so)"
+    if [ ! -f "${runtime}" ]; then
+        runtime="$(find /usr /opt -name libclang_rt.asan-x86_64.so -type f 2>/dev/null | sort | tail -n 1 || true)"
+    fi
+    if [ -z "${runtime}" ] || [ ! -f "${runtime}" ]; then
+        echo "libclang_rt.asan-x86_64.so was not found after installing LLVM" >&2
+        exit 1
+    fi
+
+    mkdir -p "${ASAN_RUNTIME_DIR}"
+    ln -sf "${runtime}" "${ASAN_RUNTIME_DIR}/libasan.so"
+}
+
+install_debian_llvm() {
+    apt-get update
+    apt-get install -y --no-install-recommends ca-certificates wget gnupg lsb-release software-properties-common
+    wget -q https://apt.llvm.org/llvm.sh -O /tmp/llvm.sh
+    chmod +x /tmp/llvm.sh
+    /tmp/llvm.sh "${LLVM_VERSION}"
+    apt-get install -y --no-install-recommends "clang-${LLVM_VERSION}" "libclang-rt-${LLVM_VERSION}-dev"
+    link_asan_runtime
+    rm -rf /var/lib/apt/lists/* /tmp/llvm.sh
+}
+
+install_alpine_llvm() {
+    apk add --no-cache bash ca-certificates wget
+    wget -q https://apt.llvm.org/llvm.sh -O /tmp/llvm.sh
+    chmod +x /tmp/llvm.sh
+
+    # apt.llvm.org's script is Debian/Ubuntu-oriented. Try it first so Alpine
+    # picks up support automatically if the script grows it, then fall back.
+    if bash /tmp/llvm.sh "${LLVM_VERSION}"; then
+        link_asan_runtime
+    else
+        apk add --no-cache clang llvm compiler-rt
+        link_asan_runtime
+    fi
+
+    rm -f /tmp/llvm.sh
+}
+
+if command -v apt-get >/dev/null 2>&1; then
+    install_debian_llvm
+elif command -v apk >/dev/null 2>&1; then
+    install_alpine_llvm
+else
+    echo "unsupported package manager: expected apt-get or apk" >&2
+    exit 1
+fi

--- a/integration-test-with-otel.Dockerfile
+++ b/integration-test-with-otel.Dockerfile
@@ -33,11 +33,23 @@ ARG PYROSCOPE_SDK_IMAGE
 # Runtime only image of the targetplatfrom, so the platform the image will be running on.
 FROM --platform=linux/amd64 mcr.microsoft.com/dotnet/aspnet:$SDK_VERSION$SDK_IMAGE_SUFFIX
 
+ARG RUN_ASAN=OFF
+ARG LLVM_VERSION=22
+ARG ASAN_PRELOAD_PREFIX=
+ENV RUN_ASAN=${RUN_ASAN}
+ENV LD_PRELOAD=${ASAN_PRELOAD_PREFIX}/dotnet/subfolder/Pyroscope.Linux.ApiWrapper.x64.so
+
 RUN if command -v apt-get > /dev/null 2>&1; then \
         apt-get update && apt-get install -y --no-install-recommends curl unzip && rm -rf /var/lib/apt/lists/*; \
     else \
         apk add --no-cache curl unzip; \
     fi
+
+COPY build/install-llvm.sh /tmp/install-llvm.sh
+RUN if [ "${RUN_ASAN}" = "ON" ]; then \
+        sh /tmp/install-llvm.sh "${LLVM_VERSION}"; \
+    fi && \
+    rm -f /tmp/install-llvm.sh
 
 ARG OTEL_VERSION=1.14.1
 ENV OTEL_DOTNET_AUTO_HOME=/opt/otel-dotnet
@@ -72,7 +84,6 @@ ENV CORECLR_ENABLE_NOTIFICATION_PROFILERS=1
 # single-entry lists without trailing ';' are never processed).
 # See https://github.com/dotnet/runtime/issues/126197
 ENV CORECLR_NOTIFICATION_PROFILERS=/dotnet/subfolder/Pyroscope.Profiler.Native.so={BD1A650D-AC5D-4896-B64F-D6FA25D6B26A};
-ENV LD_PRELOAD=/dotnet/subfolder/Pyroscope.Linux.ApiWrapper.x64.so
 
 ENV PYROSCOPE_SERVER_ADDRESS=http://pyroscope:4040
 ENV PYROSCOPE_LOG_LEVEL=debug

--- a/integration-test-with-otel.Dockerfile
+++ b/integration-test-with-otel.Dockerfile
@@ -35,9 +35,8 @@ FROM --platform=linux/amd64 mcr.microsoft.com/dotnet/aspnet:$SDK_VERSION$SDK_IMA
 
 ARG RUN_ASAN=OFF
 ARG LLVM_VERSION=22
-ARG ASAN_PRELOAD_PREFIX=
+ARG LD_PRELOAD_VALUE=/dotnet/subfolder/Pyroscope.Linux.ApiWrapper.x64.so
 ENV RUN_ASAN=${RUN_ASAN}
-ENV LD_PRELOAD=${ASAN_PRELOAD_PREFIX}/dotnet/subfolder/Pyroscope.Linux.ApiWrapper.x64.so
 
 RUN if command -v apt-get > /dev/null 2>&1; then \
         apt-get update && apt-get install -y --no-install-recommends curl unzip && rm -rf /var/lib/apt/lists/*; \
@@ -77,6 +76,11 @@ WORKDIR /dotnet
 COPY --from=sdk /Pyroscope.Profiler.Native.so ./subfolder/Pyroscope.Profiler.Native.so
 COPY --from=sdk /Pyroscope.Linux.ApiWrapper.x64.so ./subfolder/Pyroscope.Linux.ApiWrapper.x64.so
 COPY --from=build /dotnet/publish ./
+
+# Under ASAN this is just the ASAN runtime (the API wrapper is dropped because
+# the ASAN runtime segfaults when another library shares LD_PRELOAD); otherwise
+# it is the API wrapper.
+ENV LD_PRELOAD=${LD_PRELOAD_VALUE}
 
 ENV LD_LIBRARY_PATH=/dotnet/subfolder/
 ENV CORECLR_ENABLE_NOTIFICATION_PROFILERS=1

--- a/integration-test-with-otel.Dockerfile
+++ b/integration-test-with-otel.Dockerfile
@@ -47,7 +47,7 @@ RUN if command -v apt-get > /dev/null 2>&1; then \
 
 COPY build/install-llvm.sh /tmp/install-llvm.sh
 RUN if [ "${RUN_ASAN}" = "ON" ]; then \
-        sh /tmp/install-llvm.sh "${LLVM_VERSION}"; \
+        LINK_ASAN_RUNTIME=ON sh /tmp/install-llvm.sh "${LLVM_VERSION}"; \
     fi && \
     rm -f /tmp/install-llvm.sh
 

--- a/integration-test.Dockerfile
+++ b/integration-test.Dockerfile
@@ -33,6 +33,18 @@ ARG PYROSCOPE_SDK_IMAGE
 # Runtime only image of the targetplatfrom, so the platform the image will be running on.
 FROM --platform=linux/amd64 mcr.microsoft.com/dotnet/aspnet:$SDK_VERSION$SDK_IMAGE_SUFFIX
 
+ARG RUN_ASAN=OFF
+ARG LLVM_VERSION=22
+ARG ASAN_PRELOAD_PREFIX=
+ENV RUN_ASAN=${RUN_ASAN}
+ENV LD_PRELOAD=${ASAN_PRELOAD_PREFIX}/dotnet/subfolder/Pyroscope.Linux.ApiWrapper.x64.so
+
+COPY build/install-llvm.sh /tmp/install-llvm.sh
+RUN if [ "${RUN_ASAN}" = "ON" ]; then \
+        sh /tmp/install-llvm.sh "${LLVM_VERSION}"; \
+    fi && \
+    rm -f /tmp/install-llvm.sh
+
 WORKDIR /dotnet
 
 # place the binaries in a subfolder - to rigger a problme when SONAME was Datadog.Profiler.Native
@@ -47,7 +59,6 @@ ENV LD_LIBRARY_PATH=/dotnet/subfolder/
 ENV CORECLR_ENABLE_PROFILING=1
 ENV CORECLR_PROFILER={BD1A650D-AC5D-4896-B64F-D6FA25D6B26A}
 ENV CORECLR_PROFILER_PATH=/dotnet/subfolder/Pyroscope.Profiler.Native.so
-ENV LD_PRELOAD=/dotnet/subfolder/Pyroscope.Linux.ApiWrapper.x64.so
 
 ENV PYROSCOPE_SERVER_ADDRESS=http://pyroscope:4040
 ENV PYROSCOPE_LOG_LEVEL=debug

--- a/integration-test.Dockerfile
+++ b/integration-test.Dockerfile
@@ -35,9 +35,8 @@ FROM --platform=linux/amd64 mcr.microsoft.com/dotnet/aspnet:$SDK_VERSION$SDK_IMA
 
 ARG RUN_ASAN=OFF
 ARG LLVM_VERSION=22
-ARG ASAN_PRELOAD_PREFIX=
+ARG LD_PRELOAD_VALUE=/dotnet/subfolder/Pyroscope.Linux.ApiWrapper.x64.so
 ENV RUN_ASAN=${RUN_ASAN}
-ENV LD_PRELOAD=${ASAN_PRELOAD_PREFIX}/dotnet/subfolder/Pyroscope.Linux.ApiWrapper.x64.so
 
 COPY build/install-llvm.sh /tmp/install-llvm.sh
 RUN if [ "${RUN_ASAN}" = "ON" ]; then \
@@ -52,6 +51,11 @@ WORKDIR /dotnet
 COPY --from=sdk /Pyroscope.Profiler.Native.so ./subfolder/Pyroscope.Profiler.Native.so
 COPY --from=sdk /Pyroscope.Linux.ApiWrapper.x64.so ./subfolder/Pyroscope.Linux.ApiWrapper.x64.so
 COPY --from=build /dotnet/publish ./
+
+# Under ASAN this is just the ASAN runtime (the API wrapper is dropped because
+# the ASAN runtime segfaults when another library shares LD_PRELOAD); otherwise
+# it is the API wrapper.
+ENV LD_PRELOAD=${LD_PRELOAD_VALUE}
 
 # Fix for alpine not being able to dlopen an already loaded library
 ENV LD_LIBRARY_PATH=/dotnet/subfolder/

--- a/integration-test.Dockerfile
+++ b/integration-test.Dockerfile
@@ -41,7 +41,7 @@ ENV LD_PRELOAD=${ASAN_PRELOAD_PREFIX}/dotnet/subfolder/Pyroscope.Linux.ApiWrappe
 
 COPY build/install-llvm.sh /tmp/install-llvm.sh
 RUN if [ "${RUN_ASAN}" = "ON" ]; then \
-        sh /tmp/install-llvm.sh "${LLVM_VERSION}"; \
+        LINK_ASAN_RUNTIME=ON sh /tmp/install-llvm.sh "${LLVM_VERSION}"; \
     fi && \
     rm -f /tmp/install-llvm.sh
 

--- a/integration-test/dockertest/dockertest.go
+++ b/integration-test/dockertest/dockertest.go
@@ -91,12 +91,10 @@ func StartContainer(t *testing.T, req ContainerRequest) *Container {
 	t.Cleanup(func() {
 		if t.Failed() {
 			if out, err := exec.Command("docker", "inspect", c.ID, "--format",
-				"ExitCode={{.State.ExitCode}} OOMKilled={{.State.OOMKilled}} Running={{.State.Running}}").CombinedOutput(); err == nil {
+				"ExitCode={{.State.ExitCode}} OOMKilled={{.State.OOMKilled}} Running={{.State.Running}} Error={{.State.Error}}").CombinedOutput(); err == nil {
 				t.Logf("dockertest: container %s state: %s", c.ID[:12], out)
 			}
-			if logs, err := exec.Command("docker", "logs", "--tail", "50", c.ID).CombinedOutput(); err == nil {
-				t.Logf("dockertest: container %s logs:\n%s", c.ID[:12], logs)
-			}
+			dumpContainerLogs(t, c.ID)
 		}
 		runQuiet("docker", "rm", "-f", c.ID)
 	})
@@ -195,6 +193,23 @@ func run(t *testing.T, name string, args ...string) string {
 			name, strings.Join(args, " "), err, stdout.String(), stderr.String())
 	}
 	return stdout.String()
+}
+
+// dumpContainerLogs writes the container's full stdout and stderr to the test
+// log. stdout and stderr are captured separately so AddressSanitizer reports
+// (which go to stderr) are easy to spot.
+func dumpContainerLogs(t *testing.T, id string) {
+	t.Helper()
+	cmd := exec.Command("docker", "logs", id)
+	var stdout, stderr strings.Builder
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		t.Logf("dockertest: container %s docker logs failed: %v", id[:12], err)
+		return
+	}
+	t.Logf("dockertest: container %s stdout:\n%s", id[:12], stdout.String())
+	t.Logf("dockertest: container %s stderr:\n%s", id[:12], stderr.String())
 }
 
 func runQuiet(name string, args ...string) {

--- a/integration-test/integration_test.go
+++ b/integration-test/integration_test.go
@@ -43,9 +43,9 @@ func startPyroscope(t *testing.T, net *dockertest.Network) string {
 
 func buildAppImage(t *testing.T, libcType, version string, otel bool) string {
 	t.Helper()
-	tag := fmt.Sprintf("rideshare-app-%s:integration-test-%s", libcType, version)
+	tag := fmt.Sprintf("rideshare-app-%s%s:integration-test-%s", libcType, asanImageSuffix(), version)
 	if otel {
-		tag = fmt.Sprintf("rideshare-app-%s-otel:integration-test-%s", libcType, version)
+		tag = fmt.Sprintf("rideshare-app-%s%s-otel:integration-test-%s", libcType, asanImageSuffix(), version)
 	}
 	dockertest.BuildImage(t, dockertest.BuildRequest{
 		Context:    repoRoot(),
@@ -56,6 +56,8 @@ func buildAppImage(t *testing.T, libcType, version string, otel bool) string {
 			"PYROSCOPE_SDK_IMAGE": profilerImageTag(libcType),
 			"SDK_VERSION":         version,
 			"SDK_IMAGE_SUFFIX":    sdkImageSuffix(libcType, version),
+			"RUN_ASAN":            envRunASAN(),
+			"ASAN_PRELOAD_PREFIX": asanRuntimePreloadPrefix(),
 		},
 	})
 	return tag
@@ -72,6 +74,9 @@ func startAppWithEnv(t *testing.T, net *dockertest.Network, libcType, version st
 		"PYROSCOPE_APPLICATION_NAME": svcName,
 		"PYROSCOPE_SERVER_ADDRESS":   "http://pyroscope:4040",
 		"DD_TRACE_DEBUG":             "true",
+	}
+	if runASANEnabled() {
+		env["ASAN_OPTIONS"] = "detect_leaks=0:abort_on_error=1"
 	}
 	for k, v := range extraEnv {
 		env[k] = v
@@ -470,15 +475,20 @@ func startAppForTLSTest(t *testing.T, libcType, version, serverAddress string, c
 		extraHosts = []string{extraHost}
 	}
 
+	env := map[string]string{
+		"REGION":                     "us-east",
+		"PYROSCOPE_APPLICATION_NAME": "tls-test-app",
+		"PYROSCOPE_SERVER_ADDRESS":   serverAddress,
+		"DD_TRACE_DEBUG":             "true",
+	}
+	if runASANEnabled() {
+		env["ASAN_OPTIONS"] = "detect_leaks=0:abort_on_error=1"
+	}
+
 	c := dockertest.StartContainer(t, dockertest.ContainerRequest{
-		Image:    image,
-		Platform: "linux/amd64",
-		Env: map[string]string{
-			"REGION":                     "us-east",
-			"PYROSCOPE_APPLICATION_NAME": "tls-test-app",
-			"PYROSCOPE_SERVER_ADDRESS":   serverAddress,
-			"DD_TRACE_DEBUG":             "true",
-		},
+		Image:      image,
+		Platform:   "linux/amd64",
+		Env:        env,
 		ExtraHosts: extraHosts,
 		Files: []dockertest.ContainerFile{
 			{

--- a/integration-test/integration_test.go
+++ b/integration-test/integration_test.go
@@ -57,7 +57,7 @@ func buildAppImage(t *testing.T, libcType, version string, otel bool) string {
 			"SDK_VERSION":         version,
 			"SDK_IMAGE_SUFFIX":    sdkImageSuffix(libcType, version),
 			"RUN_ASAN":            envRunASAN(),
-			"ASAN_PRELOAD_PREFIX": asanRuntimePreloadPrefix(),
+			"LD_PRELOAD_VALUE":    ldPreloadValue(),
 		},
 	})
 	return tag

--- a/integration-test/matrix.go
+++ b/integration-test/matrix.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"sync"
 	"testing"
 )
@@ -19,6 +20,34 @@ func envOrDefault(key, defaultValue string) string {
 
 func envLibcType() string      { return envOrDefault("LIBC_TYPE", "glibc") }
 func envDotnetVersion() string { return envOrDefault("DOTNET_VERSION", "10.0") }
+
+func envRunASAN() string {
+	value := envOrDefault("RUN_ASAN", "OFF")
+	switch strings.ToUpper(value) {
+	case "1", "TRUE", "YES", "ON":
+		return "ON"
+	case "0", "FALSE", "NO", "OFF":
+		return "OFF"
+	default:
+		panic(fmt.Sprintf("unknown RUN_ASAN value %q: expected ON or OFF", value))
+	}
+}
+
+func runASANEnabled() bool { return envRunASAN() == "ON" }
+
+func asanImageSuffix() string {
+	if runASANEnabled() {
+		return "-asan"
+	}
+	return ""
+}
+
+func asanRuntimePreloadPrefix() string {
+	if runASANEnabled() {
+		return "/opt/llvm-asan/libasan.so:"
+	}
+	return ""
+}
 
 func sdkImageSuffix(libcType, version string) string {
 	if libcType == "musl" {
@@ -42,7 +71,7 @@ func profilerDockerfile(libcType string) string {
 }
 
 func profilerImageTag(libcType string) string {
-	return fmt.Sprintf("pyroscope-dotnet-%s:test", libcType)
+	return fmt.Sprintf("pyroscope-dotnet-%s%s:test", libcType, asanImageSuffix())
 }
 
 func appDockerfile(otel bool) string {
@@ -74,7 +103,9 @@ var profilerBuilds sync.Map
 
 func ensureProfilerImage(t *testing.T, libcType string) {
 	t.Helper()
-	val, _ := profilerBuilds.LoadOrStore(libcType, &profilerBuildResult{})
+	runASAN := envRunASAN()
+	key := libcType + "-" + runASAN
+	val, _ := profilerBuilds.LoadOrStore(key, &profilerBuildResult{})
 	pb := val.(*profilerBuildResult)
 	pb.once.Do(func() {
 		tag := profilerImageTag(libcType)
@@ -84,6 +115,7 @@ func ensureProfilerImage(t *testing.T, libcType string) {
 			"-t", tag,
 			"-f", filepath.Join(repoRoot(), profilerDockerfile(libcType)),
 			"--build-arg", "CMAKE_BUILD_TYPE=Debug",
+			"--build-arg", "RUN_ASAN="+runASAN,
 			repoRoot(),
 		)
 		out, err := cmd.CombinedOutput()

--- a/integration-test/matrix.go
+++ b/integration-test/matrix.go
@@ -42,11 +42,18 @@ func asanImageSuffix() string {
 	return ""
 }
 
-func asanRuntimePreloadPrefix() string {
+// ldPreloadValue returns the LD_PRELOAD the app container should run with.
+//
+// Under ASAN we preload only the ASAN runtime and intentionally drop the
+// Pyroscope API wrapper: the ASAN runtime segfaults at load time when another
+// library is present in LD_PRELOAD. This matches upstream dd-trace-dotnet,
+// which runs its ASAN profiler demo with LD_PRELOAD=libasan.so only.
+func ldPreloadValue() string {
+	const wrapper = "/dotnet/subfolder/Pyroscope.Linux.ApiWrapper.x64.so"
 	if runASANEnabled() {
-		return "/opt/llvm-asan/libasan.so:"
+		return "/opt/llvm-asan/libasan.so"
 	}
-	return ""
+	return wrapper
 }
 
 func sdkImageSuffix(libcType, version string) string {

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/DllMain.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/DllMain.cpp
@@ -35,6 +35,7 @@ extern "C" BOOL STDMETHODCALLTYPE DllMain(HINSTANCE hInstDll, DWORD reason, PVOI
     switch (reason)
     {
         case DLL_PROCESS_ATTACH:
+        {
             Log::Info("Profiler DLL loaded.");
             Log::Info("Profiler version = ", PROFILER_VERSION);
             Log::Info("Pointer size: ", 8 * sizeof(void*), " bits.");
@@ -46,6 +47,7 @@ extern "C" BOOL STDMETHODCALLTYPE DllMain(HINSTANCE hInstDll, DWORD reason, PVOI
             delete[] asanProbe;
 #endif
             break;
+        }
 
         case DLL_PROCESS_DETACH:
             Log::Info("Profiler DLL unloaded.");

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/DllMain.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/DllMain.cpp
@@ -12,6 +12,10 @@
 
 #include "dd_profiler_version.h"
 
+#ifndef __has_feature
+#define __has_feature(x) 0
+#endif
+
 HINSTANCE DllHandle;
 
 const IID IID_IUnknown = {0x00000000,
@@ -34,6 +38,13 @@ extern "C" BOOL STDMETHODCALLTYPE DllMain(HINSTANCE hInstDll, DWORD reason, PVOI
             Log::Info("Profiler DLL loaded.");
             Log::Info("Profiler version = ", PROFILER_VERSION);
             Log::Info("Pointer size: ", 8 * sizeof(void*), " bits.");
+#if defined(__SANITIZE_ADDRESS__) || __has_feature(address_sanitizer)
+            // Intentional CI probe: ASAN integration jobs should fail here.
+            auto* asanProbe = new char[1];
+            volatile char* volatileAsanProbe = asanProbe;
+            volatileAsanProbe[1] = 'x';
+            delete[] asanProbe;
+#endif
             break;
 
         case DLL_PROCESS_DETACH:

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/DllMain.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/DllMain.cpp
@@ -12,10 +12,6 @@
 
 #include "dd_profiler_version.h"
 
-#ifndef __has_feature
-#define __has_feature(x) 0
-#endif
-
 HINSTANCE DllHandle;
 
 const IID IID_IUnknown = {0x00000000,
@@ -35,19 +31,10 @@ extern "C" BOOL STDMETHODCALLTYPE DllMain(HINSTANCE hInstDll, DWORD reason, PVOI
     switch (reason)
     {
         case DLL_PROCESS_ATTACH:
-        {
             Log::Info("Profiler DLL loaded.");
             Log::Info("Profiler version = ", PROFILER_VERSION);
             Log::Info("Pointer size: ", 8 * sizeof(void*), " bits.");
-#if defined(__SANITIZE_ADDRESS__) || __has_feature(address_sanitizer)
-            // Intentional CI probe: ASAN integration jobs should fail here.
-            auto* asanProbe = new char[1];
-            volatile char* volatileAsanProbe = asanProbe;
-            volatileAsanProbe[1] = 'x';
-            delete[] asanProbe;
-#endif
             break;
-        }
 
         case DLL_PROCESS_DETACH:
             Log::Info("Profiler DLL unloaded.");


### PR DESCRIPTION
## Summary
- Run the full integration test matrix for both `RUN_ASAN=OFF` and `RUN_ASAN=ON` profiler builds across glibc/musl and .NET 8/9/10.
- Add shared LLVM 22 installation via `build/install-llvm.sh` for profiler builders and app test images, with ASAN runtime preloaded through `ENV LD_PRELOAD`.
- Add an intentional ASAN-only heap-buffer-overflow probe in `DllMain.cpp` so ASAN CI jobs fail when sanitizer coverage is active.

## Test plan
- [ ] Non-ASAN integration jobs pass
- [ ] ASAN integration jobs fail on the intentional probe
- [ ] Profiler Docker builds succeed with LLVM 22 on glibc and musl