### PR TITLE
fix(Pyroscope): guard native version mismatch

### DIFF
--- a/Pyroscope/Pyroscope/NativeInterop.cs
+++ b/Pyroscope/Pyroscope/NativeInterop.cs
@@ -17,6 +17,13 @@ namespace Pyroscope
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
+        public static string GetProfilerVersion()
+        {
+            var versionPtr = NativeMethods.GetProfilerVersion();
+            return versionPtr == IntPtr.Zero ? string.Empty : Marshal.PtrToStringAnsi(versionPtr) ?? string.Empty;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
         public static IntPtr GetTraceContextNativePointer()
         {
             return NativeMethods.GetTraceContextNativePointer();
@@ -81,6 +88,9 @@ namespace Pyroscope
         {
             [DllImport(dllName: "Pyroscope.Profiler.Native", EntryPoint = "GetNativeProfilerIsReadyPtr")]
             public static extern IntPtr GetProfilerStatusPointer();
+
+            [DllImport(dllName: "Pyroscope.Profiler.Native", EntryPoint = "GetPyroscopeProfilerVersion")]
+            public static extern IntPtr GetProfilerVersion();
 
             [DllImport(dllName: "Pyroscope.Profiler.Native", EntryPoint = "GetPointerToNativeTraceContext")]
             public static extern IntPtr GetTraceContextNativePointer();

--- a/Pyroscope/Pyroscope/Profiler.cs
+++ b/Pyroscope/Pyroscope/Profiler.cs
@@ -9,8 +9,9 @@ namespace Pyroscope
     {
         private static Profiler? _instance;
 
-        internal Profiler(ContextTracker contextTracker)
+        internal Profiler(ProfilerStatus status, ContextTracker contextTracker)
         {
+            _status = status;
             _contextTracker = contextTracker;
         }
 
@@ -41,7 +42,7 @@ namespace Pyroscope
 
         public void SetDynamicTag(string key, string value)
         {
-            if (_dllNotFound)
+            if (!IsNativeInteropAvailable())
             {
                 return;
             }
@@ -59,7 +60,7 @@ namespace Pyroscope
 
         public void ClearDynamicTags()
         {
-            if (_dllNotFound)
+            if (!IsNativeInteropAvailable())
             {
                 return;
             }
@@ -82,7 +83,7 @@ namespace Pyroscope
         /// configured, this function will have no effect.
         public void SetCPUTrackingEnabled(bool enabled)
         {
-            if (_dllNotFound)
+            if (!IsNativeInteropAvailable())
             {
                 return;
             }
@@ -104,7 +105,7 @@ namespace Pyroscope
         /// If allocation profiling is not configured, this function will have no effect.
         public void SetAllocationTrackingEnabled(bool enabled)
         {
-            if (_dllNotFound)
+            if (!IsNativeInteropAvailable())
             {
                 return;
             }
@@ -126,7 +127,7 @@ namespace Pyroscope
         /// If contention profiling is not configured, this function will have no effect.
         public void SetContentionTrackingEnabled(bool enabled)
         {
-            if (_dllNotFound)
+            if (!IsNativeInteropAvailable())
             {
                 return;
             }
@@ -148,7 +149,7 @@ namespace Pyroscope
         /// If exception profiling is not configured, this function will have no effect.
         public void SetExceptionTrackingEnabled(bool enabled)
         {
-            if (_dllNotFound)
+            if (!IsNativeInteropAvailable())
             {
                 return;
             }
@@ -166,7 +167,7 @@ namespace Pyroscope
 
         public void SetAuthToken(string authToken)
         {
-            if (_dllNotFound)
+            if (!IsNativeInteropAvailable())
             {
                 return;
             }
@@ -184,7 +185,7 @@ namespace Pyroscope
 
         public void SetBasicAuth(string username, string password)
         {
-            if (_dllNotFound)
+            if (!IsNativeInteropAvailable())
             {
                 return;
             }
@@ -207,13 +208,19 @@ namespace Pyroscope
         }
 
         private readonly ContextTracker _contextTracker;
+        private readonly ProfilerStatus _status;
         private bool _dllNotFound;
 
         private static Profiler Create()
         {
             var status = new ProfilerStatus();
             var contextTracker = new ContextTracker(status);
-            return new Profiler(contextTracker);
+            return new Profiler(status, contextTracker);
+        }
+
+        private bool IsNativeInteropAvailable()
+        {
+            return !_dllNotFound && _status.IsNativeVersionCompatible;
         }
     }
 }

--- a/Pyroscope/Pyroscope/ProfilerStatus.cs
+++ b/Pyroscope/Pyroscope/ProfilerStatus.cs
@@ -13,6 +13,7 @@ namespace Pyroscope
         private readonly bool _isProfilingEnabled;
         private readonly object _lockObj;
         private bool _isInitialized;
+        private bool _isNativeVersionCompatible;
         private IntPtr _engineStatusPtr;
 
         public ProfilerStatus()
@@ -28,6 +29,16 @@ namespace Pyroscope
 
             _lockObj = new object();
             _isInitialized = false;
+            _isNativeVersionCompatible = false;
+        }
+
+        public bool IsNativeVersionCompatible
+        {
+            get
+            {
+                EnsureNativeIsInitialized();
+                return _isNativeVersionCompatible;
+            }
         }
 
         public bool IsProfilerReady
@@ -40,7 +51,7 @@ namespace Pyroscope
                 }
 
                 EnsureNativeIsInitialized();
-                return _engineStatusPtr != IntPtr.Zero && Marshal.ReadByte(_engineStatusPtr) != 0;
+                return _isNativeVersionCompatible && _engineStatusPtr != IntPtr.Zero && Marshal.ReadByte(_engineStatusPtr) != 0;
             }
         }
 
@@ -62,11 +73,22 @@ namespace Pyroscope
 
                 try
                 {
+                    var managedVersion = ProfilerVersion.ManagedVersion;
+                    var nativeVersion = NativeInterop.GetProfilerVersion();
+                    if (!ProfilerVersion.IsCompatible(managedVersion, nativeVersion))
+                    {
+                        _isNativeVersionCompatible = false;
+                        _engineStatusPtr = IntPtr.Zero;
+                        return;
+                    }
+
+                    _isNativeVersionCompatible = true;
                     _engineStatusPtr = NativeInterop.GetProfilerStatusPointer();
                 }
                 catch (Exception ex)
                 {
                     Console.WriteLine($"[ProfilerStatus] Failed to get profiler status pointer: {ex.Message}");
+                    _isNativeVersionCompatible = false;
                     _engineStatusPtr = IntPtr.Zero;
                 }
             }

--- a/Pyroscope/Pyroscope/ProfilerVersion.cs
+++ b/Pyroscope/Pyroscope/ProfilerVersion.cs
@@ -1,0 +1,26 @@
+using System.Reflection;
+
+namespace Pyroscope
+{
+    internal static class ProfilerVersion
+    {
+        public static string ManagedVersion
+        {
+            get
+            {
+                var informationalVersion = typeof(ProfilerVersion).Assembly
+                    .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?
+                    .InformationalVersion;
+
+                return informationalVersion ?? string.Empty;
+            }
+        }
+
+        public static bool IsCompatible(string managedVersion, string nativeVersion)
+        {
+            return !string.IsNullOrEmpty(managedVersion) &&
+                   !string.IsNullOrEmpty(nativeVersion) &&
+                   string.Equals(managedVersion, nativeVersion, StringComparison.Ordinal);
+        }
+    }
+}

--- a/Pyroscope/Pyroscope/ProfilerVersion.cs
+++ b/Pyroscope/Pyroscope/ProfilerVersion.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+using System;
 
 namespace Pyroscope
 {
@@ -8,19 +8,18 @@ namespace Pyroscope
         {
             get
             {
-                var informationalVersion = typeof(ProfilerVersion).Assembly
-                    .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?
-                    .InformationalVersion;
+                var version = typeof(ProfilerVersion).Assembly.GetName().Version;
 
-                return informationalVersion ?? string.Empty;
+                return version?.ToString(version.Build >= 0 ? 3 : 2) ?? string.Empty;
             }
         }
 
         public static bool IsCompatible(string managedVersion, string nativeVersion)
         {
-            return !string.IsNullOrEmpty(managedVersion) &&
-                   !string.IsNullOrEmpty(nativeVersion) &&
-                   string.Equals(managedVersion, nativeVersion, StringComparison.Ordinal);
+            return Version.TryParse(managedVersion, out var parsedManagedVersion) &&
+                   Version.TryParse(nativeVersion, out var parsedNativeVersion) &&
+                   parsedManagedVersion.Major == parsedNativeVersion.Major &&
+                   parsedManagedVersion.Minor == parsedNativeVersion.Minor;
         }
     }
 }

--- a/Pyroscope/Pyroscope/Pyroscope.csproj
+++ b/Pyroscope/Pyroscope/Pyroscope.csproj
@@ -2,10 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>net8.0</TargetFramework>
-        <PackageVersion>1.3.0</PackageVersion>
-        <AssemblyVersion>1.3.0</AssemblyVersion>
-        <FileVersion>1.3.0</FileVersion>
-        <InformationalVersion>$(PackageVersion)</InformationalVersion>
+        <VersionPrefix>1.3.0</VersionPrefix>
         <PackageReadmeFile>README.md</PackageReadmeFile>
     </PropertyGroup>
 

--- a/Pyroscope/Pyroscope/Pyroscope.csproj
+++ b/Pyroscope/Pyroscope/Pyroscope.csproj
@@ -5,6 +5,7 @@
         <PackageVersion>1.3.0</PackageVersion>
         <AssemblyVersion>1.3.0</AssemblyVersion>
         <FileVersion>1.3.0</FileVersion>
+        <InformationalVersion>$(PackageVersion)</InformationalVersion>
         <PackageReadmeFile>README.md</PackageReadmeFile>
     </PropertyGroup>
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/datadog_profiling.version
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/datadog_profiling.version
@@ -1,4 +1,4 @@
 {
-  global: SetConfiguration; GetNativeProfilerIsReadyPtr; GetPointerToNativeTraceContext; Profiler_Version; SetApplicationInfoForAppDomain; SetEndpointForTrace; SetGitMetadataForApplication; ThreadsCpuManager_Map; DllGetClassObject; DllCanUnloadNow; FlushProfile; SetDynamicTag; ClearDynamicTags; SetCPUTrackingEnabled; SetAllocationTrackingEnabled; SetContentionTrackingEnabled; SetExceptionTrackingEnabled; SetPyroscopeAuthToken; SetPyroscopeBasicAuth;
+  global: SetConfiguration; GetNativeProfilerIsReadyPtr; GetPyroscopeProfilerVersion; GetPointerToNativeTraceContext; Profiler_Version; SetApplicationInfoForAppDomain; SetEndpointForTrace; SetGitMetadataForApplication; ThreadsCpuManager_Map; DllGetClassObject; DllCanUnloadNow; FlushProfile; SetDynamicTag; ClearDynamicTags; SetCPUTrackingEnabled; SetAllocationTrackingEnabled; SetContentionTrackingEnabled; SetExceptionTrackingEnabled; SetPyroscopeAuthToken; SetPyroscopeBasicAuth;
   local: *;
 };

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/Datadog.Profiler.Native.def
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/Datadog.Profiler.Native.def
@@ -5,6 +5,7 @@
 
   ThreadsCpuManager_Map PRIVATE
   GetNativeProfilerIsReadyPtr PRIVATE
+  GetPyroscopeProfilerVersion PRIVATE
   GetPointerToNativeTraceContext PRIVATE
   SetApplicationInfoForAppDomain PRIVATE
   SetEndpointForTrace PRIVATE

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/PInvoke.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/PInvoke.cpp
@@ -7,6 +7,7 @@
 #include "Log.h"
 #include "ManagedThreadList.h"
 #include "ProfilerEngineStatus.h"
+#include "PyroscopeVersion.h"
 #include "ThreadsCpuManager.h"
 
 extern "C" void __stdcall ThreadsCpuManager_Map(std::uint32_t threadId, const WCHAR* pName)
@@ -37,6 +38,11 @@ extern "C" void* __stdcall GetNativeProfilerIsReadyPtr()
     }
 
     return (void*)ProfilerEngineStatus::GetReadPtrIsProfilerEngineActive();
+}
+
+extern "C" const char* __stdcall GetPyroscopeProfilerVersion()
+{
+    return PYROSCOPE_SPY_VERSION;
 }
 
 extern "C" void* __stdcall GetPointerToNativeTraceContext()

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/PInvoke.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/PInvoke.h
@@ -38,6 +38,8 @@
 
 extern "C" void* __stdcall GetNativeProfilerIsReadyPtr();
 
+extern "C" const char* __stdcall GetPyroscopeProfilerVersion();
+
 extern "C" void* __stdcall GetPointerToNativeTraceContext();
 
 extern "C" void __stdcall SetApplicationInfoForAppDomain(const char* runtimeId, const char* serviceName, const char* environment, const char* version);

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/PyroscopePprofSink.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/PyroscopePprofSink.h
@@ -25,8 +25,7 @@
 #pragma warning(pop)
 #endif
 #include "url.hpp"
-
-#define PYROSCOPE_SPY_VERSION "1.3.0" // x-release-please-version
+#include "PyroscopeVersion.h"
 
 class PyroscopePprofSink : public PProfExportSink
 {

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/PyroscopeVersion.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/PyroscopeVersion.h
@@ -1,0 +1,3 @@
+#pragma once
+
+#define PYROSCOPE_SPY_VERSION "1.3.0" // x-release-please-version

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -39,7 +39,7 @@
         },
         {
           "type": "generic",
-          "path": "profiler/src/ProfilerEngine/Datadog.Profiler.Native/PyroscopePprofSink.h"
+          "path": "profiler/src/ProfilerEngine/Datadog.Profiler.Native/PyroscopeVersion.h"
         }
       ]
     },


### PR DESCRIPTION
This stops managed Pyroscope interop when the native profiler version does not match the managed package version.

It also exposes the Pyroscope native version through P/Invoke and keeps that version in the release-please bump path.