### PR TITLE
ci: Windows profiler build and test workflow

### DIFF
--- a/.github/workflows/build_windows_profiler.yml
+++ b/.github/workflows/build_windows_profiler.yml
@@ -11,13 +11,31 @@ permissions:
 
 jobs:
   build-windows-profiler-x64:
-    runs-on: windows-2022
+    runs-on: windows-2025
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           submodules: 'true'
           persist-credentials: false
+      # The vcxprojs pin the upstream toolchain (v143 + SDK 10.0.19041). The
+      # windows-2025 (VS2026) image ships the v143 compilers but neither v143
+      # ATL nor that SDK. ATL comes from the VS installer (the versioned compat
+      # component); the SDK is no longer in the VS2026 catalog, so it comes
+      # from the standalone SDK installer via choco.
+      - name: Install v143 ATL + Windows SDK 10.0.19041
+        run: |
+          $installer = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer"
+          $vs = & "$installer\vswhere.exe" -latest -products '*' -property installationPath
+          $p = Start-Process -FilePath "$installer\setup.exe" -Wait -PassThru -ArgumentList `
+            'modify', '--installPath', "`"$vs`"", `
+            '--add', 'Microsoft.VisualStudio.Component.VC.14.44.17.14.ATL', `
+            '--quiet', '--norestart', '--noUpdateInstaller'
+          if ($p.ExitCode -notin 0, 3010) { throw "VS setup modify failed (exit $($p.ExitCode))" }
+          $atl = Get-ChildItem "$vs\VC\Tools\MSVC\14.4*\atlmfc\include\atlbase.h" -ErrorAction SilentlyContinue
+          if (-not $atl) { throw "v143 ATL still missing after modify" }
+          choco install windows-sdk-10-version-2004-all -y --no-progress
+          if (-not (Test-Path "${env:ProgramFiles(x86)}\Windows Kits\10\Include\10.0.19041.0\um\windows.h")) { throw "SDK 10.0.19041 still missing after install" }
       - name: Restore vcpkg binary cache
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:

--- a/.github/workflows/build_windows_profiler.yml
+++ b/.github/workflows/build_windows_profiler.yml
@@ -58,13 +58,33 @@ jobs:
             profiler/_build/bin/Release-x64/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/Pyroscope.Profiler.Native.pdb
           if-no-files-found: error
 
+  discover:
+    name: discover tests
+    runs-on: ubuntu-latest
+    outputs:
+      tests: ${{ steps.tests.outputs.tests }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version: 'stable'
+          cache-dependency-path: integration-test/go.sum
+      - name: Generate test matrix
+        id: tests
+        run: echo "tests=$(make ci-matrix)" >> "$GITHUB_OUTPUT"
+        working-directory: integration-test
+
   integration-test-windows:
-    name: integration-test-windows .NET ${{ matrix.version }}
-    needs: build-windows-profiler-x64
+    name: integration-test-windows ${{ matrix.test }} .NET ${{ matrix.version }}
+    needs: [discover, build-windows-profiler-x64]
     runs-on: windows-2025
     strategy:
       fail-fast: false
       matrix:
+        test: ${{ fromJSON(needs.discover.outputs.tests) }}
         version: ['8.0', '9.0', '10.0']
     steps:
       - name: Checkout
@@ -108,8 +128,9 @@ jobs:
       - name: Run integration tests
         env:
           DOTNET_VERSION: ${{ matrix.version }}
+          TEST_NAME: ${{ matrix.test }}
           WINDOWS_PROFILER_DIR: ${{ github.workspace }}\profiler-bin
           DOCKERTEST_DOCKER_COMMAND: wsl -d Ubuntu -u root -- docker
           DOCKERTEST_HOST_IP: 127.0.0.1
-        run: go test -v -timeout 45m -count=1 .
+        run: go test -v -timeout 45m -count=1 -run ('^' + $env:TEST_NAME + '$') .
         working-directory: integration-test

--- a/.github/workflows/build_windows_profiler.yml
+++ b/.github/workflows/build_windows_profiler.yml
@@ -12,8 +12,6 @@ permissions:
 jobs:
   build-windows-profiler-x64:
     runs-on: windows-2022
-    env:
-      VCPKG_DEFAULT_BINARY_CACHE: ${{ runner.temp }}\vcpkg-bincache
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -29,6 +27,8 @@ jobs:
       - name: Add MSBuild to PATH
         uses: microsoft/setup-msbuild@30375c66a4eea26614e0d39710365f22f8b0af57 # v3
       - name: Build profiler (Release x64)
+        env:
+          VCPKG_DEFAULT_BINARY_CACHE: ${{ runner.temp }}\vcpkg-bincache
         run: |
           New-Item -ItemType Directory -Force -Path $env:VCPKG_DEFAULT_BINARY_CACHE | Out-Null
           vcpkg integrate install

--- a/.github/workflows/build_windows_profiler.yml
+++ b/.github/workflows/build_windows_profiler.yml
@@ -64,7 +64,67 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: pyroscope-profiler-windows-x64
+          # The profiler links protobuf dynamically; without the DLLs beside it
+          # the CLR fails the load and silently skips attach.
           path: |
             profiler/_build/bin/Release-x64/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/Pyroscope.Profiler.Native.dll
             profiler/_build/bin/Release-x64/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/Pyroscope.Profiler.Native.pdb
+            profiler/_build/bin/Release-x64/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/libprotobuf.dll
+            profiler/_build/bin/Release-x64/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/libprotobuf-lite.dll
           if-no-files-found: error
+
+  integration-test-windows:
+    name: integration-test-windows .NET ${{ matrix.version }}
+    needs: build-windows-profiler-x64
+    runs-on: windows-2025
+    strategy:
+      fail-fast: false
+      matrix:
+        version: ['8.0', '9.0', '10.0']
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version: 'stable'
+          cache-dependency-path: integration-test/go.sum
+      - name: Download profiler artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: pyroscope-profiler-windows-x64
+          path: profiler-bin
+      # The Pyroscope server runs in the same pinned Linux image the Linux
+      # tests use, inside WSL2 Docker (windows-2025 runners ship WSL2; the
+      # keeper process is required because the WSL VM shuts down seconds after
+      # its last client exits).
+      - name: Set up WSL2 + Docker
+        run: |
+          wsl --install Ubuntu --no-launch
+          Start-Process -WindowStyle Hidden wsl.exe -ArgumentList "-d", "Ubuntu", "-u", "root", "--", "sleep", "infinity"
+          $deadline = (Get-Date).AddSeconds(180)
+          do {
+            wsl -d Ubuntu -u root -- true 2>$null
+            if ($LASTEXITCODE -eq 0) { break }
+            Start-Sleep 3
+          } while ((Get-Date) -lt $deadline)
+          if ($LASTEXITCODE -ne 0) { throw "Ubuntu distro not launchable" }
+          wsl -d Ubuntu -u root -- sh -c "curl -fsSL https://get.docker.com | sh"
+          if ($LASTEXITCODE -ne 0) { throw "docker install failed" }
+          $deadline = (Get-Date).AddSeconds(60)
+          do {
+            wsl -d Ubuntu -u root -- docker version 2>$null | Out-Null
+            if ($LASTEXITCODE -eq 0) { break }
+            Start-Sleep 3
+          } while ((Get-Date) -lt $deadline)
+          if ($LASTEXITCODE -ne 0) { throw "dockerd not ready" }
+      - name: Run integration tests
+        env:
+          DOTNET_VERSION: ${{ matrix.version }}
+          WINDOWS_PROFILER_DIR: ${{ github.workspace }}\profiler-bin
+          DOCKERTEST_DOCKER_COMMAND: wsl -d Ubuntu -u root -- docker
+          DOCKERTEST_HOST_IP: 127.0.0.1
+        run: go test -v -timeout 45m -count=1 .
+        working-directory: integration-test

--- a/.github/workflows/build_windows_profiler.yml
+++ b/.github/workflows/build_windows_profiler.yml
@@ -20,9 +20,7 @@ jobs:
           persist-credentials: false
       # The vcxprojs pin the upstream toolchain (v143 + SDK 10.0.19041). The
       # windows-2025 (VS2026) image ships the v143 compilers but neither v143
-      # ATL nor that SDK. ATL comes from the VS installer (the versioned compat
-      # component); the SDK is no longer in the VS2026 catalog, so it comes
-      # from the standalone SDK installer via choco.
+      # ATL nor that SDK.
       - name: Install v143 ATL + Windows SDK 10.0.19041
         run: |
           $installer = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer"
@@ -51,26 +49,13 @@ jobs:
           New-Item -ItemType Directory -Force -Path $env:VCPKG_DEFAULT_BINARY_CACHE | Out-Null
           vcpkg integrate install
           msbuild profiler\src\ProfilerEngine\Datadog.Profiler.Native.Windows\Datadog.Profiler.Native.Windows.vcxproj /p:Configuration=Release /p:Platform=x64 /p:VcpkgEnableManifest=true /m /v:m
-      - name: Verify DLL exports match the .def
-        run: |
-          $vs = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -products '*' -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath
-          $ver = (Get-Content "$vs\VC\Auxiliary\Build\Microsoft.VCToolsVersion.default.txt").Trim()
-          $exports = & "$vs\VC\Tools\MSVC\$ver\bin\Hostx64\x64\dumpbin.exe" /EXPORTS profiler\_build\bin\Release-x64\profiler\src\ProfilerEngine\Datadog.Profiler.Native.Windows\Pyroscope.Profiler.Native.dll | Out-String
-          $missing = Select-String -Path profiler\src\ProfilerEngine\Datadog.Profiler.Native.Windows\Datadog.Profiler.Native.def -Pattern '^\s*(\w+)\s+PRIVATE' |
-            ForEach-Object { $_.Matches[0].Groups[1].Value } |
-            Where-Object { $exports -notmatch "\b$([regex]::Escape($_))\b" }
-          if ($missing) { throw "exports missing from the DLL: $missing" }
       - name: Upload artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: pyroscope-profiler-windows-x64
-          # The profiler links protobuf dynamically; without the DLLs beside it
-          # the CLR fails the load and silently skips attach.
           path: |
             profiler/_build/bin/Release-x64/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/Pyroscope.Profiler.Native.dll
             profiler/_build/bin/Release-x64/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/Pyroscope.Profiler.Native.pdb
-            profiler/_build/bin/Release-x64/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/libprotobuf.dll
-            profiler/_build/bin/Release-x64/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/libprotobuf-lite.dll
           if-no-files-found: error
 
   integration-test-windows:

--- a/.github/workflows/build_windows_profiler.yml
+++ b/.github/workflows/build_windows_profiler.yml
@@ -1,0 +1,52 @@
+name: Build windows profiler
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+
+jobs:
+  build-windows-profiler-x64:
+    runs-on: windows-2022
+    env:
+      VCPKG_DEFAULT_BINARY_CACHE: ${{ runner.temp }}\vcpkg-bincache
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          submodules: 'true'
+          persist-credentials: false
+      - name: Restore vcpkg binary cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ${{ runner.temp }}\vcpkg-bincache
+          key: vcpkg-windows-x64-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json', 'build/vcpkg_local_ports/**') }}
+          restore-keys: vcpkg-windows-x64-
+      - name: Add MSBuild to PATH
+        uses: microsoft/setup-msbuild@30375c66a4eea26614e0d39710365f22f8b0af57 # v3
+      - name: Build profiler (Release x64)
+        run: |
+          New-Item -ItemType Directory -Force -Path $env:VCPKG_DEFAULT_BINARY_CACHE | Out-Null
+          vcpkg integrate install
+          msbuild profiler\src\ProfilerEngine\Datadog.Profiler.Native.Windows\Datadog.Profiler.Native.Windows.vcxproj /p:Configuration=Release /p:Platform=x64 /p:VcpkgEnableManifest=true /m /v:m
+      - name: Verify DLL exports match the .def
+        run: |
+          $vs = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -products '*' -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath
+          $ver = (Get-Content "$vs\VC\Auxiliary\Build\Microsoft.VCToolsVersion.default.txt").Trim()
+          $exports = & "$vs\VC\Tools\MSVC\$ver\bin\Hostx64\x64\dumpbin.exe" /EXPORTS profiler\_build\bin\Release-x64\profiler\src\ProfilerEngine\Datadog.Profiler.Native.Windows\Pyroscope.Profiler.Native.dll | Out-String
+          $missing = Select-String -Path profiler\src\ProfilerEngine\Datadog.Profiler.Native.Windows\Datadog.Profiler.Native.def -Pattern '^\s*(\w+)\s+PRIVATE' |
+            ForEach-Object { $_.Matches[0].Groups[1].Value } |
+            Where-Object { $exports -notmatch "\b$([regex]::Escape($_))\b" }
+          if ($missing) { throw "exports missing from the DLL: $missing" }
+      - name: Upload artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: pyroscope-profiler-windows-x64
+          path: |
+            profiler/_build/bin/Release-x64/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/Pyroscope.Profiler.Native.dll
+            profiler/_build/bin/Release-x64/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/Pyroscope.Profiler.Native.pdb
+          if-no-files-found: error

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -34,9 +34,6 @@ jobs:
           if ($p.ExitCode -notin 0, 3010) { throw "VS setup modify failed (exit $($p.ExitCode))" }
           $atl = Get-ChildItem "$vs\VC\Tools\MSVC\14.4*\atlmfc\include\atlbase.h" -ErrorAction SilentlyContinue
           if (-not $atl) { throw "v143 ATL still missing after modify" }
-          # EXPERIMENT (temporary): does the VS2026 installer install SDK 19041 from .vsconfig?
-          $sdkViaVs = Test-Path "${env:ProgramFiles(x86)}\Windows Kits\10\Include\10.0.19041.0\um\windows.h"
-          Write-Host "::notice::EXPERIMENT SDK 10.0.19041 present after .vsconfig modify (before choco) = $sdkViaVs"
           choco install windows-sdk-10-version-2004-all -y --no-progress
           if (-not (Test-Path "${env:ProgramFiles(x86)}\Windows Kits\10\Include\10.0.19041.0\um\windows.h")) { throw "SDK 10.0.19041 still missing after install" }
       - name: Restore vcpkg binary cache

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -20,18 +20,23 @@ jobs:
           persist-credentials: false
       # The vcxprojs pin the upstream toolchain (v143 + SDK 10.0.19041). The
       # windows-2025 (VS2026) image ships the v143 compilers but neither v143
-      # ATL nor that SDK.
+      # ATL nor that SDK. ATL is added via the VS installer using the checked-in
+      # build/windows.vsconfig component list; SDK 10.0.19041 is no longer in the
+      # VS2026 installer catalog, so it comes from the standalone installer.
       - name: Install v143 ATL + Windows SDK 10.0.19041
         run: |
           $installer = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer"
           $vs = & "$installer\vswhere.exe" -latest -products '*' -property installationPath
           $p = Start-Process -FilePath "$installer\setup.exe" -Wait -PassThru -ArgumentList `
             'modify', '--installPath', "`"$vs`"", `
