### PR TITLE
fix(Pyroscope): trigger tracing package release

### DIFF
--- a/Pyroscope/Pyroscope.OpenTelemetry/README.md
+++ b/Pyroscope/Pyroscope.OpenTelemetry/README.md
@@ -6,6 +6,7 @@ See [Link tracing and profiling with Span Profiles](https://grafana.com/docs/pyr
 
 ## Prerequisites
 
+
 - Your .NET application is instrumented with [Pyroscope's profiler](https://grafana.com/docs/pyroscope/latest/configure-client/language-sdks/dotnet/)
 - Your .NET application is instrumented (manually) with [OpenTelemetry](https://opentelemetry.io/docs/instrumentation/net/getting-started/)
 

--- a/Pyroscope/Pyroscope.OpenTracing/README.md
+++ b/Pyroscope/Pyroscope.OpenTracing/README.md
@@ -6,6 +6,7 @@ See [Link tracing and profiling with Span Profiles](https://grafana.com/docs/pyr
 
 ## Prerequisites
 
+
 - Your .NET application is instrumented with [Pyroscope's profiler](https://grafana.com/docs/pyroscope/latest/configure-client/language-sdks/dotnet/)
 - Your .NET application is instrumented with [OpenTracing](https://opentracing.io/guides/csharp/)
 


### PR DESCRIPTION
## Summary
- Trigger a tracing component release after Pyroscope 1.3.0 was published.
- Keep the tracing package changes whitespace-only while ensuring release-please sees changes in both tracing package paths.

## Test plan
- Ran `dotnet build Pyroscope/Pyroscope.OpenTracing/Pyroscope.OpenTracing.csproj --configuration Release`.
- Ran `dotnet build Pyroscope/Pyroscope.OpenTelemetry/Pyroscope.OpenTelemetry.csproj --configuration Release`.
- Inspected generated NuGet metadata and confirmed both tracing packages reference `Pyroscope` 1.3.0.