### PR TITLE
feat(windows): support HTTPS profile uploads

### DIFF
--- a/integration-test/hostapp.go
+++ b/integration-test/hostapp.go
@@ -249,7 +249,13 @@ func startHostApp(t *testing.T, version string, otel bool, svcName, serverAddres
 		_ = cmd.Process.Kill()
 		_, _ = cmd.Process.Wait()
 		if t.Failed() {
-			t.Logf("rideshare output (tail):\n%s", tailLines(output.String(), 60))
+			full := output.String()
+			// The load generator floods stdout with request logs; surface the
+			// profiler's own sink/upload lines separately so they aren't lost.
+			if sink := profilerLines(full); sink != "" {
+				t.Logf("rideshare profiler lines:\n%s", sink)
+			}
+			t.Logf("rideshare output (tail):\n%s", tailLines(full, 60))
 		}
 	})
 
@@ -284,6 +290,21 @@ func (b *syncBuffer) String() string {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	return b.buf.String()
+}
+
+// profilerLines returns the lines of native-profiler output that concern the
+// upload sink or TLS, filtering out the app's own request logging.
+func profilerLines(s string) string {
+	var b strings.Builder
+	for _, ln := range strings.Split(s, "\n") {
+		if strings.Contains(ln, "PyroscopePprofSink") ||
+			strings.Contains(ln, "SSL") ||
+			strings.Contains(ln, "ssl") {
+			b.WriteString(ln)
+			b.WriteByte('\n')
+		}
+	}
+	return b.String()
 }
 
 func tailLines(s string, n int) string {

--- a/integration-test/integration_test.go
+++ b/integration-test/integration_test.go
@@ -414,11 +414,18 @@ func generateTestCerts(t *testing.T, hostname string) (caCertPEM, serverCertPEM,
 	serverTemplate := &x509.Certificate{
 		SerialNumber: big.NewInt(2),
 		Subject:      pkix.Name{CommonName: hostname},
-		DNSNames:     []string{hostname},
 		NotBefore:    time.Now().Add(-time.Minute),
 		NotAfter:     time.Now().Add(24 * time.Hour),
 		KeyUsage:     x509.KeyUsageDigitalSignature,
 		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	}
+	// An IP literal (Windows uses 127.0.0.1) must be in the IP SAN; a DNS name
+	// (Linux uses host.docker.internal) in the DNS SAN. OpenSSL/cpp-httplib
+	// verify the two differently.
+	if ip := net.ParseIP(hostname); ip != nil {
+		serverTemplate.IPAddresses = []net.IP{ip}
+	} else {
+		serverTemplate.DNSNames = []string{hostname}
 	}
 	serverDER, err := x509.CreateCertificate(rand.Reader, serverTemplate, caCert, &serverKey.PublicKey, caKey)
 	require.NoError(t, err)
@@ -481,13 +488,12 @@ func hostDockerInternalExtraHost(t *testing.T) string {
 func startAppForTLSTest(t *testing.T, libcType, version, serverAddress string, caCertPEM []byte) string {
 	t.Helper()
 	if runtime.GOOS == "windows" {
+		// The profiler honors SSL_CERT_FILE for a custom CA (see
+		// PyroscopePprofSink); point it at the test CA.
 		caPath := filepath.Join(t.TempDir(), "ca.crt")
 		if err := os.WriteFile(caPath, caCertPEM, 0o644); err != nil {
 			t.Fatalf("writing CA cert: %v", err)
 		}
-		// SSL_CERT_FILE steers OpenSSL-based exporters to the test CA. If the
-		// Windows exporter turns out to use schannel instead, this test will
-		// say so and the CA needs to go into the machine store instead.
 		return startHostApp(t, version, false, "tls-test-app", serverAddress, map[string]string{
 			"SSL_CERT_FILE": caPath,
 		})
@@ -527,14 +533,6 @@ func startAppForTLSTest(t *testing.T, libcType, version, serverAddress string, c
 }
 
 func runTLSProfileUploadTest(t *testing.T, libcType, version string) {
-	if runtime.GOOS == "windows" {
-		// Only the Linux build defines CPPHTTPLIB_OPENSSL_SUPPORT
-		// (Datadog.Profiler.Native.Linux/CMakeLists.txt), so the Windows
-		// profiler cannot upload over HTTPS yet. Public-preview blocker,
-		// tracked in the work-state; unskip once the Windows build links
-		// OpenSSL.
-		t.Skip("HTTPS upload not yet supported in the Windows build")
-	}
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 

--- a/profiler/Directory.Build.props
+++ b/profiler/Directory.Build.props
@@ -211,6 +211,12 @@
     <ItemDefinitionGroup Condition=" '$(MSBuildProjectExtension)' == '.vcxproj' ">
       <ClCompile>
         <PreprocessorDefinitions>%(PreprocessorDefinitions);MICROSOFT_WINDOWS_WINBASE_H_DEFINE_INTERLOCKED_CPLUSPLUS_OVERLOADS=1</PreprocessorDefinitions>
+        <!-- PYROSCOPE_WINDOWS_NOTE: enable cpp-httplib's OpenSSL/TLS support (the Linux build sets
+             this in Datadog.Profiler.Native.Linux/CMakeLists.txt). Set globally so every TU that
+             includes httplib.h agrees on the layout - the header is header-only, so a per-project
+             mismatch would be an ODR/ABI bug. OpenSSL comes from vcpkg (see vcpkg.json). On
+             Windows cpp-httplib loads CA roots from the system cert store automatically. -->
+        <PreprocessorDefinitions>%(PreprocessorDefinitions);CPPHTTPLIB_OPENSSL_SUPPORT</PreprocessorDefinitions>
         <!-- PYROSCOPE_WINDOWS_NOTE: force-include winsock2.h before anything else. httplib.h (cpp-httplib)
              needs winsock2, and <windows.h> auto-includes winsock v1 unless winsock2 has set _WINSOCKAPI_
              first. WIN32_LEAN_AND_MEAN is the usual workaround but breaks <atlbase.h>. Force-include is

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/PyroscopePprofSink.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/PyroscopePprofSink.cpp
@@ -9,6 +9,8 @@
 #include "nlohmann/json.hpp"
 #include "gen/push/v1/push.pb.h"
 #include "gen/types/v1/types.pb.h"
+#include "shared/src/native-src/string.h"
+#include "shared/src/native-src/util.h"
 
 namespace
 {
@@ -42,6 +44,18 @@ PyroscopePprofSink::PyroscopePprofSink(
 {
     _client.set_connection_timeout(10);
     _client.set_read_timeout(10);
+
+    // Honor SSL_CERT_FILE for a custom/private CA. OpenSSL consults it via the
+    // default verify paths only on Unix (cpp-httplib's load_system_certs takes
+    // the Windows cert-store branch and never calls SSL_CTX_set_default_verify_paths),
+    // so wire it explicitly here for parity. Setting a CA path also makes
+    // cpp-httplib verify with OpenSSL alone, skipping its extra Windows Schannel
+    // check that wouldn't know about a privately-trusted CA.
+    auto caCertFile = shared::ToString(shared::GetEnvironmentValue(WStr("SSL_CERT_FILE")));
+    if (!caCertFile.empty())
+    {
+        _client.set_ca_cert_path(caCertFile);
+    }
 
 #ifdef CPPHTTPLIB_OPENSSL_SUPPORT
     // OpenSSL 3.x flags a TLS connection closed without a close_notify alert as a

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/PyroscopePprofSink.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/PyroscopePprofSink.h
@@ -13,7 +13,17 @@
 // every profile upload larger than ~1 KiB fails. Disable the behavior (0 = never)
 // so the body is always sent with the headers.
 #define CPPHTTPLIB_EXPECT_100_THRESHOLD 0
+#ifdef _MSC_VER
+// cpp-httplib's OpenSSL path trips C4996 (sscanf, and the library calling its own
+// [[deprecated]] TLS helpers), which /sdl elevates to errors. Suppress for this
+// third-party header only; our own code keeps the /sdl checks.
+#pragma warning(push)
+#pragma warning(disable : 4996)
+#endif
 #include "httplib.h"
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
 #include "url.hpp"
 
 #define PYROSCOPE_SPY_VERSION "1.2.0" // x-release-please-version

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -9,6 +9,9 @@
         },
         {
             "name": "protobuf"
+        },
+        {
+            "name": "openssl"
         }
     ],
     "overrides": [


### PR DESCRIPTION
Enables the Windows profiler to upload over HTTPS - e.g. to Grafana Cloud Profiles.

## What
 - Build OpenSSL via vcpkg (static, single-DLL preserved) and define `CPPHTTPLIB_OPENSSL_SUPPORT`, matching what the Linux CMake build already does. Without it, `https://` endpoints silently no-op.
- Un-skip `TestTLSProfileUpload` on Windows.

## Validated
- `TestTLSProfileUpload` passes (custom-CA path).
- **Real end-to-end:** profiles from a Windows host upload to Grafana Cloud Profiles and are queryable.

## Known issue

Against Grafana Cloud, each *successful* upload also logs `PyroscopePprofSink err Failed to read connection`: the push is accepted and ingested, but cpp-httplib's OpenSSL read of the *response* fails. Impact is log noise + the client can't see the real HTTP status. Potential fix: `SSL_OP_IGNORE_UNEXPECTED_EOF` on the SSL context.

Edit: This last issue is now fixed with #360 