### PR TITLE
ci: build Windows profiler with the runner's native toolchain

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -116,30 +116,52 @@ jobs:
           ref: ${{ needs.release-please.outputs.pyroscope_sha }}
           submodules: 'true'
           persist-credentials: false
-      # The vcxprojs pin the upstream toolchain (v143 + SDK 10.0.19041). The
-      # windows-2025 (VS2026) image ships the v143 compilers but neither v143
-      # ATL nor that SDK. ATL is added via the VS installer using the checked-in
-      # build/windows.vsconfig component list; SDK 10.0.19041 is no longer in the
-      # VS2026 installer catalog, so it comes from the standalone installer.
-      - name: Install v143 ATL + Windows SDK 10.0.19041
-        run: |
-          $installer = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer"
-          $vs = & "$installer\vswhere.exe" -latest -products '*' -property installationPath
-          $p = Start-Process -FilePath "$installer\setup.exe" -Wait -PassThru -ArgumentList `
-            'modify', '--installPath', "`"$vs`"", `
-            '--config', "`"$env:GITHUB_WORKSPACE\build\windows.vsconfig`"", `
-            '--quiet', '--norestart', '--noUpdateInstaller'
-          if ($p.ExitCode -notin 0, 3010) { throw "VS setup modify failed (exit $($p.ExitCode))" }
-          $atl = Get-ChildItem "$vs\VC\Tools\MSVC\14.4*\atlmfc\include\atlbase.h" -ErrorAction SilentlyContinue
-          if (-not $atl) { throw "v143 ATL still missing after modify" }
-          choco install windows-sdk-10-version-2004-all -y --no-progress
-          if (-not (Test-Path "${env:ProgramFiles(x86)}\Windows Kits\10\Include\10.0.19041.0\um\windows.h")) { throw "SDK 10.0.19041 still missing after install" }
+      - name: Restore vcpkg binary cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ${{ runner.temp }}\vcpkg-bincache
+          key: vcpkg-windows-x64-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json', 'build/vcpkg_local_ports/**', 'build/vcpkg_triplets/**') }}
+          restore-keys: vcpkg-windows-x64-
       - name: Add MSBuild to PATH
         uses: microsoft/setup-msbuild@30375c66a4eea26614e0d39710365f22f8b0af57 # v3
-      - name: Build profiler (Release x64)
+      # The vcxprojs pin v143 + SDK 10.0.19041, but the windows-2025 image (now
+      # VS2026) ships neither: installing them at runtime cost ~12 min. Instead
+      # build with the newest toolset + SDK the image actually ships, detected
+      # here and overridden via /p: so the upstream vcxprojs stay untouched.
+      # VCPKG_TOOLSET_OVERRIDE makes vcpkg build the static deps with the same
+      # toolset we link against (see build/vcpkg_triplets/x64-windows-static.cmake).
+      # The vcpkg cache (key shared with the Windows CI workflow) restores the
+      # openssl + protobuf builds; a miss just rebuilds them from source.
+      - name: Detect native toolset + SDK
+        shell: pwsh
         run: |
+          $installer = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer"
+          $vs = & "$installer\vswhere.exe" -latest -products * -property installationPath
+          $toolset = Get-ChildItem "$vs\MSBuild\Microsoft\VC" -Directory -Filter 'v*' -ErrorAction SilentlyContinue |
+            ForEach-Object { Get-ChildItem (Join-Path $_.FullName 'Platforms\x64\PlatformToolsets') -Directory -ErrorAction SilentlyContinue } |
+            Select-Object -ExpandProperty Name | Where-Object { $_ -match '^v\d+$' } | Sort-Object -Unique |
+            Sort-Object { [int]$_.Substring(1) } -Descending | Select-Object -First 1
+          if (-not $toolset) { throw "No MSVC PlatformToolset found" }
+          $sdk = Get-ChildItem "${env:ProgramFiles(x86)}\Windows Kits\10\Include" -Directory -ErrorAction SilentlyContinue |
+            Where-Object { Test-Path "$($_.FullName)\um\windows.h" } |
+            Select-Object -ExpandProperty Name | Sort-Object -Descending | Select-Object -First 1
+          if (-not $sdk) { throw "No Windows SDK found" }
+          Write-Host "Building with PlatformToolset=$toolset  WindowsTargetPlatformVersion=$sdk"
+          "WIN_TOOLSET=$toolset"            | Out-File -Append -Encoding utf8 $env:GITHUB_ENV
+          "WIN_SDK=$sdk"                    | Out-File -Append -Encoding utf8 $env:GITHUB_ENV
+          "VCPKG_TOOLSET_OVERRIDE=$toolset" | Out-File -Append -Encoding utf8 $env:GITHUB_ENV
+      - name: Build profiler (Release x64)
+        shell: pwsh
+        env:
+          VCPKG_DEFAULT_BINARY_CACHE: ${{ runner.temp }}\vcpkg-bincache
+        run: |
+          New-Item -ItemType Directory -Force -Path $env:VCPKG_DEFAULT_BINARY_CACHE | Out-Null
           vcpkg integrate install
-          msbuild profiler\src\ProfilerEngine\Datadog.Profiler.Native.Windows\Datadog.Profiler.Native.Windows.vcxproj /p:Configuration=Release /p:Platform=x64 /p:VcpkgEnableManifest=true /m /v:m
+          msbuild profiler\src\ProfilerEngine\Datadog.Profiler.Native.Windows\Datadog.Profiler.Native.Windows.vcxproj `
+            /p:Configuration=Release /p:Platform=x64 /p:VcpkgEnableManifest=true `
+            /p:PlatformToolset=$env:WIN_TOOLSET `
+            /p:WindowsTargetPlatformVersion=$env:WIN_SDK `
+            /m /v:m
       - name: Stage artifacts
         run: |
           $bin = "profiler\_build\bin\Release-x64\profiler\src\ProfilerEngine\Datadog.Profiler.Native.Windows"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -116,22 +116,12 @@ jobs:
           ref: ${{ needs.release-please.outputs.pyroscope_sha }}
           submodules: 'true'
           persist-credentials: false
-      - name: Restore vcpkg binary cache
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: ${{ runner.temp }}\vcpkg-bincache
-          key: vcpkg-windows-x64-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json', 'build/vcpkg_local_ports/**', 'build/vcpkg_triplets/**') }}
-          restore-keys: vcpkg-windows-x64-
-      - name: Add MSBuild to PATH
-        uses: microsoft/setup-msbuild@30375c66a4eea26614e0d39710365f22f8b0af57 # v3
       # The vcxprojs pin v143 + SDK 10.0.19041, but the windows-2025 image (now
       # VS2026) ships neither: installing them at runtime cost ~12 min. Instead
       # build with the newest toolset + SDK the image actually ships, detected
       # here and overridden via /p: so the upstream vcxprojs stay untouched.
       # VCPKG_TOOLSET_OVERRIDE makes vcpkg build the static deps with the same
       # toolset we link against (see build/vcpkg_triplets/x64-windows-static.cmake).
-      # The vcpkg cache (key shared with the Windows CI workflow) restores the
-      # openssl + protobuf builds; a miss just rebuilds them from source.
       - name: Detect native toolset + SDK
         shell: pwsh
         run: |
@@ -142,14 +132,31 @@ jobs:
             Select-Object -ExpandProperty Name | Where-Object { $_ -match '^v\d+$' } | Sort-Object -Unique |
             Sort-Object { [int]$_.Substring(1) } -Descending | Select-Object -First 1
           if (-not $toolset) { throw "No MSVC PlatformToolset found" }
+          $msvc = Get-ChildItem "$vs\VC\Tools\MSVC" -Directory -ErrorAction SilentlyContinue |
+            Select-Object -ExpandProperty Name | Sort-Object -Descending | Select-Object -First 1
+          if (-not $msvc) { throw "No MSVC toolset version found" }
           $sdk = Get-ChildItem "${env:ProgramFiles(x86)}\Windows Kits\10\Include" -Directory -ErrorAction SilentlyContinue |
             Where-Object { Test-Path "$($_.FullName)\um\windows.h" } |
             Select-Object -ExpandProperty Name | Sort-Object -Descending | Select-Object -First 1
           if (-not $sdk) { throw "No Windows SDK found" }
-          Write-Host "Building with PlatformToolset=$toolset  WindowsTargetPlatformVersion=$sdk"
+          Write-Host "Building with PlatformToolset=$toolset  MSVC=$msvc  WindowsTargetPlatformVersion=$sdk"
           "WIN_TOOLSET=$toolset"            | Out-File -Append -Encoding utf8 $env:GITHUB_ENV
+          "WIN_MSVC=$msvc"                  | Out-File -Append -Encoding utf8 $env:GITHUB_ENV
           "WIN_SDK=$sdk"                    | Out-File -Append -Encoding utf8 $env:GITHUB_ENV
           "VCPKG_TOOLSET_OVERRIDE=$toolset" | Out-File -Append -Encoding utf8 $env:GITHUB_ENV
+      # Key shared with the Windows CI workflow. Include the MSVC version:
+      # vcpkg's binary cache is content-addressed by an ABI hash that includes
+      # the compiler, so when the image toolset bumps we want a key miss (which
+      # re-saves) rather than an exact hit on a stale cache that vcpkg then
+      # rebuilds from source on every run. A miss just rebuilds openssl+protobuf.
+      - name: Restore vcpkg binary cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ${{ runner.temp }}\vcpkg-bincache
+          key: vcpkg-windows-x64-${{ env.WIN_MSVC }}-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json', 'build/vcpkg_local_ports/**', 'build/vcpkg_triplets/**') }}
+          restore-keys: vcpkg-windows-x64-${{ env.WIN_MSVC }}-
+      - name: Add MSBuild to PATH
+        uses: microsoft/setup-msbuild@30375c66a4eea26614e0d39710365f22f8b0af57 # v3
       - name: Build profiler (Release x64)
         shell: pwsh
         env:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -19,39 +19,50 @@ jobs:
         with:
           submodules: 'true'
           persist-credentials: false
-      # The vcxprojs pin the upstream toolchain (v143 + SDK 10.0.19041). The
-      # windows-2025 (VS2026) image ships the v143 compilers but neither v143
-      # ATL nor that SDK. ATL is added via the VS installer using the checked-in
-      # build/windows.vsconfig component list; SDK 10.0.19041 is no longer in the
-      # VS2026 installer catalog, so it comes from the standalone installer.
-      - name: Install v143 ATL + Windows SDK 10.0.19041
-        run: |
-          $installer = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer"
-          $vs = & "$installer\vswhere.exe" -latest -products '*' -property installationPath
-          $p = Start-Process -FilePath "$installer\setup.exe" -Wait -PassThru -ArgumentList `
-            'modify', '--installPath', "`"$vs`"", `
-            '--config', "`"$env:GITHUB_WORKSPACE\build\windows.vsconfig`"", `
-            '--quiet', '--norestart', '--noUpdateInstaller'
-          if ($p.ExitCode -notin 0, 3010) { throw "VS setup modify failed (exit $($p.ExitCode))" }
-          $atl = Get-ChildItem "$vs\VC\Tools\MSVC\14.4*\atlmfc\include\atlbase.h" -ErrorAction SilentlyContinue
-          if (-not $atl) { throw "v143 ATL still missing after modify" }
-          choco install windows-sdk-10-version-2004-all -y --no-progress
-          if (-not (Test-Path "${env:ProgramFiles(x86)}\Windows Kits\10\Include\10.0.19041.0\um\windows.h")) { throw "SDK 10.0.19041 still missing after install" }
       - name: Restore vcpkg binary cache
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ${{ runner.temp }}\vcpkg-bincache
-          key: vcpkg-windows-x64-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json', 'build/vcpkg_local_ports/**') }}
+          key: vcpkg-windows-x64-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json', 'build/vcpkg_local_ports/**', 'build/vcpkg_triplets/**') }}
           restore-keys: vcpkg-windows-x64-
       - name: Add MSBuild to PATH
         uses: microsoft/setup-msbuild@30375c66a4eea26614e0d39710365f22f8b0af57 # v3
+      # The vcxprojs pin v143 + SDK 10.0.19041, but the windows-2025 image (now
+      # VS2026) ships neither: installing them at runtime cost ~12 min. Instead
+      # build with the newest toolset + SDK the image actually ships, detected
+      # here and overridden via /p: so the upstream vcxprojs stay untouched.
+      # VCPKG_TOOLSET_OVERRIDE makes vcpkg build the static deps with the same
+      # toolset we link against (see build/vcpkg_triplets/x64-windows-static.cmake).
+      - name: Detect native toolset + SDK
+        shell: pwsh
+        run: |
+          $installer = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer"
+          $vs = & "$installer\vswhere.exe" -latest -products * -property installationPath
+          $toolset = Get-ChildItem "$vs\MSBuild\Microsoft\VC" -Directory -Filter 'v*' -ErrorAction SilentlyContinue |
+            ForEach-Object { Get-ChildItem (Join-Path $_.FullName 'Platforms\x64\PlatformToolsets') -Directory -ErrorAction SilentlyContinue } |
+            Select-Object -ExpandProperty Name | Where-Object { $_ -match '^v\d+$' } | Sort-Object -Unique |
+            Sort-Object { [int]$_.Substring(1) } -Descending | Select-Object -First 1
+          if (-not $toolset) { throw "No MSVC PlatformToolset found" }
+          $sdk = Get-ChildItem "${env:ProgramFiles(x86)}\Windows Kits\10\Include" -Directory -ErrorAction SilentlyContinue |
+            Where-Object { Test-Path "$($_.FullName)\um\windows.h" } |
+            Select-Object -ExpandProperty Name | Sort-Object -Descending | Select-Object -First 1
+          if (-not $sdk) { throw "No Windows SDK found" }
+          Write-Host "Building with PlatformToolset=$toolset  WindowsTargetPlatformVersion=$sdk"
+          "WIN_TOOLSET=$toolset"            | Out-File -Append -Encoding utf8 $env:GITHUB_ENV
+          "WIN_SDK=$sdk"                    | Out-File -Append -Encoding utf8 $env:GITHUB_ENV
+          "VCPKG_TOOLSET_OVERRIDE=$toolset" | Out-File -Append -Encoding utf8 $env:GITHUB_ENV
       - name: Build profiler (Release x64)
+        shell: pwsh
         env:
           VCPKG_DEFAULT_BINARY_CACHE: ${{ runner.temp }}\vcpkg-bincache
         run: |
           New-Item -ItemType Directory -Force -Path $env:VCPKG_DEFAULT_BINARY_CACHE | Out-Null
           vcpkg integrate install
-          msbuild profiler\src\ProfilerEngine\Datadog.Profiler.Native.Windows\Datadog.Profiler.Native.Windows.vcxproj /p:Configuration=Release /p:Platform=x64 /p:VcpkgEnableManifest=true /m /v:m
+          msbuild profiler\src\ProfilerEngine\Datadog.Profiler.Native.Windows\Datadog.Profiler.Native.Windows.vcxproj `
+            /p:Configuration=Release /p:Platform=x64 /p:VcpkgEnableManifest=true `
+            /p:PlatformToolset=$env:WIN_TOOLSET `
+            /p:WindowsTargetPlatformVersion=$env:WIN_SDK `
+            /m /v:m
       - name: Upload artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -19,14 +19,6 @@ jobs:
         with:
           submodules: 'true'
           persist-credentials: false
-      - name: Restore vcpkg binary cache
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: ${{ runner.temp }}\vcpkg-bincache
-          key: vcpkg-windows-x64-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json', 'build/vcpkg_local_ports/**', 'build/vcpkg_triplets/**') }}
-          restore-keys: vcpkg-windows-x64-
-      - name: Add MSBuild to PATH
-        uses: microsoft/setup-msbuild@30375c66a4eea26614e0d39710365f22f8b0af57 # v3
       # The vcxprojs pin v143 + SDK 10.0.19041, but the windows-2025 image (now
       # VS2026) ships neither: installing them at runtime cost ~12 min. Instead
       # build with the newest toolset + SDK the image actually ships, detected
@@ -43,14 +35,30 @@ jobs:
             Select-Object -ExpandProperty Name | Where-Object { $_ -match '^v\d+$' } | Sort-Object -Unique |
             Sort-Object { [int]$_.Substring(1) } -Descending | Select-Object -First 1
           if (-not $toolset) { throw "No MSVC PlatformToolset found" }
+          $msvc = Get-ChildItem "$vs\VC\Tools\MSVC" -Directory -ErrorAction SilentlyContinue |
+            Select-Object -ExpandProperty Name | Sort-Object -Descending | Select-Object -First 1
+          if (-not $msvc) { throw "No MSVC toolset version found" }
           $sdk = Get-ChildItem "${env:ProgramFiles(x86)}\Windows Kits\10\Include" -Directory -ErrorAction SilentlyContinue |
             Where-Object { Test-Path "$($_.FullName)\um\windows.h" } |
             Select-Object -ExpandProperty Name | Sort-Object -Descending | Select-Object -First 1
           if (-not $sdk) { throw "No Windows SDK found" }
-          Write-Host "Building with PlatformToolset=$toolset  WindowsTargetPlatformVersion=$sdk"
+          Write-Host "Building with PlatformToolset=$toolset  MSVC=$msvc  WindowsTargetPlatformVersion=$sdk"
           "WIN_TOOLSET=$toolset"            | Out-File -Append -Encoding utf8 $env:GITHUB_ENV
+          "WIN_MSVC=$msvc"                  | Out-File -Append -Encoding utf8 $env:GITHUB_ENV
           "WIN_SDK=$sdk"                    | Out-File -Append -Encoding utf8 $env:GITHUB_ENV
           "VCPKG_TOOLSET_OVERRIDE=$toolset" | Out-File -Append -Encoding utf8 $env:GITHUB_ENV
+      # Key the cache on the MSVC version: vcpkg's binary cache is content-
+      # addressed by an ABI hash that includes the compiler, so when the image
+      # toolset bumps we want a key miss (which re-saves) rather than an exact
+      # hit on a stale cache that vcpkg then rebuilds from source on every run.
+      - name: Restore vcpkg binary cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ${{ runner.temp }}\vcpkg-bincache
+          key: vcpkg-windows-x64-${{ env.WIN_MSVC }}-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json', 'build/vcpkg_local_ports/**', 'build/vcpkg_triplets/**') }}
+          restore-keys: vcpkg-windows-x64-${{ env.WIN_MSVC }}-
+      - name: Add MSBuild to PATH
+        uses: microsoft/setup-msbuild@30375c66a4eea26614e0d39710365f22f8b0af57 # v3
       - name: Build profiler (Release x64)
         shell: pwsh
         env:

--- a/build/vcpkg_triplets/x64-windows-static.cmake
+++ b/build/vcpkg_triplets/x64-windows-static.cmake
@@ -1,9 +1,14 @@
 # Overlay for the builtin x64-windows-static triplet that pins the toolset.
-# Without the pin, vcpkg builds ports with the newest MSVC it finds; on hosts
-# with a newer VS (e.g. GitHub's windows-2025/VS2026 image) the static
-# protobuf objects then reference STL helpers (__std_rotate) that the v143
-# STL we link against does not export.
+# vcpkg must build the static deps (openssl, protobuf) with the SAME toolset we
+# link the profiler with, or the static objects reference STL helpers (e.g.
+# __std_rotate) the link toolset's STL may not export. CI builds with whatever
+# toolset the runner image ships and passes it here via VCPKG_TOOLSET_OVERRIDE;
+# unset, we fall back to v143 (the upstream vcxproj pin).
 set(VCPKG_TARGET_ARCHITECTURE x64)
 set(VCPKG_CRT_LINKAGE static)
 set(VCPKG_LIBRARY_LINKAGE static)
-set(VCPKG_PLATFORM_TOOLSET v143)
+if(DEFINED ENV{VCPKG_TOOLSET_OVERRIDE} AND NOT "$ENV{VCPKG_TOOLSET_OVERRIDE}" STREQUAL "")
+    set(VCPKG_PLATFORM_TOOLSET "$ENV{VCPKG_TOOLSET_OVERRIDE}")
+else()
+    set(VCPKG_PLATFORM_TOOLSET v143)
+endif()

--- a/build/windows.vsconfig
+++ b/build/windows.vsconfig
@@ -1,6 +1,0 @@
-{
-  "version": "1.0",
-  "components": [
-    "Microsoft.VisualStudio.Component.VC.14.44.17.14.ATL"
-  ]
-}


### PR DESCRIPTION
The no-cache Windows profiler release build takes **~33 min**, vs ~7-8 min for the Linux builds. Two costs dominate, and neither is the actual profiler compile (~4.5 min, similar to Linux):

- **~12 min** installing v143 ATL + Windows SDK 10.0.19041 at runtime. The vcxprojs pin that toolchain, but the `windows-2025` image ships neither so every build reinstalls them (~9 min VS-installer modify for ATL + ~2.5 min choco for the SDK).
- **~16 min** of vcpkg building openssl + protobuf from source, on every release.

## What this does

- **Build with the toolchain the image actually ships**, detected at runtime (currently `v145` + SDK `10.0.26100`) and applied via `/p:PlatformToolset` / `/p:WindowsTargetPlatformVersion`. The upstream vcxprojs are left untouched (no merge friction).
- **`VCPKG_TOOLSET_OVERRIDE`** makes vcpkg build the static deps with the same toolset we link against.
- **Re-enable the vcpkg binary cache on releases**, sharing the key with the Windows CI workflow. vcpkg's cache is ABI-addressed, so a restore is equivalent to a from-source build; a miss just rebuilds.
- Remove the now-unused `build/windows.vsconfig`.

## Results

| Build | Before | After |
| --- | --- | --- |
| Release (`release-please.yml`) | ~33 min | ~5-7 min |
| Per-PR / main (`windows.yml`) | ~18 min | ~4.5 min (warm cache) |

## Validation

Proven on a throwaway [workflow](https://github.com/grafana/pyroscope-dotnet/actions/workflows/win-native-test.yml) against the live `windows-2025`/VS2026 image before productionizing here:
- Native build, cold cache: success, ~21 min (no install step; ~16 min was vcpkg from source).
- Native build, warm cache: success, **4m39s** end-to-end.