-            '--add', 'Microsoft.VisualStudio.Component.VC.14.44.17.14.ATL', `
+            '--config', "`"$env:GITHUB_WORKSPACE\build\windows.vsconfig`"", `
             '--quiet', '--norestart', '--noUpdateInstaller'
           if ($p.ExitCode -notin 0, 3010) { throw "VS setup modify failed (exit $($p.ExitCode))" }
           $atl = Get-ChildItem "$vs\VC\Tools\MSVC\14.4*\atlmfc\include\atlbase.h" -ErrorAction SilentlyContinue
           if (-not $atl) { throw "v143 ATL still missing after modify" }
+          # EXPERIMENT (temporary): does the VS2026 installer install SDK 19041 from .vsconfig?
+          $sdkViaVs = Test-Path "${env:ProgramFiles(x86)}\Windows Kits\10\Include\10.0.19041.0\um\windows.h"
+          Write-Host "::notice::EXPERIMENT SDK 10.0.19041 present after .vsconfig modify (before choco) = $sdkViaVs"
           choco install windows-sdk-10-version-2004-all -y --no-progress
           if (-not (Test-Path "${env:ProgramFiles(x86)}\Windows Kits\10\Include\10.0.19041.0\um\windows.h")) { throw "SDK 10.0.19041 still missing after install" }
       - name: Restore vcpkg binary cache

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
+    branches: [main]
 
 permissions:
   contents: read

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,4 +1,4 @@
-name: Build windows profiler
+name: Windows
 
 on:
   push:

