### PR TITLE
ci: release signed Windows profiler alongside Linux

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -101,10 +101,130 @@ jobs:
       - name: Publish to nuget.org
         run: dotnet nuget push ./Pyroscope/artifacts/package/release/Pyroscope*.nupkg -k "${{ steps.nuget-login.outputs.NUGET_API_KEY }}" -s https://api.nuget.org/v3/index.json
 
+  build-profiler-windows:
+    permissions:
+      contents: read
+    needs: release-please
+    if: ${{ needs.release-please.outputs.pyroscope_release_created == 'true' }}
+    runs-on: windows-2025
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ needs.release-please.outputs.pyroscope_sha }}
+          submodules: 'true'
+          persist-credentials: false
+      # The vcxprojs pin the upstream toolchain (v143 + SDK 10.0.19041). The
+      # windows-2025 (VS2026) image ships the v143 compilers but neither v143
+      # ATL nor that SDK. ATL is added via the VS installer using the checked-in
+      # build/windows.vsconfig component list; SDK 10.0.19041 is no longer in the
+      # VS2026 installer catalog, so it comes from the standalone installer.
+      - name: Install v143 ATL + Windows SDK 10.0.19041
+        run: |
+          $installer = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer"
+          $vs = & "$installer\vswhere.exe" -latest -products '*' -property installationPath
+          $p = Start-Process -FilePath "$installer\setup.exe" -Wait -PassThru -ArgumentList `
+            'modify', '--installPath', "`"$vs`"", `
+            '--config', "`"$env:GITHUB_WORKSPACE\build\windows.vsconfig`"", `
+            '--quiet', '--norestart', '--noUpdateInstaller'
+          if ($p.ExitCode -notin 0, 3010) { throw "VS setup modify failed (exit $($p.ExitCode))" }
+          $atl = Get-ChildItem "$vs\VC\Tools\MSVC\14.4*\atlmfc\include\atlbase.h" -ErrorAction SilentlyContinue
+          if (-not $atl) { throw "v143 ATL still missing after modify" }
+          choco install windows-sdk-10-version-2004-all -y --no-progress
+          if (-not (Test-Path "${env:ProgramFiles(x86)}\Windows Kits\10\Include\10.0.19041.0\um\windows.h")) { throw "SDK 10.0.19041 still missing after install" }
+      - name: Add MSBuild to PATH
+        uses: microsoft/setup-msbuild@30375c66a4eea26614e0d39710365f22f8b0af57 # v3
+      - name: Build profiler (Release x64)
+        run: |
+          vcpkg integrate install
+          msbuild profiler\src\ProfilerEngine\Datadog.Profiler.Native.Windows\Datadog.Profiler.Native.Windows.vcxproj /p:Configuration=Release /p:Platform=x64 /p:VcpkgEnableManifest=true /m /v:m
+      - name: Stage artifacts
+        run: |
+          $bin = "profiler\_build\bin\Release-x64\profiler\src\ProfilerEngine\Datadog.Profiler.Native.Windows"
+          New-Item -ItemType Directory -Force -Path staging | Out-Null
+          Copy-Item "$bin\Pyroscope.Profiler.Native.dll" staging\
+          Copy-Item "$bin\Pyroscope.Profiler.Native.pdb" staging\
+      - name: Upload unsigned profiler artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: pyroscope-profiler-windows-x64
+          path: staging/
+          if-no-files-found: error
+
+  # Signing runs in its own job with no checkout: it only handles the built
+  # artifact, so the signing credentials are never exposed to repo code. The
+  # azure-trusted-signing environment gates OIDC access to Azure Trusted Signing
+  # (Grafana shared infra); the federated credential restricts it to this repo.
+  sign-profiler-windows:
+    needs: build-profiler-windows
+    runs-on: windows-2025
+    environment:
+      name: azure-trusted-signing
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Fetch Azure Trusted Signing credentials
+        id: get-signing-secrets
+        uses: grafana/shared-workflows/actions/get-vault-secrets@e46fe1e9a2bf9e618bcf8d8d32f3a7381b45c06d # get-vault-secrets/v2.0.0
+        with:
+          repo_secrets: |
+            client-id=azure-trusted-signing:client-id
+            subscription-id=azure-trusted-signing:subscription-id
+            tenant-id=azure-trusted-signing:tenant-id
+      - name: Sign profiler DLL
+        uses: grafana/shared-workflows/actions/azure-trusted-signing@6a042eda14a697e71944976ab618d27104d9fed4 # azure-trusted-signing/v1.0.3
+        with:
+          application-description: 'Pyroscope .NET Profiler'
+          artifact-to-sign: 'pyroscope-profiler-windows-x64'
+          file-filter: 'Pyroscope.Profiler.Native.dll'
+          azure-client-id: ${{ fromJSON(steps.get-signing-secrets.outputs.secrets).client-id }}
+          azure-subscription-id: ${{ fromJSON(steps.get-signing-secrets.outputs.secrets).subscription-id }}
+          azure-tenant-id: ${{ fromJSON(steps.get-signing-secrets.outputs.secrets).tenant-id }}
+          signed-artifact-name: 'pyroscope-profiler-windows-x64-signed'
+      - name: Download signed DLL for verification
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: pyroscope-profiler-windows-x64-signed
+          path: signed
+      - name: Verify Authenticode signature
+        shell: pwsh
+        run: |
+          $sig = Get-AuthenticodeSignature signed\Pyroscope.Profiler.Native.dll
+          Write-Host "Status : $($sig.Status)"
+          Write-Host "Signer : $($sig.SignerCertificate.Subject)"
+          if ($sig.Status -ne 'Valid') { throw "Authenticode status is $($sig.Status): $($sig.StatusMessage)" }
+          $expectedSubject = 'CN=Grafana Labs, O=Grafana Labs, L=New York City, S=New York, C=US'
+          if ($sig.SignerCertificate.Subject -ne $expectedSubject) { throw "Unexpected signer: $($sig.SignerCertificate.Subject)" }
+
+  publish-profiler-windows:
+    permissions:
+      contents: write
+    needs: [release-please, sign-profiler-windows]
+    if: ${{ needs.release-please.outputs.pyroscope_release_created == 'true' }}
+    runs-on: ${{ github.repository_owner == 'grafana' && 'ubuntu-x64-small' || 'ubuntu-latest' }}
+    env:
+      GH_TOKEN: ${{ github.token }}
+      TAG: ${{ needs.release-please.outputs.pyroscope_tag_name }}
+    steps:
+      - name: Download signed Windows profiler
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: pyroscope-profiler-windows-x64-signed
+          path: windows-signed
+      - name: Package and upload Windows profiler to draft release
+        run: |
+          version="${TAG#pyroscope-}"
+          archive="pyroscope.${version}-windows-x64.zip"
+          zip -j "$archive" \
+            windows-signed/Pyroscope.Profiler.Native.dll \
+            windows-signed/Pyroscope.Profiler.Native.pdb
+          gh release upload --clobber "$TAG" "$archive"
+
   publish-pyroscope-release:
     permissions:
       contents: write
