### PR TITLE
fix: upload large profiles reliably

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/PyroscopePprofSink.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/PyroscopePprofSink.cpp
@@ -43,6 +43,20 @@ PyroscopePprofSink::PyroscopePprofSink(
     _client.set_connection_timeout(10);
     _client.set_read_timeout(10);
 
+#ifdef CPPHTTPLIB_OPENSSL_SUPPORT
+    // OpenSSL 3.x flags a TLS connection closed without a close_notify alert as a
+    // fatal read error (SSL_R_UNEXPECTED_EOF_WHILE_READING) rather than a clean EOF.
+    // When a remote server closes the upload connection that way, every successful
+    // upload still fails to read the response: it logs a spurious "Failed to read
+    // connection" and the real HTTP status is never seen. Treat the unclean shutdown
+    // as a normal end-of-stream. tls_context() returns null for plain-HTTP clients,
+    // so this is a no-op there.
+    if (auto* sslCtx = static_cast<SSL_CTX*>(_client.tls_context()))
+    {
+        SSL_CTX_set_options(sslCtx, SSL_OP_IGNORE_UNEXPECTED_EOF);
+    }
+#endif
+
     _workerThread = std::thread(&PyroscopePprofSink::work, this);
 }
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/PyroscopePprofSink.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/PyroscopePprofSink.h
@@ -7,6 +7,12 @@
 #include "PprofExporter.h"
 
 #include "LockingQueue.h"
+// A remote server might not honor "Expect: 100-continue". cpp-httplib adds that
+// header automatically once a request body reaches its default 1 KiB threshold,
+// then withholds the body waiting for a "100 Continue" that never arrives, so
+// every profile upload larger than ~1 KiB fails. Disable the behavior (0 = never)
+// so the body is always sent with the headers.
+#define CPPHTTPLIB_EXPECT_100_THRESHOLD 0
 #include "httplib.h"
 #include "url.hpp"
 


### PR DESCRIPTION
Since 0.15.0, profile uploads larger than ~1 KiB can fail silently against some HTTP servers/reverse proxies: `process_cpu` (the main flame graph) and other large profiles never arrive, while the profiler logs a stream of `PyroscopePprofSink err Failed to read connection`.

Root cause: `0.15.0` bumped the bundled `cpp-httplib` from `v0.14.1` to `v0.34.0`, which auto-adds `Expect: 100-continue` for any request body >= 1 KiB. Servers/proxies that don't honor it never send `100 Continue`, so the client withholds the body, the exchange stalls, and the response read fails. Related: OpenSSL 3.x reports a TLS connection closed without `close_notify` as a read error rather than a clean EOF.

Fix:
- Disable cpp-httplib's automatic `Expect: 100-continue` (`CPPHTTPLIB_EXPECT_100_THRESHOLD 0`) so the body is always sent with the headers.
- Set `SSL_OP_IGNORE_UNEXPECTED_EOF` so an unclean TLS shutdown is treated as end-of-stream.

Validation
- Before: large uploads fail with `Failed to read connection`; `process_cpu` missing from the ingested data.
- After: all uploads return `200`, all profile types present.
- Version matrix: clean on `0.8.14` through `0.14.0`, broken from `0.15.0` onward, confirming the regression came in with the `cpp-httplib` bump.
- `TestTLSProfileUpload` still passes.

Notes:
- CI doesn't catch this: the integration test pushes to a local Pyroscope server that honors `Expect: 100-continue` and closes cleanly, so it never reproduced the proxy behavior. A test that exercises the no-`100 Continue` / no-`close_notify` path would be a good follow-up.