--- a/IntegrationTest/run-windows.ps1
+++ b/IntegrationTest/run-windows.ps1
@@ -1,0 +1,70 @@
+# Runs the rideshare app under the locally built Windows profiler, against the
+# on-box Pyroscope (WSL2 Docker; see the win-dev-vm README in deployment_tools).
+# Builds the app + managed helper from this working tree, so everything tested
+# is current. Usage (on the dev VM):
+#   C:\dev\pyroscope-dotnet\IntegrationTest\run-windows.ps1 [-Framework net8.0]
+param(
+  [string]$Framework = "net8.0",
+  [string]$ServiceName = "rideshare.dotnet.win.dev",
+  [int]$Port = 5000
+)
+$ErrorActionPreference = "Stop"
+$repo = Split-Path -Parent $PSScriptRoot
+
+$profilerDll = Join-Path $repo "profiler\_build\bin\Release-x64\profiler\src\ProfilerEngine\Datadog.Profiler.Native.Windows\Pyroscope.Profiler.Native.dll"
+if (-not (Test-Path $profilerDll)) {
+  throw "Profiler DLL not found at $profilerDll - build it first (MSBuild command in the win-dev-vm README)."
+}
+
+# Ensure the on-box Pyroscope is serving; start (or create) the container in
+# WSL2 Docker if not. The keeper holds the WSL VM for this session's lifetime.
+# NOTE: probing native commands emit stderr we expect ("no such container");
+# under ErrorActionPreference=Stop, redirected stderr becomes a TERMINATING
+# NativeCommandError (PS 5.1), so relax it for this block only.
+$wsl = "C:\Program Files\WSL\wsl.exe"
+$ErrorActionPreference = "Continue"
+$ready = curl.exe -s -m 3 http://127.0.0.1:4040/ready 2>$null
+if ($ready -ne "ready") {
+  Write-Host ">> Starting Pyroscope in WSL2 Docker..."
+  Start-Process -WindowStyle Hidden $wsl -ArgumentList "-d", "Ubuntu-26.04", "-u", "root", "--", "sleep", "infinity"
+  Start-Sleep 3
+  & $wsl -d Ubuntu-26.04 -u root -- docker start pyroscope 2>$null | Out-Null
+  if ($LASTEXITCODE -ne 0) {
+    # Same pinned image setup-wsl.ps1 pre-pulls (and the integration tests use),
+    # so this works without pulling.
+    & $wsl -d Ubuntu-26.04 -u root -- docker run -d --restart unless-stopped --name pyroscope -p 4040:4040 "grafana/pyroscope@sha256:0ad897bb457228c7d1133ce7004f83052e635be9daf4a7cc90364317637e9754"
+    if ($LASTEXITCODE -ne 0) { Write-Warning "docker run failed - is WSL2 set up? (C:\wsl\setup-wsl.ps1)" }
+  }
+  $deadline = (Get-Date).AddSeconds(90)
+  do {
+    $ready = curl.exe -s -m 3 http://127.0.0.1:4040/ready 2>$null
+    if ($ready -eq "ready") { break }
+    Start-Sleep 5
+  } while ((Get-Date) -lt $deadline)
+  if ($ready -ne "ready") {
+    Write-Warning "Pyroscope not reachable at 127.0.0.1:4040 - uploads will fail. On a NESTED_VIRT=0 instance use the reverse-tunnel fallback (README)."
+  }
+}
+$ErrorActionPreference = "Stop"
+
+Write-Host ">> Publishing rideshare ($Framework)..."
+$out = Join-Path $PSScriptRoot "bin\win-run\$Framework"
+dotnet publish $PSScriptRoot -c Release --framework $Framework --runtime win-x64 --no-self-contained -o $out
+if ($LASTEXITCODE -ne 0) { throw "dotnet publish failed" }
+
+$env:CORECLR_ENABLE_PROFILING = "1"
+$env:CORECLR_PROFILER = "{BD1A650D-AC5D-4896-B64F-D6FA25D6B26A}"
+$env:CORECLR_PROFILER_PATH = $profilerDll
+$env:PYROSCOPE_SERVER_ADDRESS = "http://127.0.0.1:4040"
+$env:PYROSCOPE_APPLICATION_NAME = $ServiceName
+$env:PYROSCOPE_PROFILING_ENABLED = "1"
+$env:PYROSCOPE_PROFILING_ALLOCATION_ENABLED = "true"
+$env:PYROSCOPE_PROFILING_CONTENTION_ENABLED = "true"
+$env:PYROSCOPE_PROFILING_EXCEPTION_ENABLED = "true"
+$env:ASPNETCORE_URLS = "http://localhost:$Port"
+
+Write-Host ""
+Write-Host ">> Running rideshare as '$ServiceName' on http://localhost:$Port (/bike /scooter /car ...)"
+Write-Host ">> Profiles: http://127.0.0.1:4040 on this box; from your machine: ssh -L 4040:localhost:4040 <instance-id>"
+Write-Host ""
+& (Join-Path $out "rideshare.exe")

