### PR TITLE
feat(profiler): optional source file and line info in pprof

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.cpp
@@ -78,7 +78,9 @@ Configuration::Configuration()
     _namedPipeName = GetEnvironmentValue(EnvironmentVariables::NamedPipeName, DefaultEmptyString);
     _isTimestampsAsLabelEnabled = GetEnvironmentValue(EnvironmentVariables::TimestampsAsLabelEnabled, false);
     _isAllocationRecorderEnabled = GetEnvironmentValue(EnvironmentVariables::AllocationRecorderEnabled, false);
-    _isDebugInfoEnabled = GetEnvironmentValue(EnvironmentVariables::DebugInfoEnabled, false);
+    _isSourceLocationEnabled = GetEnvironmentValue(EnvironmentVariables::SourceLocationEnabled, false);
+    // emitting source locations into pprof requires the .pdb debug info to actually be collected
+    _isDebugInfoEnabled = GetEnvironmentValue(EnvironmentVariables::DebugInfoEnabled, false) || _isSourceLocationEnabled;
     _isGcThreadsCpuTimeEnabled = GetEnvironmentValue(EnvironmentVariables::GcThreadsCpuTimeEnabled,
                                   GetEnvironmentValue(EnvironmentVariables::GcThreadsCpuTimeInternalEnabled, true), true);
     _isThreadLifetimeEnabled = GetEnvironmentValue(EnvironmentVariables::ThreadLifetimeEnabled,
@@ -597,6 +599,11 @@ bool Configuration::IsAgentless() const
 bool Configuration::IsDebugInfoEnabled() const
 {
     return _isDebugInfoEnabled;
+}
+
+bool Configuration::IsSourceLocationEnabled() const
+{
+    return _isSourceLocationEnabled;
 }
 
 bool Configuration::IsSystemCallsShieldEnabled() const

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.h
@@ -93,6 +93,7 @@ public:
     bool UseManagedCodeCache() const override;
     bool IsMemoryFootprintEnabled() const override;
     bool IsAllocationTypeLeafEnabled() const override;
+    bool IsSourceLocationEnabled() const override;
 
     std::string PyroscopeServerAddress() const override;
     std::string PyroscopeApplicationName() const override;
@@ -229,4 +230,5 @@ private:
     bool _useManagedCodeCache;
     bool _isMemoryFootprintEnabled;
     bool _isAllocationTypeLeafEnabled;
+    bool _isSourceLocationEnabled;
 };

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.cpp
@@ -686,7 +686,8 @@ void CorProfilerCallback::InitializeServices()
         _pConfiguration->GetUserTags());
     _pExporter = std::make_unique<PprofExporter>(_pApplicationStore,
                                                  _pyroscopePprofSink,
-                                                 sampleTypeDefinitions);
+                                                 sampleTypeDefinitions,
+                                                 _pConfiguration->IsSourceLocationEnabled());
 
     if (_gcThreadsCpuProvider != nullptr)
     {

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/EnvironmentVariables.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/EnvironmentVariables.h
@@ -100,4 +100,5 @@ public:
     inline static const shared::WSTRING UseManagedCodeCache         = WStr("DD_INTERNAL_PROFILING_USE_MANAGED_CODE_CACHE");
 
     inline static const shared::WSTRING AllocationTypeLeafEnabled   = WStr("PYROSCOPE_ALLOCATION_TYPE_LEAF_ENABLED");
+    inline static const shared::WSTRING SourceLocationEnabled       = WStr("PYROSCOPE_PROFILING_SOURCE_LOCATION_ENABLED");
 };

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/IConfiguration.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/IConfiguration.h
@@ -66,6 +66,9 @@ public:
     virtual bool IsHeapProfilingEnabled() const = 0;
     virtual bool IsAllocationRecorderEnabled() const = 0;
     virtual bool IsDebugInfoEnabled() const = 0;
+    // when enabled, the source file and the method start line coming from the .pdb are
+    // written into the pprof Function.filename/Function.start_line/Line.line fields
+    virtual bool IsSourceLocationEnabled() const = 0;
     virtual bool IsGcThreadsCpuTimeEnabled() const = 0;
     virtual bool IsThreadLifetimeEnabled() const = 0;
     virtual std::string const& GetGitRepositoryUrl() const = 0;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/PprofBuilder.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/PprofBuilder.cpp