-    needs: [release-please, build-profiler, build-managed-helper]
+    needs: [release-please, build-profiler, build-managed-helper, publish-profiler-windows]
     if: ${{ needs.release-please.outputs.pyroscope_release_created == 'true' }}
     runs-on: ${{ github.repository_owner == 'grafana' && 'ubuntu-x64-small' || 'ubuntu-latest' }}
     env:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -99,7 +99,9 @@ jobs:
         with:
           user: Pyroscope
       - name: Publish to nuget.org
-        run: dotnet nuget push ./Pyroscope/artifacts/package/release/Pyroscope*.nupkg -k "${{ steps.nuget-login.outputs.NUGET_API_KEY }}" -s https://api.nuget.org/v3/index.json
+        env:
+          NUGET_API_KEY: ${{ steps.nuget-login.outputs.NUGET_API_KEY }}
+        run: dotnet nuget push ./Pyroscope/artifacts/package/release/Pyroscope*.nupkg -s https://api.nuget.org/v3/index.json
 
   build-profiler-windows:
     permissions:


### PR DESCRIPTION
Wires up signed windows builds into the release process.

Three jobs added to `release-please.yml`:
- `build-profiler-windows` — Release x64 build on `windows-2025`, uploads the DLL+PDB as an unsigned artifact (no vcpkg cache; ~38 min cold).
- `sign-profiler-windows` — signs the DLL via Azure Trusted Signing and verifies the signature, in the `azure-trusted-signing` environment with no checkout so signing credentials never touch repo code.
- `publish-profiler-windows` — packages `pyroscope.<version>-windows-x64.zip` (signed DLL + PDB) and attaches it to the draft release; `publish-pyroscope-release` gates on it.

Tested with a throwaway workflow ([here](https://github.com/grafana/pyroscope-dotnet/actions/runs/27831875386)).