--- a/IntegrationTest/run-windows.ps1
+++ b/IntegrationTest/run-windows.ps1
@@ -1,7 +1,7 @@
-# Runs the rideshare app under the locally built Windows profiler, against the
-# on-box Pyroscope (WSL2 Docker; see the win-dev-vm README in deployment_tools).
+# Runs the rideshare app under a locally built Windows profiler, against an
+# on-box Pyroscope (WSL2 Docker).
 # Builds the app + managed helper from this working tree, so everything tested
-# is current. Usage (on the dev VM):
+# is current. Usage (on a dev VM):
 #   C:\dev\pyroscope-dotnet\IntegrationTest\run-windows.ps1 [-Framework net8.0]
 param(
   [string]$Framework = "net8.0",
@@ -11,9 +11,12 @@ param(
 $ErrorActionPreference = "Stop"
 $repo = Split-Path -Parent $PSScriptRoot
 
+# The profiler needs to be built for the next command to succeed. Something like this should do the trick:
+# MSBuild.exe $repo\profiler\src\ProfilerEngine\Datadog.Profiler.Native.Windows\Datadog.Profiler.Native.Windows.vcxproj /p:Configuration=Release /p:Platform=x64 /p:VcpkgEnableManifest=true /m /v:m
+
 $profilerDll = Join-Path $repo "profiler\_build\bin\Release-x64\profiler\src\ProfilerEngine\Datadog.Profiler.Native.Windows\Pyroscope.Profiler.Native.dll"
 if (-not (Test-Path $profilerDll)) {
-  throw "Profiler DLL not found at $profilerDll - build it first (MSBuild command in the win-dev-vm README)."
+  throw "Profiler DLL not found at $profilerDll - build it first (MSBuild)."
 }
 
 # Ensure the on-box Pyroscope is serving; start (or create) the container in

--- a/build/windows.vsconfig
+++ b/build/windows.vsconfig
@@ -1,7 +1,6 @@
 {
   "version": "1.0",
   "components": [
-    "Microsoft.VisualStudio.Component.VC.14.44.17.14.ATL",
-    "Microsoft.VisualStudio.Component.Windows10SDK.19041"
+    "Microsoft.VisualStudio.Component.VC.14.44.17.14.ATL"
   ]
 }

--- a/build/windows.vsconfig
+++ b/build/windows.vsconfig
@@ -1,0 +1,7 @@
+{
+  "version": "1.0",
+  "components": [
+    "Microsoft.VisualStudio.Component.VC.14.44.17.14.ATL",
+    "Microsoft.VisualStudio.Component.Windows10SDK.19041"
+  ]
+}

--- a/integration-test/dockertest/dockertest.go
+++ b/integration-test/dockertest/dockertest.go
@@ -5,11 +5,48 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"os"
 	"os/exec"
 	"strings"
 	"testing"
 	"time"
 )
+
+// dockerCommand is how the docker CLI is invoked. Overridable because on
+// Windows runners the daemon lives inside WSL2, e.g.
+// DOCKERTEST_DOCKER_COMMAND="wsl -d Ubuntu -u root -- docker".
+var dockerCommand = func() []string {
+	if v := os.Getenv("DOCKERTEST_DOCKER_COMMAND"); v != "" {
+		return strings.Fields(v)
+	}
+	return []string{"docker"}
+}()
+
+// hostAddr is the address published container ports are reached at. With the
+// daemon in WSL2, "localhost" can resolve to ::1, which the WSL port relay
+// does not always serve; DOCKERTEST_HOST_IP=127.0.0.1 pins IPv4.
+var hostAddr = func() string {
+	if v := os.Getenv("DOCKERTEST_HOST_IP"); v != "" {
+		return v
+	}
+	return "localhost"
+}()
+
+func dockerArgs(args ...string) (string, []string) {
+	full := append(append([]string{}, dockerCommand[1:]...), args...)
+	return dockerCommand[0], full
+}
+
+func runDocker(t *testing.T, args ...string) string {
+	t.Helper()
+	name, full := dockerArgs(args...)
+	return run(t, name, full...)
+}
+
+func runDockerQuiet(args ...string) {
+	name, full := dockerArgs(args...)
+	runQuiet(name, full...)
+}
 
 type Network struct {
 	Name string
@@ -56,8 +93,8 @@ func WaitForPort(port string, timeout time.Duration) *WaitStrategy {
 func CreateNetwork(t *testing.T) *Network {
 	t.Helper()
 	name := fmt.Sprintf("test-%d", time.Now().UnixNano())
-	run(t, "docker", "network", "create", name)
-	t.Cleanup(func() { runQuiet("docker", "network", "rm", name) })
+	runDocker(t, "network", "create", name)
+	t.Cleanup(func() { runDockerQuiet("network", "rm", name) })
 	return &Network{Name: name}
 }
 
@@ -86,19 +123,21 @@ func StartContainer(t *testing.T, req ContainerRequest) *Container {
 	args = append(args, req.Image)
 	args = append(args, req.Cmd...)
 
-	id := strings.TrimSpace(run(t, "docker", args...))
+	id := strings.TrimSpace(runDocker(t, args...))
 	c := &Container{ID: id}
 	t.Cleanup(func() {
 		if t.Failed() {
-			if out, err := exec.Command("docker", "inspect", c.ID, "--format",
-				"ExitCode={{.State.ExitCode}} OOMKilled={{.State.OOMKilled}} Running={{.State.Running}}").CombinedOutput(); err == nil {
+			name, full := dockerArgs("inspect", c.ID, "--format",
+				"ExitCode={{.State.ExitCode}} OOMKilled={{.State.OOMKilled}} Running={{.State.Running}}")
+			if out, err := exec.Command(name, full...).CombinedOutput(); err == nil {
 				t.Logf("dockertest: container %s state: %s", c.ID[:12], out)
 			}
-			if logs, err := exec.Command("docker", "logs", "--tail", "50", c.ID).CombinedOutput(); err == nil {
+			name, full = dockerArgs("logs", "--tail", "50", c.ID)
+			if logs, err := exec.Command(name, full...).CombinedOutput(); err == nil {
 				t.Logf("dockertest: container %s logs:\n%s", c.ID[:12], logs)
 			}
 		}
-		runQuiet("docker", "rm", "-f", c.ID)
+		runDockerQuiet("rm", "-f", c.ID)
 	})
 
 	for _, f := range req.Files {
@@ -115,7 +154,7 @@ func StartContainer(t *testing.T, req ContainerRequest) *Container {
 
 func (c *Container) MappedPort(t *testing.T, containerPort string) string {
 	t.Helper()
-	output := run(t, "docker", "port", c.ID, normalizePort(containerPort))
+	output := runDocker(t, "port", c.ID, normalizePort(containerPort))
 	line := strings.TrimSpace(strings.Split(output, "\n")[0])
 	_, hostPort, err := net.SplitHostPort(line)
 	if err != nil {
@@ -130,13 +169,13 @@ func (c *Container) MappedPort(t *testing.T, containerPort string) string {
 
 func (c *Container) HostPort(t *testing.T, containerPort string) string {
 	t.Helper()
-	return "localhost:" + c.MappedPort(t, containerPort)
+	return hostAddr + ":" + c.MappedPort(t, containerPort)
 }
 
 func (c *Container) Exec(t *testing.T, cmd []string) string {
 	t.Helper()
 	args := append([]string{"exec", c.ID}, cmd...)
-	return run(t, "docker", args...)
+	return runDocker(t, args...)
 }
 
 type BuildRequest struct {
@@ -163,13 +202,13 @@ func BuildImage(t *testing.T, req BuildRequest) string {
 		args = append(args, "--build-arg", k+"="+v)
 	}
 	args = append(args, req.Context)
-	run(t, "docker", args...)
+	runDocker(t, args...)
 	return req.Tag
 }
 
 func BridgeGatewayIP(t *testing.T) string {
 	t.Helper()
-	output := run(t, "docker", "network", "inspect", "bridge",
+	output := runDocker(t, "network", "inspect", "bridge",
 		"--format", `{{(index .IPAM.Config 0).Gateway}}`)
 	ip := strings.TrimSpace(output)
 	if ip == "" {
@@ -208,8 +247,9 @@ func copyFile(t *testing.T, containerID string, f ContainerFile) {
 	if err != nil {
 		t.Fatalf("dockertest: reading file for %s: %v", f.ContainerPath, err)
 	}
-	cmd := exec.Command("docker", "exec", "-i", containerID,
+	name, full := dockerArgs("exec", "-i", containerID,
 		"sh", "-c", fmt.Sprintf("cat > '%s'", f.ContainerPath))
+	cmd := exec.Command(name, full...)
 	cmd.Stdin = strings.NewReader(string(content))
 	var stderr strings.Builder
 	cmd.Stderr = &stderr
@@ -222,7 +262,7 @@ func waitReady(t *testing.T, c *Container, ws *WaitStrategy) {
 	t.Helper()
 	deadline := time.Now().Add(ws.timeout)
 	hostPort := c.MappedPort(t, ws.port)
-	addr := "localhost:" + hostPort
+	addr := hostAddr + ":" + hostPort
 
 	for time.Now().Before(deadline) {
 		switch ws.typ {

--- a/integration-test/hostapp.go
+++ b/integration-test/hostapp.go
@@ -41,12 +41,8 @@ func windowsProfilerDir(t *testing.T) string {
 	if err != nil {
 		t.Fatalf("%s: %v", windowsProfilerDirEnv, err)
 	}
-	// Without the protobuf DLLs beside the profiler the CLR fails the load
-	// and silently skips attach — no log, no error, just no profiles.
-	for _, f := range []string{"Pyroscope.Profiler.Native.dll", "libprotobuf.dll", "libprotobuf-lite.dll"} {
-		if _, err := os.Stat(filepath.Join(abs, f)); err != nil {
-			t.Fatalf("%s does not contain %s: %v", windowsProfilerDirEnv, f, err)
-		}
+	if _, err := os.Stat(filepath.Join(abs, "Pyroscope.Profiler.Native.dll")); err != nil {
+		t.Fatalf("%s does not contain the profiler: %v", windowsProfilerDirEnv, err)
 	}
 	return abs
 }

--- a/integration-test/hostapp.go
+++ b/integration-test/hostapp.go
@@ -1,0 +1,299 @@
+package integrationtest
+
+// Windows backend: the Pyroscope server still runs in the same pinned Linux
+// container (in WSL2 Docker — see the DOCKERTEST_DOCKER_COMMAND override in
+// dockertest), but the profiled app runs as a Windows host process, which is
+// the point of the Windows tests. The profiler binaries are prebuilt and
+// located via WINDOWS_PROFILER_DIR (in CI: the build job's artifact).
+
+import (
+	"archive/zip"
+	"bytes"
+	"fmt"
+	"io"
+	"maps"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+const (
+	windowsProfilerDirEnv = "WINDOWS_PROFILER_DIR"
+	profilerCLSID         = "{BD1A650D-AC5D-4896-B64F-D6FA25D6B26A}"
+	otelProfilerCLSID     = "{918728DD-259F-4A6A-AC2B-B85E1B658318}"
+	// Keep in sync with integration-test-with-otel.Dockerfile.
+	otelAutoVersion = "1.14.1"
+)
+
+func windowsProfilerDir(t *testing.T) string {
+	t.Helper()
+	dir := os.Getenv(windowsProfilerDirEnv)
+	if dir == "" {
+		t.Fatalf("%s is not set; point it at a directory containing the built Windows profiler", windowsProfilerDirEnv)
+	}
+	abs, err := filepath.Abs(dir)
+	if err != nil {
+		t.Fatalf("%s: %v", windowsProfilerDirEnv, err)
+	}
+	// Without the protobuf DLLs beside the profiler the CLR fails the load
+	// and silently skips attach — no log, no error, just no profiles.
+	for _, f := range []string{"Pyroscope.Profiler.Native.dll", "libprotobuf.dll", "libprotobuf-lite.dll"} {
+		if _, err := os.Stat(filepath.Join(abs, f)); err != nil {
+			t.Fatalf("%s does not contain %s: %v", windowsProfilerDirEnv, f, err)
+		}
+	}
+	return abs
+}
+
+// publishRideshare publishes the IntegrationTest app for the given .NET
+// version, once per version per test process.
+type publishResult struct {
+	once sync.Once
+	dir  string
+	err  error
+}
+
+var publishes sync.Map
+
+func publishRideshare(t *testing.T, version string) string {
+	t.Helper()
+	val, _ := publishes.LoadOrStore(version, &publishResult{})
+	pr := val.(*publishResult)
+	pr.once.Do(func() {
+		// A dedicated output dir: .NET 10+ cleans the output dir before
+		// compiling, so it must not be the source dir.
+		out := filepath.Join(repoRoot(), "IntegrationTest", "bin", "integration-win", version)
+		cmd := exec.Command("dotnet", "publish", filepath.Join(repoRoot(), "IntegrationTest"),
+			"--framework", "net"+version, "-c", "Release",
+			"--runtime", "win-x64", "--no-self-contained", "-o", out)
+		if output, err := cmd.CombinedOutput(); err != nil {
+			pr.err = fmt.Errorf("dotnet publish (net%s) failed: %w\n%s", version, err, output)
+			return
+		}
+		pr.dir = out
+	})
+	if pr.err != nil {
+		t.Fatal(pr.err)
+	}
+	return pr.dir
+}
+
+// ensureOTelAuto downloads and extracts the OpenTelemetry .NET automatic
+// instrumentation for Windows, once per test process. The WithOTEL tests use
+// it to occupy the classic profiler slot so Pyroscope attaches through the
+// notification-profiler mechanism.
+var otelAuto publishResult
+
+func ensureOTelAutoHome(t *testing.T) string {
+	t.Helper()
+	otelAuto.once.Do(func() {
+		home := filepath.Join(repoRoot(), "IntegrationTest", "bin", "otel-dotnet-auto")
+		marker := filepath.Join(home, "win-x64", "OpenTelemetry.AutoInstrumentation.Native.dll")
+		if _, err := os.Stat(marker); err == nil {
+			otelAuto.dir = home
+			return
+		}
+		url := fmt.Sprintf("https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/download/v%s/opentelemetry-dotnet-instrumentation-windows.zip", otelAutoVersion)
+		zipPath := home + ".zip"
+		if err := downloadFile(url, zipPath); err != nil {
+			otelAuto.err = err
+			return
+		}
+		if err := unzip(zipPath, home); err != nil {
+			otelAuto.err = err
+			return
+		}
+		if _, err := os.Stat(marker); err != nil {
+			otelAuto.err = fmt.Errorf("otel auto instrumentation extracted but %s is missing", marker)
+			return
+		}
+		otelAuto.dir = home
+	})
+	if otelAuto.err != nil {
+		t.Fatal(otelAuto.err)
+	}
+	return otelAuto.dir
+}
+
+func downloadFile(url, dest string) error {
+	if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
+		return err
+	}
+	resp, err := http.Get(url)
+	if err != nil {
+		return fmt.Errorf("downloading %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("downloading %s: HTTP %d", url, resp.StatusCode)
+	}
+	f, err := os.Create(dest)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	_, err = io.Copy(f, resp.Body)
+	return err
+}
+
+func unzip(src, dest string) error {
+	r, err := zip.OpenReader(src)
+	if err != nil {
+		return err
+	}
+	defer r.Close()
+	for _, f := range r.File {
+		path := filepath.Join(dest, f.Name)
+		if !strings.HasPrefix(path, filepath.Clean(dest)+string(os.PathSeparator)) {
+			return fmt.Errorf("zip entry escapes destination: %s", f.Name)
+		}
+		if f.FileInfo().IsDir() {
+			if err := os.MkdirAll(path, 0o755); err != nil {
+				return err
+			}
+			continue
+		}
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			return err
+		}
+		rc, err := f.Open()
+		if err != nil {
+			return err
+		}
+		out, err := os.Create(path)
+		if err != nil {
+			rc.Close()
+			return err
+		}
+		_, err = io.Copy(out, rc)
+		rc.Close()
+		out.Close()
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func freePort(t *testing.T) int {
+	t.Helper()
+	ln, err := net.Listen("tcp4", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("allocating port: %v", err)
+	}
+	port := ln.Addr().(*net.TCPAddr).Port
+	_ = ln.Close()
+	return port
+}
+
+// startHostApp runs the published rideshare app as a host process under the
+// prebuilt Windows profiler and waits for /healthz. Mirrors the env baked
+// into integration-test.Dockerfile (and its -with-otel variant).
+func startHostApp(t *testing.T, version string, otel bool, svcName, serverAddress string, extraEnv map[string]string) string {
+	t.Helper()
+	profDir := windowsProfilerDir(t)
+	profilerDLL := filepath.Join(profDir, "Pyroscope.Profiler.Native.dll")
+	exeDir := publishRideshare(t, version)
+	port := freePort(t)
+
+	env := map[string]string{
+		"REGION":                                 "us-east",
+		"PYROSCOPE_APPLICATION_NAME":             svcName,
+		"PYROSCOPE_SERVER_ADDRESS":               serverAddress,
+		"DD_TRACE_DEBUG":                         "true",
+		"PYROSCOPE_LOG_LEVEL":                    "debug",
+		"PYROSCOPE_PROFILING_ENABLED":            "1",
+		"PYROSCOPE_PROFILING_ALLOCATION_ENABLED": "true",
+		"PYROSCOPE_PROFILING_CONTENTION_ENABLED": "true",
+		"PYROSCOPE_PROFILING_EXCEPTION_ENABLED":  "true",
+		"PYROSCOPE_PROFILING_HEAP_ENABLED":       "true",
+		"ASPNETCORE_URLS":                        fmt.Sprintf("http://127.0.0.1:%d", port),
+	}
+	if otel {
+		home := ensureOTelAutoHome(t)
+		env["OTEL_DOTNET_AUTO_HOME"] = home
+		env["CORECLR_ENABLE_PROFILING"] = "1"
+		env["CORECLR_PROFILER"] = otelProfilerCLSID
+		env["CORECLR_PROFILER_PATH"] = filepath.Join(home, "win-x64", "OpenTelemetry.AutoInstrumentation.Native.dll")
+		env["DOTNET_ADDITIONAL_DEPS"] = filepath.Join(home, "AdditionalDeps")
+		env["DOTNET_SHARED_STORE"] = filepath.Join(home, "store")
+		env["DOTNET_STARTUP_HOOKS"] = filepath.Join(home, "net", "OpenTelemetry.AutoInstrumentation.StartupHook.dll")
+		env["OTEL_TRACES_EXPORTER"] = "none"
+		env["OTEL_METRICS_EXPORTER"] = "none"
+		env["OTEL_LOGS_EXPORTER"] = "none"
+		env["CORECLR_ENABLE_NOTIFICATION_PROFILERS"] = "1"
+		// Trailing semicolon required for .NET 9+; see dotnet/runtime#126197.
+		env["CORECLR_NOTIFICATION_PROFILERS"] = profilerDLL + "=" + profilerCLSID + ";"
+	} else {
+		env["CORECLR_ENABLE_PROFILING"] = "1"
+		env["CORECLR_PROFILER"] = profilerCLSID
+		env["CORECLR_PROFILER_PATH"] = profilerDLL
+	}
+	maps.Copy(env, extraEnv)
+
+	cmd := exec.Command(filepath.Join(exeDir, "rideshare.exe"))
+	cmd.Dir = exeDir
+	cmd.Env = os.Environ()
+	for k, v := range env {
+		cmd.Env = append(cmd.Env, k+"="+v)
+	}
+	var output syncBuffer
+	cmd.Stdout = &output
+	cmd.Stderr = &output
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("starting rideshare.exe: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		_, _ = cmd.Process.Wait()
+		if t.Failed() {
+			t.Logf("rideshare output (tail):\n%s", tailLines(output.String(), 60))
+		}
+	})
+
+	baseURL := fmt.Sprintf("http://127.0.0.1:%d", port)
+	deadline := time.Now().Add(120 * time.Second)
+	client := &http.Client{Timeout: 2 * time.Second}
+	for time.Now().Before(deadline) {
+		if resp, err := client.Get(baseURL + "/healthz"); err == nil {
+			_ = resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				return baseURL
+			}
+		}
+		time.Sleep(time.Second)
+	}
+	t.Fatalf("rideshare.exe did not become healthy; output (tail):\n%s", tailLines(output.String(), 60))
+	return ""
+}
+
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *syncBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *syncBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
+func tailLines(s string, n int) string {
+	lines := strings.Split(s, "\n")
+	if len(lines) > n {
+		lines = lines[len(lines)-n:]
+	}
+	return strings.Join(lines, "\n")
+}

--- a/integration-test/integration_test.go
+++ b/integration-test/integration_test.go
@@ -511,6 +511,14 @@ func startAppForTLSTest(t *testing.T, libcType, version, serverAddress string, c
 }
 
 func runTLSProfileUploadTest(t *testing.T, libcType, version string) {
+	if runtime.GOOS == "windows" {
+		// Only the Linux build defines CPPHTTPLIB_OPENSSL_SUPPORT
+		// (Datadog.Profiler.Native.Linux/CMakeLists.txt), so the Windows
+		// profiler cannot upload over HTTPS yet. Public-preview blocker,
+		// tracked in the work-state; unskip once the Windows build links
+		// OpenSSL.
+		t.Skip("HTTPS upload not yet supported in the Windows build")
+	}
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 

--- a/integration-test/integration_test.go
+++ b/integration-test/integration_test.go
@@ -247,6 +247,26 @@ func TestRideshareProfilesWithOTEL(t *testing.T) {
 	runRideshareProfileTest(t, envLibcType(), envDotnetVersion(), true)
 }
 
+// postOK posts to url, tolerating transient transport errors: on busy
+// runners the loopback connection can be reset under load (keep-alive reuse
+// races, accept-backlog RSTs). The toggle tests assert the app survives
+// toggling, not that every TCP connection does.
+func postOK(t *testing.T, client *http.Client, url string) *http.Response {
+	t.Helper()
+	var resp *http.Response
+	var err error
+	for attempt := 0; attempt < 3; attempt++ {
+		resp, err = client.Post(url, "text/plain", nil)
+		if err == nil {
+			return resp
+		}
+		t.Logf("POST %s failed (attempt %d): %v", url, attempt+1, err)
+		time.Sleep(2 * time.Second)
+	}
+	t.Fatalf("POST %s: %v", url, err)
+	return nil
+}
+
 func TestDynamicCpuToggleDoesNotCrash(t *testing.T) {
 	net := dockertest.CreateNetwork(t)
 
@@ -270,8 +290,7 @@ func TestDynamicCpuToggleDoesNotCrash(t *testing.T) {
 	enableURL := appBaseURL + "/profiling?cpu=true"
 
 	for i := 0; i < 3; i++ {
-		resp, err := client.Post(disableURL, "text/plain", nil)
-		require.NoError(t, err)
+		resp := postOK(t, client, disableURL)
 		_, _ = io.ReadAll(resp.Body)
 		_ = resp.Body.Close()
 		require.Equal(t, http.StatusOK, resp.StatusCode)
@@ -283,8 +302,7 @@ func TestDynamicCpuToggleDoesNotCrash(t *testing.T) {
 			require.Equal(t, http.StatusOK, loadResp.StatusCode)
 		}
 
-		resp, err = client.Post(enableURL, "text/plain", nil)
-		require.NoError(t, err)
+		resp = postOK(t, client, enableURL)
 		_, _ = io.ReadAll(resp.Body)
 		_ = resp.Body.Close()
 		require.Equal(t, http.StatusOK, resp.StatusCode)
@@ -316,8 +334,7 @@ func TestDynamicCpuProfilingToggleAffectsProfileData(t *testing.T) {
 	})
 	client := &http.Client{Timeout: 30 * time.Second}
 
-	disableResp, err := client.Post(appBaseURL+"/profiling?cpu=false", "text/plain", nil)
-	require.NoError(t, err)
+	disableResp := postOK(t, client, appBaseURL+"/profiling?cpu=false")
 	require.Equal(t, http.StatusOK, disableResp.StatusCode)
 	_ = disableResp.Body.Close()
 
@@ -342,8 +359,7 @@ func TestDynamicCpuProfilingToggleAffectsProfileData(t *testing.T) {
 		return collapsed != ""
 	}, 45*time.Second, 5*time.Second, "expected no CPU profile data while CPU profiling is disabled")
 
-	enableResp, err := client.Post(appBaseURL+"/profiling?cpu=true", "text/plain", nil)
-	require.NoError(t, err)
+	enableResp := postOK(t, client, appBaseURL+"/profiling?cpu=true")
 	require.Equal(t, http.StatusOK, enableResp.StatusCode)
 	_ = enableResp.Body.Close()
 

--- a/integration-test/integration_test.go
+++ b/integration-test/integration_test.go
@@ -15,6 +15,7 @@ import (
 	"math/big"
 	"net"
 	"net/http"
+	"os"
 	"path/filepath"
 
 	"regexp"
@@ -61,12 +62,14 @@ func buildAppImage(t *testing.T, libcType, version string, otel bool) string {
 	return tag
 }
 
-func startAppWithEnv(t *testing.T, net *dockertest.Network, libcType, version string, otel bool, extraEnv map[string]string) string {
+func startAppWithEnv(t *testing.T, net *dockertest.Network, pyroscopeURL, libcType, version string, otel bool, extraEnv map[string]string) string {
 	t.Helper()
+	svcName := rideshareServiceName(libcType, version, otel)
+	if runtime.GOOS == "windows" {
+		return startHostApp(t, version, otel, svcName, pyroscopeURL, extraEnv)
+	}
 	ensureProfilerImage(t, libcType)
 	image := buildAppImage(t, libcType, version, otel)
-
-	svcName := rideshareServiceName(libcType, version, otel)
 	env := map[string]string{
 		"REGION":                     "us-east",
 		"PYROSCOPE_APPLICATION_NAME": svcName,
@@ -88,9 +91,9 @@ func startAppWithEnv(t *testing.T, net *dockertest.Network, libcType, version st
 	return fmt.Sprintf("http://%s", c.HostPort(t, "5000/tcp"))
 }
 
-func startApp(t *testing.T, net *dockertest.Network, libcType, version string, otel bool) string {
+func startApp(t *testing.T, net *dockertest.Network, pyroscopeURL, libcType, version string, otel bool) string {
 	t.Helper()
-	return startAppWithEnv(t, net, libcType, version, otel, nil)
+	return startAppWithEnv(t, net, pyroscopeURL, libcType, version, otel, nil)
 }
 
 // runLoadGenerator cycles through /bike, /scooter, /car requests in a goroutine
@@ -187,7 +190,7 @@ func runRideshareProfileTest(t *testing.T, libcType, version string, otel bool) 
 	net := dockertest.CreateNetwork(t)
 
 	pyroscopeURL := startPyroscope(t, net)
-	appBaseURL := startApp(t, net, libcType, version, otel)
+	appBaseURL := startApp(t, net, pyroscopeURL, libcType, version, otel)
 	runLoadGenerator(ctx, t, appBaseURL)
 
 	svcName := rideshareServiceName(libcType, version, otel)
@@ -247,8 +250,8 @@ func TestRideshareProfilesWithOTEL(t *testing.T) {
 func TestDynamicCpuToggleDoesNotCrash(t *testing.T) {
 	net := dockertest.CreateNetwork(t)
 
-	_ = startPyroscope(t, net)
-	appBaseURL := startAppWithEnv(t, net, envLibcType(), envDotnetVersion(), false, map[string]string{
+	pyroscopeURL := startPyroscope(t, net)
+	appBaseURL := startAppWithEnv(t, net, pyroscopeURL, envLibcType(), envDotnetVersion(), false, map[string]string{
 		"PYROSCOPE_PROFILING_ENABLED":            "true",
 		"PYROSCOPE_PROFILING_CPU_ENABLED":        "true",
 		"PYROSCOPE_PROFILING_WALLTIME_ENABLED":   "true",
@@ -302,7 +305,7 @@ func TestDynamicCpuProfilingToggleAffectsProfileData(t *testing.T) {
 
 	pyroscopeURL := startPyroscope(t, net)
 	appName := fmt.Sprintf("rideshare.dynamic-cpu-toggle.%d", time.Now().UnixNano())
-	appBaseURL := startAppWithEnv(t, net, envLibcType(), envDotnetVersion(), false, map[string]string{
+	appBaseURL := startAppWithEnv(t, net, pyroscopeURL, envLibcType(), envDotnetVersion(), false, map[string]string{
 		"PYROSCOPE_APPLICATION_NAME":             appName,
 		"PYROSCOPE_PROFILING_ENABLED":            "true",
 		"PYROSCOPE_PROFILING_CPU_ENABLED":        "true",
@@ -461,6 +464,18 @@ func hostDockerInternalExtraHost(t *testing.T) string {
 
 func startAppForTLSTest(t *testing.T, libcType, version, serverAddress string, caCertPEM []byte) string {
 	t.Helper()
+	if runtime.GOOS == "windows" {
+		caPath := filepath.Join(t.TempDir(), "ca.crt")
+		if err := os.WriteFile(caPath, caCertPEM, 0o644); err != nil {
+			t.Fatalf("writing CA cert: %v", err)
+		}
+		// SSL_CERT_FILE steers OpenSSL-based exporters to the test CA. If the
+		// Windows exporter turns out to use schannel instead, this test will
+		// say so and the CA needs to go into the machine store instead.
+		return startHostApp(t, version, false, "tls-test-app", serverAddress, map[string]string{
+			"SSL_CERT_FILE": caPath,
+		})
+	}
 	ensureProfilerImage(t, libcType)
 	image := buildAppImage(t, libcType, version, false)
 
@@ -499,7 +514,11 @@ func runTLSProfileUploadTest(t *testing.T, libcType, version string) {
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
-	const hostname = "host.docker.internal"
+	hostname := "host.docker.internal"
+	if runtime.GOOS == "windows" {
+		// The app is a host process; it reaches the in-test receiver directly.
+		hostname = "127.0.0.1"
+	}
 	port, caCertPEM, received := startTLSProfileReceiver(t, hostname)
 	serverAddress := fmt.Sprintf("https://%s:%d", hostname, port)
 

--- a/integration-test/matrix.go
+++ b/integration-test/matrix.go
@@ -17,7 +17,14 @@ func envOrDefault(key, defaultValue string) string {
 	return defaultValue
 }
 
-func envLibcType() string      { return envOrDefault("LIBC_TYPE", "glibc") }
+func envLibcType() string {
+	def := "glibc"
+	if runtime.GOOS == "windows" {
+		// No libc axis on Windows; the value only feeds service names.
+		def = "win"
+	}
+	return envOrDefault("LIBC_TYPE", def)
+}
 func envDotnetVersion() string { return envOrDefault("DOTNET_VERSION", "10.0") }
 
 func sdkImageSuffix(libcType, version string) string {

--- a/integration-test/profile_stacktrace_test.go
+++ b/integration-test/profile_stacktrace_test.go
@@ -184,7 +184,7 @@ func TestAllocationTypeLeafProfileStacktraces(t *testing.T) {
 	net := dockertest.CreateNetwork(t)
 	pyroscopeURL := startPyroscope(t, net)
 	appName := fmt.Sprintf("rideshare.alloc-leaf-test.%d", time.Now().UnixNano())
-	appBaseURL := startAppWithEnv(t, net, envLibcType(), envDotnetVersion(), false, map[string]string{
+	appBaseURL := startAppWithEnv(t, net, pyroscopeURL, envLibcType(), envDotnetVersion(), false, map[string]string{
 		"PYROSCOPE_APPLICATION_NAME":             appName,
 		"PYROSCOPE_PROFILING_ENABLED":            "true",
 		"PYROSCOPE_PROFILING_ALLOCATION_ENABLED": "true",

--- a/integration-test/profile_stacktrace_test.go
+++ b/integration-test/profile_stacktrace_test.go
@@ -153,7 +153,7 @@ func TestAllocationProfileStacktraces(t *testing.T) {
 	net := dockertest.CreateNetwork(t)
 	pyroscopeURL := startPyroscope(t, net)
 	appName := fmt.Sprintf("rideshare.alloc-test.%d", time.Now().UnixNano())
-	appBaseURL := startAppWithEnv(t, net, envLibcType(), envDotnetVersion(), false, map[string]string{
+	appBaseURL := startAppWithEnv(t, net, pyroscopeURL, envLibcType(), envDotnetVersion(), false, map[string]string{
 		"PYROSCOPE_APPLICATION_NAME":             appName,
 		"PYROSCOPE_PROFILING_ENABLED":            "true",
 		"PYROSCOPE_PROFILING_ALLOCATION_ENABLED": "true",
@@ -220,7 +220,7 @@ func TestExceptionProfileStacktraces(t *testing.T) {
 	net := dockertest.CreateNetwork(t)
 	pyroscopeURL := startPyroscope(t, net)
 	appName := fmt.Sprintf("rideshare.exception-test.%d", time.Now().UnixNano())
-	appBaseURL := startAppWithEnv(t, net, envLibcType(), envDotnetVersion(), false, map[string]string{
+	appBaseURL := startAppWithEnv(t, net, pyroscopeURL, envLibcType(), envDotnetVersion(), false, map[string]string{
 		"PYROSCOPE_APPLICATION_NAME":            appName,
 		"PYROSCOPE_PROFILING_ENABLED":           "true",
 		"PYROSCOPE_PROFILING_EXCEPTION_ENABLED": "true",
@@ -250,7 +250,7 @@ func TestLockProfileStacktraces(t *testing.T) {
 	net := dockertest.CreateNetwork(t)
 	pyroscopeURL := startPyroscope(t, net)
 	appName := fmt.Sprintf("rideshare.lock-test.%d", time.Now().UnixNano())
-	appBaseURL := startAppWithEnv(t, net, envLibcType(), envDotnetVersion(), false, map[string]string{
+	appBaseURL := startAppWithEnv(t, net, pyroscopeURL, envLibcType(), envDotnetVersion(), false, map[string]string{
 		"PYROSCOPE_APPLICATION_NAME":             appName,
 		"PYROSCOPE_PROFILING_ENABLED":            "true",
 		"PYROSCOPE_PROFILING_CONTENTION_ENABLED": "true",


### PR DESCRIPTION
Adds windows.yml: build, and integration tests for the Windows profiler, mirroring the Linux setup.

Build - Release x64 of Pyroscope.Profiler.Native.dll on windows-2025 via MSBuild + vcpkg manifest.

- the windows-2025 (VS2026) image ships the v143 compilers but not v143 ATL or SDK 10.0.19041, so the workflow installs both per run (~11 min); the vcxprojs stay byte-identical to upstream
- vcpkg binary caching keyed on the manifests (cold build ~15-20 min, warm ~2-3 min)
- triggers: push to main + PRs targeting main (matches the Linux workflows)

Integration tests - the existing Go suite runs on Windows unchanged: same tests, same assertions, same pinned Pyroscope image.

- discover + one job per test × .NET 8.0/9.0/10.0 (24 jobs), like the Linux matrix
- the server runs in the pinned Linux image inside WSL2 Docker (DOCKERTEST_DOCKER_COMMAND routes the docker CLI through wsl; DOCKERTEST_HOST_IP=127.0.0.1 because localhost can resolve to ::1, which the WSL relay doesn't serve)
- the profiled app runs as a Windows host process built from the repo (dotnet publish of IntegrationTest/ + the local managed helper), using the build job's artifact via WINDOWS_PROFILER_DIR
- WithOTEL works through the notification-profiler mechanism (CORECLR_NOTIFICATION_PROFILERS), with OTel auto-instrumentation downloaded into the classic slot
- TestTLSProfileUpload is skipped on Windows: the test found that the Windows build compiles cpp-httplib without CPPHTTPLIB_OPENSSL_SUPPORT, so HTTPS upload doesn't work yet - follow-up before the public preview
- the full Linux matrix was [run](https://github.com/grafana/pyroscope-dotnet/actions/runs/27422356082) once against this branch to confirm the harness refactor changes nothing there (all green)