@@ -13,8 +13,9 @@ auto constexpr traceIDLabelName  = "trace_id";
 
 }
 
-PprofBuilder::PprofBuilder(std::vector<SampleValueType> sampleTypeDefinitions) :
-    _sampleTypeDefinitions(std::move(sampleTypeDefinitions))
+PprofBuilder::PprofBuilder(std::vector<SampleValueType> sampleTypeDefinitions, bool emitSourceLocation) :
+    _sampleTypeDefinitions(std::move(sampleTypeDefinitions)),
+    _emitSourceLocation(emitSourceLocation)
 {
     Reset();
 }
@@ -24,14 +25,23 @@ void PprofBuilder::AddSample(const Sample& sample, std::span<const int64_t> valu
     assert(values.size() == _sampleTypeDefinitions.size());
     std::lock_guard lock(this->_lock);
     auto* pSample = _profile.add_sample();
-    auto addLocation = [&](std::string_view frame, std::string_view module) {
-        const auto moduleNameStringId = AddString(module);
+    auto addLocation = [&](std::string_view frame, std::string_view filename, std::uint32_t startLine) {
+        const auto filenameStringId = AddString(filename);
         const auto functionNameStringId = AddString(frame);
-        const auto locId = AddLocation(functionNameStringId, moduleNameStringId);
+        const auto locId = AddLocation(functionNameStringId, filenameStringId, startLine);
         pSample->add_location_id(locId);
     };
     auto addFrame = [&](const FrameInfoView& frame) {
-        addLocation(frame.Frame, frame.ModuleName);
+        // Function.filename holds the assembly name, unless source locations are enabled and
+        // the .pdb debug info gave us an actual source file for this method.
+        if (_emitSourceLocation && !frame.Filename.empty())
+        {
+            addLocation(frame.Frame, frame.Filename, frame.StartLine);
+        }
+        else
+        {
+            addLocation(frame.Frame, frame.ModuleName, 0);
+        }
     };
     AddTraceContext(sample, pSample);
     if (auto frame = sample.GetLeafFrame(); !frame.empty())
@@ -40,7 +50,7 @@ void PprofBuilder::AddSample(const Sample& sample, std::span<const int64_t> valu
         _scratchBuffer.reserve(ClassLeafPrefix.size() + frame.size());
         _scratchBuffer.append(ClassLeafPrefix);
         _scratchBuffer.append(frame);
-        addLocation(_scratchBuffer, {});
+        addLocation(_scratchBuffer, {}, 0);
     }
     for (auto const& frame : sample.GetCallstack())
     {
@@ -112,9 +122,9 @@ int64_t PprofBuilder::AddString(const std::string_view& keyNotOwned)
     return id;
 }
 
-int64_t PprofBuilder::AddLocation(int64_t functionName, int64_t moduleName)
+int64_t PprofBuilder::AddLocation(int64_t functionName, int64_t filename, std::uint32_t startLine)
 {
-    std::pair<int64_t, int64_t> loc(moduleName, functionName);
+    std::tuple<int64_t, int64_t, std::uint32_t> loc(filename, functionName, startLine);
     auto it = _locations.find(loc);
     if (it != _locations.end())
     {
@@ -126,11 +136,18 @@ int64_t PprofBuilder::AddLocation(int64_t functionName, int64_t moduleName)
     auto* pFunction = _profile.add_function();
     pFunction->set_id(id);
     pFunction->set_name(functionName);
-    pFunction->set_filename(moduleName);
+    pFunction->set_filename(filename);
     auto* pLocation = _profile.add_location();
     pLocation->set_id(id);
     auto* pLine = pLocation->add_line();
     pLine->set_function_id(id);
+    if (startLine != 0)
+    {
+        // there is no call site line in the pipeline: the .pdb only gives us the line
+        // the method is declared at, which is reported for both the function and the line
+        pFunction->set_start_line(startLine);
+        pLine->set_line(startLine);
+    }
     _locations.insert(std::make_pair(loc, id));
     return id;
 }

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/PprofBuilder.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/PprofBuilder.h
@@ -9,16 +9,19 @@
 #include "google/v1/profile.pb.h"
 #include "IExporter.h"
 
+#include <cstdint>
+#include <map>
 #include <memory>
 #include <mutex>
 #include <span>
 #include <string>
 #include <string_view>
+#include <tuple>
 
 class PprofBuilder
 {
 public:
-    PprofBuilder(std::vector<SampleValueType> sampleTypeDefinitions);
+    PprofBuilder(std::vector<SampleValueType> sampleTypeDefinitions, bool emitSourceLocation = false);
     void AddTraceContext(const Sample& sample, google::v1::Sample* pSample);
 
     void AddSample(const Sample& sample, std::span<const int64_t> values);
@@ -27,15 +30,16 @@ public:
 private:
     int64_t AddHexString(std::span<const std::byte> bs);
     int64_t AddString(const std::string_view& sv);
-    int64_t AddLocation(int64_t functionName, int64_t moduleName);
+    int64_t AddLocation(int64_t functionName, int64_t filename, std::uint32_t startLine);
     void Reset();
 
     std::mutex _lock;
     int _samplesCount = 0;
     google::v1::Profile _profile;
     std::map<std::string_view, int64_t> _strings;
-    std::map<std::pair<int64_t, int64_t>, int64_t> _locations;
+    std::map<std::tuple<int64_t, int64_t, std::uint32_t>, int64_t> _locations;
     std::vector<SampleValueType> _sampleTypeDefinitions;
+    bool _emitSourceLocation;
     std::string _scratchBuffer;
 
     int64_t _span_id_str_index{};

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/PprofExporter.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/PprofExporter.cpp
@@ -14,7 +14,8 @@
 
 PprofExporter::PprofExporter(IApplicationStore* applicationStore,
                              std::shared_ptr<PProfExportSink> sink,
-                             std::vector<SampleValueType> sampleTypeDefinitions) :
+                             std::vector<SampleValueType> sampleTypeDefinitions,
+                             bool emitSourceLocation) :
     _applicationStore(applicationStore),
     _sink(std::move(sink))
 {
@@ -33,7 +34,7 @@ PprofExporter::PprofExporter(IApplicationStore* applicationStore,
             ++i;
         }
 
-        _entries.push_back(std::make_unique<ProfileTypeEntry>(startIndex, groupTypes.size(), currentType, std::move(groupTypes)));
+        _entries.push_back(std::make_unique<ProfileTypeEntry>(startIndex, groupTypes.size(), currentType, std::move(groupTypes), emitSourceLocation));
     }
 
 #ifndef _WIN32

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/PprofExporter.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/PprofExporter.h
@@ -35,8 +35,8 @@ public:
 
 struct ProfileTypeEntry
 {
-    ProfileTypeEntry(size_t startIndex, size_t count, ProfileType profileType, std::vector<SampleValueType> sampleTypes) :
-        startIndex(startIndex), count(count), profileType(profileType), builder(std::move(sampleTypes)) {}
+    ProfileTypeEntry(size_t startIndex, size_t count, ProfileType profileType, std::vector<SampleValueType> sampleTypes, bool emitSourceLocation) :
+        startIndex(startIndex), count(count), profileType(profileType), builder(std::move(sampleTypes), emitSourceLocation) {}
 
     size_t startIndex;                 // offset into Sample::GetValues()
     size_t count;                      // number of values for this profile type
@@ -50,7 +50,8 @@ class PprofExporter : public IExporter
 public:
     PprofExporter(IApplicationStore* applicationStore,
                   std::shared_ptr<PProfExportSink> sink,
-                  std::vector<SampleValueType> sampleTypeDefinitions);
+                  std::vector<SampleValueType> sampleTypeDefinitions,
+                  bool emitSourceLocation = false);
     void Add(std::shared_ptr<Sample> const& sample) override;
     void SetEndpoint(const std::string& runtimeId, uint64_t traceId, const std::string& endpoint) override;
     bool Export(ProfileTime& startTime, ProfileTime& endTime, bool lastCall = false) override;

--- a/profiler/test/Datadog.Profiler.Native.Tests/ConfigurationTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/ConfigurationTest.cpp
@@ -698,6 +698,33 @@ TEST_F(ConfigurationTest, CheckDebugInfoIsDisabledIfEnvVarSetToFalse)
     ASSERT_THAT(configuration.IsDebugInfoEnabled(), false);
 }
 
+TEST_F(ConfigurationTest, CheckSourceLocationIsDisabledByDefault)
+{
+    auto configuration = Configuration{};
+    ASSERT_THAT(configuration.IsSourceLocationEnabled(), false);
+}
+
+TEST_F(ConfigurationTest, CheckSourceLocationIsEnabledIfEnvVarSetToTrue)
+{
+    EnvironmentHelper::EnvironmentVariable ar(EnvironmentVariables::SourceLocationEnabled, WStr("1"));
+    auto configuration = Configuration{};
+    ASSERT_THAT(configuration.IsSourceLocationEnabled(), true);
+}
+
+TEST_F(ConfigurationTest, CheckSourceLocationIsDisabledIfEnvVarSetToFalse)
+{
+    EnvironmentHelper::EnvironmentVariable ar(EnvironmentVariables::SourceLocationEnabled, WStr("0"));
+    auto configuration = Configuration{};
+    ASSERT_THAT(configuration.IsSourceLocationEnabled(), false);
+}
+
+TEST_F(ConfigurationTest, CheckSourceLocationEnablesDebugInfo)
+{
+    EnvironmentHelper::EnvironmentVariable ar(EnvironmentVariables::SourceLocationEnabled, WStr("1"));
+    auto configuration = Configuration{};
+    ASSERT_THAT(configuration.IsDebugInfoEnabled(), true);
+}
+
 TEST_F(ConfigurationTest, CheckGcThreadsCpuTimeEnabledTakesOverInternal)
 {
     EnvironmentHelper::EnvironmentVariable ev1(EnvironmentVariables::GcThreadsCpuTimeEnabled, WStr("1"));

--- a/profiler/test/Datadog.Profiler.Native.Tests/PprofBuilderTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/PprofBuilderTest.cpp
@@ -6,6 +6,8 @@
 #include <chrono>
 #include <map>
 #include <string>
+#include <utility>
+#include <vector>
 
 namespace
 {
@@ -25,6 +27,54 @@ google::v1::Profile BuildProfileWithTraceContext(const TraceContext& traceContex
     google::v1::Profile profile;
     EXPECT_TRUE(profile.ParseFromString(serialized));
     return profile;
+}
+
+google::v1::Profile BuildProfileWithFrames(bool emitSourceLocation, const std::vector<FrameInfoView>& frames)
+{
+    PprofBuilder builder({SampleValueType{"cpu", "nanoseconds", ProfileType::ProcessCpu, -1}}, emitSourceLocation);
+    Sample sample{"runtime-id"};
+    sample.SetTraceContext(TraceContext{}); // Sample leaves it uninitialized: no trace labels wanted here
+    for (auto const& frame : frames)
+    {
+        sample.AddFrame(frame);
+    }
+
+    std::array<int64_t, 1> values{42};
+    builder.AddSample(sample, values);
+
+    ProfileTime start{};
+    auto end = start + std::chrono::milliseconds{1};
+    auto serialized = builder.Build(start, end);
+
+    google::v1::Profile profile;
+    EXPECT_TRUE(profile.ParseFromString(serialized));
+    return profile;
+}
+
+// Returns the function/line pair pprof associates with the location at the given index of the first sample.
+std::pair<google::v1::Function, google::v1::Line> GetFrame(const google::v1::Profile& profile, int frameIndex)
+{
+    auto locationId = profile.sample(0).location_id(frameIndex);
+    for (const auto& location : profile.location())
+    {
+        if (location.id() != locationId)
+        {
+            continue;
+        }
+
+        EXPECT_EQ(location.line_size(), 1);
+        auto line = location.line(0);
+        for (const auto& function : profile.function())
+        {
+            if (function.id() == line.function_id())
+            {
+                return {function, line};
+            }
+        }
+    }
+
+    ADD_FAILURE() << "no function found for frame " << frameIndex;
+    return {};
 }
 
 std::map<std::string, std::string> GetStringLabels(const google::v1::Profile& profile, const google::v1::Sample& sample)
@@ -72,4 +122,76 @@ TEST(PprofBuilderTest, AddSampleWithoutLocalRootSpanIdDoesNotEmitTraceContextLab
 
     EXPECT_EQ(labels.find("span_id"), labels.end());
     EXPECT_EQ(labels.find("trace_id"), labels.end());
+}
+
+TEST(PprofBuilderTest, WithoutSourceLocationTheFunctionFilenameIsTheModuleName)
+{
+    auto profile = BuildProfileWithFrames(false, {FrameInfoView{"MyApp", "MyApp.Worker.Run", "/src/MyApp/Worker.cs", 42}});
+
+    ASSERT_EQ(profile.sample_size(), 1);
+    ASSERT_EQ(profile.sample(0).location_id_size(), 1);
+    auto [function, line] = GetFrame(profile, 0);
+
+    EXPECT_EQ(profile.string_table(function.name()), "MyApp.Worker.Run");
+    EXPECT_EQ(profile.string_table(function.filename()), "MyApp");
+    EXPECT_EQ(function.start_line(), 0);
+    EXPECT_EQ(line.line(), 0);
+}
+
+TEST(PprofBuilderTest, WithSourceLocationTheSourceFileAndStartLineAreEmitted)
+{
+    auto profile = BuildProfileWithFrames(true, {FrameInfoView{"MyApp", "MyApp.Worker.Run", "/src/MyApp/Worker.cs", 42},
+                                                FrameInfoView{"MyLib", "MyLib.Queue.Pop", "/src/MyLib/Queue.cs", 7}});
+
+    ASSERT_EQ(profile.sample_size(), 1);
+    ASSERT_EQ(profile.sample(0).location_id_size(), 2);
+
+    auto [worker, workerLine] = GetFrame(profile, 0);
+    EXPECT_EQ(profile.string_table(worker.name()), "MyApp.Worker.Run");
+    EXPECT_EQ(profile.string_table(worker.filename()), "/src/MyApp/Worker.cs");
+    EXPECT_EQ(worker.start_line(), 42);
+    EXPECT_EQ(workerLine.line(), 42);
+
+    auto [queue, queueLine] = GetFrame(profile, 1);
+    EXPECT_EQ(profile.string_table(queue.name()), "MyLib.Queue.Pop");
+    EXPECT_EQ(profile.string_table(queue.filename()), "/src/MyLib/Queue.cs");
+    EXPECT_EQ(queue.start_line(), 7);
+    EXPECT_EQ(queueLine.line(), 7);
+}
+
+TEST(PprofBuilderTest, WithSourceLocationFramesWithoutDebugInfoFallBackToTheModuleName)
+{
+    // no .pdb was found for that method: Filename is empty and StartLine is 0
+    auto profile = BuildProfileWithFrames(true, {FrameInfoView{"MyApp", "MyApp.Worker.Run", "", 0}});
+
+    ASSERT_EQ(profile.sample_size(), 1);
+    ASSERT_EQ(profile.sample(0).location_id_size(), 1);
+    auto [function, line] = GetFrame(profile, 0);
+
+    EXPECT_EQ(profile.string_table(function.filename()), "MyApp");
+    EXPECT_EQ(function.start_line(), 0);
+    EXPECT_EQ(line.line(), 0);
+}
+
+TEST(PprofBuilderTest, WithSourceLocationIdenticalFramesShareASingleLocation)
+{
+    FrameInfoView frame{"MyApp", "MyApp.Worker.Run", "/src/MyApp/Worker.cs", 42};
+    auto profile = BuildProfileWithFrames(true, {frame, frame});
+
+    ASSERT_EQ(profile.sample_size(), 1);
+    ASSERT_EQ(profile.sample(0).location_id_size(), 2);
+    EXPECT_EQ(profile.sample(0).location_id(0), profile.sample(0).location_id(1));
+    EXPECT_EQ(profile.location_size(), 1);
+    EXPECT_EQ(profile.function_size(), 1);
+}
+
+TEST(PprofBuilderTest, WithSourceLocationSameMethodInDifferentFilesGetsDistinctLocations)
+{
+    auto profile = BuildProfileWithFrames(true, {FrameInfoView{"MyApp", "MyApp.Worker.Run", "/src/MyApp/Worker.cs", 42},
+                                                FrameInfoView{"MyApp", "MyApp.Worker.Run", "/src/MyApp/Worker.g.cs", 42}});
+
+    ASSERT_EQ(profile.sample_size(), 1);
+    ASSERT_EQ(profile.sample(0).location_id_size(), 2);
+    EXPECT_NE(profile.sample(0).location_id(0), profile.sample(0).location_id(1));
+    EXPECT_EQ(profile.location_size(), 2);
 }

--- a/profiler/test/Datadog.Profiler.Native.Tests/ProfilerMockedInterface.h
+++ b/profiler/test/Datadog.Profiler.Native.Tests/ProfilerMockedInterface.h
@@ -78,6 +78,7 @@ public:
     MOCK_METHOD(bool, IsHeapProfilingEnabled, (), (const override));
     MOCK_METHOD(bool, IsAllocationRecorderEnabled, (), (const override));
     MOCK_METHOD(bool, IsDebugInfoEnabled, (), (const override));
+    MOCK_METHOD(bool, IsSourceLocationEnabled, (), (const override));
     MOCK_METHOD(bool, IsGcThreadsCpuTimeEnabled, (), (const override));
     MOCK_METHOD(bool, IsThreadLifetimeEnabled, (), (const override));
     MOCK_METHOD(std::string const&, GetGitRepositoryUrl, (), (const override));


### PR DESCRIPTION
## What

Adds an opt-in configuration option, `PYROSCOPE_PROFILING_SOURCE_LOCATION_ENABLED` (default **off**), that wires the source file and method line number into the exported pprof.

The profiler already resolves `.pdb` debug info per managed method (`DebugInfoStore` → `FrameStore` → `FrameInfoView{ModuleName, Frame, Filename, StartLine}`) and carries `Filename`/`StartLine` all the way into `Sample`, but `PprofBuilder` dropped them: it wrote the *assembly* name into `Function.filename` and never set `Function.start_line` or `Line.line`.

When the option is enabled and a frame has debug info, `PprofBuilder` now emits:

```
function {
  name:       "MyApp.Worker.Run"
  filename:   "/src/MyApp/Worker.cs"
  start_line: 42
}
location { line { function_id: ..., line: 42 } }
```

Notes:
- `Function.filename` keeps holding the assembly name for frames without debug info (and for the `cls:` allocation leaf pseudo-frame), so nothing regresses when PDBs are unavailable.
- There is no call-site line anywhere in the pipeline — the `.pdb` lookup collapses sequence points to the method's declaration line — so that single line is reported as both `Function.start_line` and `Line.line`.
- The option also turns on `.pdb` debug-info collection (`DD_INTERNAL_PROFILING_DEBUG_INFO_ENABLED`), so one variable is enough to enable the feature.
- The location dedup key now includes filename and start line, keeping the 1:1 `Location`/`Function` invariant.

With the option unset, the produced pprof is unchanged.

## Tests

- `PprofBuilderTest`: filename stays the module name when disabled; source file + `start_line` + `Line.line` when enabled; fallback to module name for frames without debug info; dedup of identical frames; distinct locations for the same method in different files.
- `ConfigurationTest`: default off, `1`/`0` handling, and that enabling it turns on debug info collection.

## Verification

Built on Windows with `msbuild profiler\src\ProfilerEngine\Datadog.Profiler.Native.Windows\Datadog.Profiler.Native.Windows.vcxproj /p:Configuration=Release /p:Platform=x64` (succeeds). The C++ unit tests can only be built on Linux (no test `.vcxproj` exists in this fork and CMake refuses Windows), and WSL2 is unavailable on this machine, so the new tests are left to CI's `test_cpp_profiler.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)