### PR TITLE
chore(deps): Replace nlohmann JSON parser with protobuf

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,9 +7,6 @@
 [submodule "profiler/third_party/cppcodec"]
 	path = profiler/third_party/cppcodec
 	url = https://github.com/tplgy/cppcodec.git
-[submodule "profiler/third_party/nlohmann_json"]
-	path = profiler/third_party/nlohmann_json
-	url = https://github.com/nlohmann/json.git
 [submodule "profiler/third_party/spdlog"]
 	path = profiler/third_party/spdlog
 	url = https://github.com/gabime/spdlog.git

--- a/profiler/CMakeLists.txt
+++ b/profiler/CMakeLists.txt
@@ -134,9 +134,6 @@ add_subdirectory(third_party/CxxUrl)
 
 set_property(TARGET libprotobuf PROPERTY POSITION_INDEPENDENT_CODE ON)
 
-set(JSON_BuildTests OFF CACHE INTERNAL "")
-set(JSON_Install OFF CACHE INTERNAL "")
-add_subdirectory(third_party/nlohmann_json)
 include_directories(third_party/cppcodec)
 
 add_subdirectory(src/ProfilerEngine/Datadog.Profiler.Native.Linux)

--- a/profiler/Directory.Build.props
+++ b/profiler/Directory.Build.props
@@ -196,7 +196,7 @@
       <!-- PYROSCOPE_WINDOWS_NOTE: protobuf headers come from vcpkg (see vcpkg.json override pinning
            3.21.12). Do NOT add profiler\third_party\protobuf\src here — having both would risk header
            vs. runtime mismatch if vcpkg protobuf moves in the future. -->
-      <SHARED-LIB-INCLUDES>$(PYROSCOPE-THIRDPARTY-PATH)spdlog\include;$(PYROSCOPE-THIRDPARTY-PATH)cpp-httplib;$(PYROSCOPE-THIRDPARTY-PATH)CxxUrl;$(PYROSCOPE-THIRDPARTY-PATH)cppcodec;$(PYROSCOPE-THIRDPARTY-PATH)nlohmann_json\include;$(PYROSCOPE-GEN-PATH)</SHARED-LIB-INCLUDES>
+      <SHARED-LIB-INCLUDES>$(PYROSCOPE-THIRDPARTY-PATH)spdlog\include;$(PYROSCOPE-THIRDPARTY-PATH)cpp-httplib;$(PYROSCOPE-THIRDPARTY-PATH)CxxUrl;$(PYROSCOPE-THIRDPARTY-PATH)cppcodec;$(PYROSCOPE-GEN-PATH)</SHARED-LIB-INCLUDES>
       <!-- VCPKG setup -->
       <!-- PYROSCOPE_WINDOWS_NOTE: static triplet so protobuf links INTO the profiler DLL,
            making Pyroscope.Profiler.Native.dll a single-file artifact like the Linux .so.

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/CMakeLists.txt
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/CMakeLists.txt
@@ -141,7 +141,6 @@ target_link_libraries(${PROFILER_STATIC_LIB_NAME}
     spdlog-headers
     libprotobuf
     chmike::CxxUrl
-    nlohmann_json::nlohmann_json
     OpenSSL::Crypto
     OpenSSL::SSL
     -static-libgcc

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/PyroscopePprofSink.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/PyroscopePprofSink.cpp
@@ -7,9 +7,10 @@
 #include "OpSysTools.h"
 #include "cppcodec/base64_rfc4648.hpp"
 #include "dd_profiler_version.h"
-#include "nlohmann/json.hpp"
 #include "gen/push/v1/push.pb.h"
 #include "gen/types/v1/types.pb.h"
+#include "google/protobuf/struct.pb.h"
+#include "google/protobuf/util/json_util.h"
 #include "shared/src/native-src/string.h"
 #include "shared/src/native-src/util.h"
 
@@ -256,31 +257,26 @@ std::map<std::string, std::string> PyroscopePprofSink::ParseHeadersJSON(std::str
     {
         return result;
     }
-    try
+
+    google::protobuf::Struct json;
+    auto status = google::protobuf::util::JsonStringToMessage(headers, &json);
+    if (!status.ok())
     {
-        nlohmann::json json = nlohmann::json::parse(headers);
-        if (json.is_object())
+        Log::Error("PyroscopePprofSink: failed to parse headers json: ", status.ToString());
+        return result;
+    }
+
+    for (const auto& [key, value] : json.fields())
+    {
+        if (value.kind_case() == google::protobuf::Value::kStringValue)
         {
-            for (auto it = json.begin(); it != json.end(); ++it)
-            {
-                if (it.value().is_string())
-                {
-                    result[it.key()] = it.value();
-                }
-                else
-                {
-                    Log::Error("PyroscopePprofSink: header value is not a string: ", it.key(), " ", it.value());
-                }
-            }
+            result[key] = value.string_value();
         }
         else
         {
-            Log::Error("PyroscopePprofSink: headers is not a JSON object");
+            Log::Error("PyroscopePprofSink: header value is not a string: ", key);
         }
     }
-    catch (...)
-    {
-        Log::Error("PyroscopePprofSink: failed to parse headers json", headers);
-    }
+
     return result;
 }

--- a/profiler/test/Datadog.Profiler.Native.Tests/PyroscopePprofSinkTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/PyroscopePprofSinkTest.cpp
@@ -174,6 +174,34 @@ TEST(PyroscopePprofSinkTest, UploadDoesNotOverrideUserProvidedSemanticLabels)
     server.stop();
     serverThread.join();
 }
+
+TEST(PyroscopePprofSinkTest, ParseHeadersJSONReturnsStringHeaders)
+{
+    const auto headers =
+        PyroscopePprofSink::ParseHeadersJSON(R"({"Authorization":"Bearer token","X-Scope-OrgID":"tenant"})");
+
+    const std::map<std::string, std::string> expected = {
+        {"Authorization", "Bearer token"},
+        {"X-Scope-OrgID", "tenant"},
+    };
+    EXPECT_EQ(headers, expected);
+}
+
+TEST(PyroscopePprofSinkTest, ParseHeadersJSONIgnoresNonStringValues)
+{
+    const auto headers = PyroscopePprofSink::ParseHeadersJSON(
+        R"({"valid":"value","number":42,"boolean":true,"null":null,"object":{},"array":[]})");
+
+    const std::map<std::string, std::string> expected = {{"valid", "value"}};
+    EXPECT_EQ(headers, expected);
+}
+
+TEST(PyroscopePprofSinkTest, ParseHeadersJSONReturnsEmptyMapForInvalidInput)
+{
+    EXPECT_TRUE(PyroscopePprofSink::ParseHeadersJSON("").empty());
+    EXPECT_TRUE(PyroscopePprofSink::ParseHeadersJSON("{invalid").empty());
+    EXPECT_TRUE(PyroscopePprofSink::ParseHeadersJSON(R"(["not","an","object"])").empty());
+}
 } // namespace
 
 TEST(PyroscopePprofSinkTest, UploadUsesNormalizedPathWhenBasePathHasTrailingSlash)


### PR DESCRIPTION
## Summary
- parse `PYROSCOPE_HTTP_HEADERS` with protobuf `Struct` and `JsonStringToMessage`
- preserve handling of malformed JSON and non-string header values
- remove the nlohmann/json submodule and build wiring
- add focused parser tests

## Testing
- `docker build --target test --build-arg CMAKE_BUILD_TYPE=Debug -f Pyroscope.Dockerfile .` (436 tests passed)