### PR TITLE
ci: fix csproj version bump in release-please config

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -25,17 +25,7 @@
         {
           "type": "xml",
           "path": "Pyroscope/Pyroscope/Pyroscope.csproj",
-          "xpath": "//PackageVersion"
-        },
-        {
-          "type": "xml",
-          "path": "Pyroscope/Pyroscope/Pyroscope.csproj",
-          "xpath": "//AssemblyVersion"
-        },
-        {
-          "type": "xml",
-          "path": "Pyroscope/Pyroscope/Pyroscope.csproj",
-          "xpath": "//FileVersion"
+          "xpath": "//VersionPrefix"
         },
         {
           "type": "generic",


### PR DESCRIPTION
#375 replaced `<PackageVersion>/<AssemblyVersion>/<FileVersion>` in `Pyroscope.csproj` with a single `<VersionPrefix>`, but the release-please extra-files config still points at the old xpaths. The XML updater silently matches nothing, so release PR #374 left the csproj at 1.3.0: the 1.3.1 pipeline built `Pyroscope.1.3.0.nupkg`, nuget.org rejected it with a 409, and `publish-pyroscope-release` was skipped — which is why the pyroscope-1.3.1 release is stuck in draft.

This points the config at `//VersionPrefix` instead. The SDK derives assembly/file/package versions from it, so one entry replaces the previous three. The OpenTracing/OpenTelemetry csprojs still use the explicit elements and are unchanged.

Notes:
- The stuck 1.3.1 draft can't be repaired by re-running the job (the release SHA has the 1.3.0 csproj baked in); it will be deleted so release-please re-anchors on the published 1.3.0 tag and regenerates #379 with the correct version.