### PR TITLE
ci: fix nuget publish and windows release upload

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -101,7 +101,7 @@ jobs:
       - name: Publish to nuget.org
         env:
           NUGET_API_KEY: ${{ steps.nuget-login.outputs.NUGET_API_KEY }}
-        run: dotnet nuget push ./Pyroscope/artifacts/package/release/Pyroscope*.nupkg -s https://api.nuget.org/v3/index.json
+        run: dotnet nuget push ./Pyroscope/artifacts/package/release/Pyroscope*.nupkg -k "$NUGET_API_KEY" -s https://api.nuget.org/v3/index.json
 
   build-profiler-windows:
     permissions:
@@ -221,7 +221,7 @@ jobs:
           zip -j "$archive" \
             windows-signed/Pyroscope.Profiler.Native.dll \
             windows-signed/Pyroscope.Profiler.Native.pdb
-          gh release upload --clobber "$TAG" "$archive"
+          gh release upload --clobber "$TAG" "$archive" --repo "$GITHUB_REPOSITORY"
 
   publish-pyroscope-release:
     permissions:


### PR DESCRIPTION
The 1.3.0 release run ([run](https://github.com/grafana/pyroscope-dotnet/actions/runs/27845710111)) failed in two publish steps. Both are isolated plumbing bugs — the Linux/Windows build, sign, and Authenticode verify all passed.

- `build-managed-helper`: `dotnet nuget push` doesn't auto-read `NUGET_API_KEY`, so dropping `-k` (the #365 review suggestion) pushed with no key → 401. Pass it with `-k "$NUGET_API_KEY"`, keeping the key in `env:` rather than interpolated into `run:`.
- `publish-profiler-windows`: the job has no checkout, so `gh release upload` couldn't infer the repo (`not a git repository`). Add `--repo "$GITHUB_REPOSITORY"`.

NuGet 1.3.0 was never published (the push 401'd) and the release stayed a draft, so nothing shipped half-baked. Completing 1.3.0 needs a pipeline re-run after this lands.
