### PR TITLE
fix(windows): change default log directory to %PROGRAMDATA%\Pyroscope\logs

### DIFF
--- a/profiler/README.md
+++ b/profiler/README.md
@@ -79,7 +79,7 @@ As a final step, enable the profiler you would like to debug by setting the corr
 
 Note:
 - the .pprof files are generated in the folder given by the `DD_INTERNAL_PROFILING_OUTPUT_DIR` environment variable
-- the log files are stored in the `C:\ProgramData\Datadog .NET Tracer\logs` folder
+- the log files are stored in the `C:\ProgramData\Pyroscope\logs` folder
 
 ### Linux
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.cpp
@@ -399,7 +399,7 @@ fs::path Configuration::GetDefaultLogDirectoryPath()
 {
     auto baseDirectory = fs::path(GetApmBaseDirectory());
 #ifdef _WINDOWS
-    return baseDirectory / WStr(R"(Datadog .NET Tracer\logs)");
+    return baseDirectory / WStr(R"(Pyroscope\logs)");
 #else
     return baseDirectory / WStr("dotnet");
 #endif

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Log.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Log.h
@@ -21,7 +21,7 @@ private:
     {
         inline static const std::string file_name = "Pyroscope-DotNet-Profiler-Native";
 #ifdef _WIN32
-        inline static const shared::WSTRING folder_path = WStr(R"(Datadog .NET Tracer\logs)");
+        inline static const shared::WSTRING folder_path = WStr(R"(Pyroscope\logs)");
 #endif
         inline static const std::string pattern = "[%Y-%m-%d %H:%M:%S.%e | %l | PId: %P | TId: %t] %v";
         static bool enable_buffering() {

--- a/profiler/test/Datadog.Profiler.Native.Tests/ConfigurationTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/ConfigurationTest.cpp
@@ -147,7 +147,7 @@ TEST_F(ConfigurationTest, CheckDefaultLogDirectoryWhenVariableIsNotSet)
     auto configuration = Configuration{};
     auto expectedValue =
 #ifdef _WINDOWS
-        WStr("C:\\ProgramData\\Datadog .NET Tracer\\logs");
+        WStr("C:\\ProgramData\\Pyroscope\\logs");
 #else
         WStr("/var/log/pyroscope/dotnet");
 #endif

--- a/profiler/test/Datadog.Profiler.Native.Tests/LogTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/LogTest.cpp
@@ -39,7 +39,7 @@ static fs::path GetCurrentFileLogPath()
 
     fs::path expectedLogFileFullPath =
 #ifdef _WINDOWS
-        "C:\\ProgramData\\Datadog .NET Tracer\\logs\\" + expectedLogFilename;
+        "C:\\ProgramData\\Pyroscope\\logs\\" + expectedLogFilename;
 #else
         "/var/log/pyroscope/dotnet/" + expectedLogFilename;
 #endif

--- a/shared/src/native-src/environment_variables.h
+++ b/shared/src/native-src/environment_variables.h
@@ -13,8 +13,8 @@ namespace shared {
 		// Sets the directory for the profiler's log file.
 		// If set, this setting takes precedence over environment variable DD_TRACE_LOG_PATH.
 		// If not set, default is
-		// "%ProgramData%"\Datadog .NET Tracer\logs\" on Windows or
-		// "/var/log/datadog/dotnet/" on Linux.
+		// "%ProgramData%\Pyroscope\logs\" on Windows or
+		// "/var/log/pyroscope/dotnet/" on Linux.
 		const WSTRING log_directory = WStr("DD_TRACE_LOG_DIRECTORY");
 
 


### PR DESCRIPTION
The Windows profiler wrote its logs to `%PROGRAMDATA%\Datadog .NET Tracer\logs`, inherited from upstream.

`PYROSCOPE_PROFILING_LOG_DIR` (or the `DD_TRACE_LOG_DIRECTORY` alias) still overrides the default. Linux is unchanged.