### PR TITLE
feat(profiler): optional per-sample line numbers in pprof

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.cpp
@@ -78,7 +78,9 @@ Configuration::Configuration()
     _namedPipeName = GetEnvironmentValue(EnvironmentVariables::NamedPipeName, DefaultEmptyString);
     _isTimestampsAsLabelEnabled = GetEnvironmentValue(EnvironmentVariables::TimestampsAsLabelEnabled, false);
     _isAllocationRecorderEnabled = GetEnvironmentValue(EnvironmentVariables::AllocationRecorderEnabled, false);
-    _isSourceLocationEnabled = GetEnvironmentValue(EnvironmentVariables::SourceLocationEnabled, false);
+    _isLineNumbersEnabled = GetEnvironmentValue(EnvironmentVariables::LineNumbersEnabled, false);
+    // per-sample line numbers are emitted through the source location fields of the pprof
+    _isSourceLocationEnabled = GetEnvironmentValue(EnvironmentVariables::SourceLocationEnabled, false) || _isLineNumbersEnabled;
     // emitting source locations into pprof requires the .pdb debug info to actually be collected
     _isDebugInfoEnabled = GetEnvironmentValue(EnvironmentVariables::DebugInfoEnabled, false) || _isSourceLocationEnabled;
     _isGcThreadsCpuTimeEnabled = GetEnvironmentValue(EnvironmentVariables::GcThreadsCpuTimeEnabled,
@@ -604,6 +606,11 @@ bool Configuration::IsDebugInfoEnabled() const
 bool Configuration::IsSourceLocationEnabled() const
 {
     return _isSourceLocationEnabled;
+}
+
+bool Configuration::IsLineNumbersEnabled() const
+{
+    return _isLineNumbersEnabled;
 }
 
 bool Configuration::IsSystemCallsShieldEnabled() const

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.cpp
@@ -78,7 +78,9 @@ Configuration::Configuration()
     _namedPipeName = GetEnvironmentValue(EnvironmentVariables::NamedPipeName, DefaultEmptyString);
     _isTimestampsAsLabelEnabled = GetEnvironmentValue(EnvironmentVariables::TimestampsAsLabelEnabled, false);
     _isAllocationRecorderEnabled = GetEnvironmentValue(EnvironmentVariables::AllocationRecorderEnabled, false);
-    _isDebugInfoEnabled = GetEnvironmentValue(EnvironmentVariables::DebugInfoEnabled, false);
+    _isSourceLocationEnabled = GetEnvironmentValue(EnvironmentVariables::SourceLocationEnabled, false);
+    // emitting source locations into pprof requires the .pdb debug info to actually be collected
+    _isDebugInfoEnabled = GetEnvironmentValue(EnvironmentVariables::DebugInfoEnabled, false) || _isSourceLocationEnabled;
     _isGcThreadsCpuTimeEnabled = GetEnvironmentValue(EnvironmentVariables::GcThreadsCpuTimeEnabled,
                                   GetEnvironmentValue(EnvironmentVariables::GcThreadsCpuTimeInternalEnabled, true), true);
     _isThreadLifetimeEnabled = GetEnvironmentValue(EnvironmentVariables::ThreadLifetimeEnabled,
@@ -597,6 +599,11 @@ bool Configuration::IsAgentless() const
 bool Configuration::IsDebugInfoEnabled() const
 {
     return _isDebugInfoEnabled;
+}
+
+bool Configuration::IsSourceLocationEnabled() const
+{
+    return _isSourceLocationEnabled;
 }
 
 bool Configuration::IsSystemCallsShieldEnabled() const

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.h
@@ -94,6 +94,7 @@ public:
     bool IsMemoryFootprintEnabled() const override;
     bool IsAllocationTypeLeafEnabled() const override;
     bool IsSourceLocationEnabled() const override;
+    bool IsLineNumbersEnabled() const override;
 
     std::string PyroscopeServerAddress() const override;
     std::string PyroscopeApplicationName() const override;
@@ -231,4 +232,5 @@ private:
     bool _isMemoryFootprintEnabled;
     bool _isAllocationTypeLeafEnabled;
     bool _isSourceLocationEnabled;
+    bool _isLineNumbersEnabled;
 };

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.h
@@ -93,6 +93,7 @@ public:
     bool UseManagedCodeCache() const override;
     bool IsMemoryFootprintEnabled() const override;
     bool IsAllocationTypeLeafEnabled() const override;
+    bool IsSourceLocationEnabled() const override;
 
     std::string PyroscopeServerAddress() const override;
     std::string PyroscopeApplicationName() const override;
@@ -229,4 +230,5 @@ private:
     bool _useManagedCodeCache;
     bool _isMemoryFootprintEnabled;
     bool _isAllocationTypeLeafEnabled;
+    bool _isSourceLocationEnabled;
 };

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.cpp
@@ -686,7 +686,8 @@ void CorProfilerCallback::InitializeServices()
         _pConfiguration->GetUserTags());
     _pExporter = std::make_unique<PprofExporter>(_pApplicationStore,
                                                  _pyroscopePprofSink,
-                                                 sampleTypeDefinitions);
+                                                 sampleTypeDefinitions,
+                                                 _pConfiguration->IsSourceLocationEnabled());
 
     if (_gcThreadsCpuProvider != nullptr)
     {

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/DebugInfoStore.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/DebugInfoStore.cpp
@@ -28,6 +28,7 @@ const std::uint32_t DebugInfoStore::NoStartLine = 0;
 DebugInfoStore::DebugInfoStore(ICorProfilerInfo4* profilerInfo, IConfiguration* _configuration) noexcept :
     _profilerInfo{profilerInfo},
     _isEnabled{_configuration->IsDebugInfoEnabled()},
+    _areLineNumbersEnabled{_configuration->IsLineNumbersEnabled()},
     _cachedItemsSize(0)
 {
 }
@@ -100,6 +101,10 @@ void DebugInfoStore::ParseModuleDebugInfo(ModuleID moduleId)
         itemSize += file.capacity();
     }
     itemSize += moduleInfo.RidToDebugInfo.capacity() * sizeof(SymbolDebugInfo);
+    for (const auto& debugInfo : moduleInfo.RidToDebugInfo)
+    {
+        itemSize += debugInfo.SequencePoints.capacity() * sizeof(SequencePointInfo);
+    }
     _cachedItemsSize.fetch_add(itemSize, std::memory_order_relaxed);
 }
 
@@ -185,7 +190,22 @@ bool DebugInfoStore::TryLoadSymbolsWithPortable(const std::string& pdbFilename, 
                     break;
                 }
             }
-            moduleInfo.RidToDebugInfo.emplace_back() = {moduleInfo.Files[row.InitialDocument], startLine};
+
+            // keep the whole sequence point table so a sampled IL offset can be mapped
+            // to its source line (0xfeefee marks hidden sequence points)
+            std::vector<SequencePointInfo> points;
+            if (_areLineNumbersEnabled)
+            {
+                points.reserve(row.Points.size());
+                for (const auto& s : row.Points)
+                {
+                    if (s.StartLine != 0xfeefee && s.EndLine != 0xfeefee)
+                    {
+                        points.push_back({s.ILOffset, s.StartLine});
+                    }
+                }
+            }
+            moduleInfo.RidToDebugInfo.emplace_back() = {moduleInfo.Files[row.InitialDocument], startLine, std::move(points)};
         }
         moduleInfo.LoadingState = SymbolLoadingState::Portable;
 
@@ -307,7 +327,12 @@ DebugInfoStore::MemoryStats DebugInfoStore::ComputeMemoryStats() const
 
         // SymbolsDebugInfo vector
         stats.moduleInfosSize += moduleInfo.RidToDebugInfo.capacity() * sizeof(SymbolDebugInfo);
-        // SymbolDebugInfo contains string_view, which doesn't own the data, so no additional memory
+        // SymbolDebugInfo contains string_view, which doesn't own the data, but it owns
+        // the sequence points (only populated when line numbers are enabled)
+        for (const auto& debugInfo : moduleInfo.RidToDebugInfo)
+        {
+            stats.moduleInfosSize += debugInfo.SequencePoints.capacity() * sizeof(SequencePointInfo);
+        }
     }
 
     return stats;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/DebugInfoStore.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/DebugInfoStore.h
@@ -57,6 +57,12 @@ public:
         // Each entry contains a string_view (2 pointers typically) and a uint32_t
         totalSize += RidToDebugInfo.capacity() * sizeof(SymbolDebugInfo);
 
+        // Size of the per-method sequence points (only populated when line numbers are enabled)
+        for (const auto& debugInfo : RidToDebugInfo)
+        {
+            totalSize += debugInfo.SequencePoints.capacity() * sizeof(SequencePointInfo);
+        }
+
         return totalSize;
     }
 };
@@ -154,6 +160,7 @@ private:
 
     ICorProfilerInfo4* _profilerInfo;
     bool _isEnabled;
+    bool _areLineNumbersEnabled;
 
 // mutable to allow locking in const methods (e.g., GetMemorySize, LogMemoryBreakdown)
     mutable std::mutex _modulesMutex;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/EnvironmentVariables.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/EnvironmentVariables.h
@@ -101,4 +101,5 @@ public:
 
     inline static const shared::WSTRING AllocationTypeLeafEnabled   = WStr("PYROSCOPE_ALLOCATION_TYPE_LEAF_ENABLED");
     inline static const shared::WSTRING SourceLocationEnabled       = WStr("PYROSCOPE_PROFILING_SOURCE_LOCATION_ENABLED");
+    inline static const shared::WSTRING LineNumbersEnabled          = WStr("PYROSCOPE_PROFILING_LINE_NUMBERS_ENABLED");
 };

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/EnvironmentVariables.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/EnvironmentVariables.h
@@ -100,4 +100,5 @@ public:
     inline static const shared::WSTRING UseManagedCodeCache         = WStr("DD_INTERNAL_PROFILING_USE_MANAGED_CODE_CACHE");
 
     inline static const shared::WSTRING AllocationTypeLeafEnabled   = WStr("PYROSCOPE_ALLOCATION_TYPE_LEAF_ENABLED");
+    inline static const shared::WSTRING SourceLocationEnabled       = WStr("PYROSCOPE_PROFILING_SOURCE_LOCATION_ENABLED");
 };

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/FrameStore.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/FrameStore.cpp
@@ -14,6 +14,8 @@
 #include "shared/src/native-src/dd_filesystem.hpp"
 // namespace fs is an alias defined in "dd_filesystem.hpp"
 
+#include <algorithm>
+
 #define ARRAY_LEN(a) (sizeof(a) / sizeof((a)[0]))
 
 FrameStore::FrameStore(ICorProfilerInfo4* pCorProfilerInfo,
@@ -22,6 +24,7 @@ FrameStore::FrameStore(ICorProfilerInfo4* pCorProfilerInfo,
     ManagedCodeCache* pManagedCodeCache) :
     _pCorProfilerInfo{pCorProfilerInfo},
     _pDebugInfoStore{debugInfoStore},
+    _areLineNumbersEnabled{pConfiguration != nullptr && pConfiguration->IsLineNumbersEnabled()},
     _pManagedCodeCache{pManagedCodeCache},
     _cachedItemsSize(0)
 {
@@ -149,7 +152,7 @@ std::pair<bool, FrameInfoView> FrameStore::GetFrame(uintptr_t instructionPointer
         }
     }
 
-    auto frameInfo = GetManagedFrame(functionId.value());
+    auto frameInfo = GetManagedFrame(functionId.value(), instructionPointer);
     return {true, frameInfo};
 }
 
@@ -172,7 +175,7 @@ std::string FrameStore::FormatFrame(
     return builder.str();
 }
 
-FrameInfoView FrameStore::GetManagedFrame(FunctionID functionId)
+FrameInfoView FrameStore::GetManagedFrame(FunctionID functionId, uintptr_t instructionPointer)
 {
     {
         std::lock_guard<std::mutex> lock(_methodsLock);
@@ -181,7 +184,9 @@ FrameInfoView FrameStore::GetManagedFrame(FunctionID functionId)
         auto element = _methods.find(functionId);
         if (element != _methods.end())
         {
-            return element->second;
+            FrameInfoView view = element->second;
+            view.Line = ResolveLine(element->second, instructionPointer);
+            return view;
         }
     }
 
@@ -248,19 +253,138 @@ FrameInfoView FrameStore::GetManagedFrame(FunctionID functionId)
 
     auto debugInfo = _pDebugInfoStore->Get(moduleId, mdTokenFunc);
 
+    FrameInfo frameInfo{pTypeDesc->Assembly, managedFrame, debugInfo.File, debugInfo.StartLine};
+    if (_areLineNumbersEnabled && !debugInfo.SequencePoints.empty())
+    {
+        frameInfo.SequencePoints = std::move(debugInfo.SequencePoints);
+        CollectLineResolutionData(functionId, frameInfo);
+    }
+
     {
         std::lock_guard<std::mutex> lock(_methodsLock);
 
         // store it into the function cache and return an iterator to the stored elements
-        auto [it, _] = _methods.emplace(functionId, FrameInfo{pTypeDesc->Assembly, managedFrame, debugInfo.File, debugInfo.StartLine});
+        auto [it, _] = _methods.emplace(functionId, std::move(frameInfo));
 
         // Incrementally track item size
-        size_t itemSize = it->second.ModuleName.capacity() + it->second.Frame.capacity();
+        size_t itemSize = it->second.ModuleName.capacity() + it->second.Frame.capacity() +
+                          it->second.SequencePoints.capacity() * sizeof(SequencePointInfo) +
+                          it->second.CodeRanges.capacity() * sizeof(COR_PRF_CODE_INFO) +
+                          it->second.IlToNativeMap.capacity() * sizeof(COR_DEBUG_IL_TO_NATIVE_MAP);
         _cachedItemsSize.fetch_add(itemSize, std::memory_order_relaxed);
 
         // first is the key, second is the associated value
-        return it->second;
+        FrameInfoView view = it->second;
+        view.Line = ResolveLine(it->second, instructionPointer);
+        return view;
     }
+}
+
+void FrameStore::CollectLineResolutionData(FunctionID functionId, FrameInfo& frameInfo)
+{
+    // native code chunks of the jitted method
+    // (only the most recent code version is returned; samples taken in another
+    // compilation tier will not match these ranges and fall back to the start line)
+    ULONG32 count = 0;
+    HRESULT hr = _pCorProfilerInfo->GetCodeInfo2(functionId, 0, &count, nullptr);
+    if (FAILED(hr) || count == 0)
+    {
+        return;
+    }
+    frameInfo.CodeRanges.resize(count);
+    hr = _pCorProfilerInfo->GetCodeInfo2(functionId, count, &count, frameInfo.CodeRanges.data());
+    if (FAILED(hr))
+    {
+        frameInfo.CodeRanges.clear();
+        return;
+    }
+
+    count = 0;
+    hr = _pCorProfilerInfo->GetILToNativeMapping(functionId, 0, &count, nullptr);
+    if (FAILED(hr) || count == 0)
+    {
+        frameInfo.CodeRanges.clear();
+        return;
+    }
+    frameInfo.IlToNativeMap.resize(count);
+    hr = _pCorProfilerInfo->GetILToNativeMapping(functionId, count, &count, frameInfo.IlToNativeMap.data());
+    if (FAILED(hr))
+    {
+        frameInfo.CodeRanges.clear();
+        frameInfo.IlToNativeMap.clear();
+        return;
+    }
+
+    // the JIT can reorder code relative to IL order: sort by native offset so
+    // ResolveLine can binary search
+    std::sort(frameInfo.IlToNativeMap.begin(), frameInfo.IlToNativeMap.end(),
+              [](const COR_DEBUG_IL_TO_NATIVE_MAP& left, const COR_DEBUG_IL_TO_NATIVE_MAP& right) {
+                  return left.nativeStartOffset < right.nativeStartOffset;
+              });
+}
+
+std::uint32_t FrameStore::ResolveLine(const FrameInfo& frameInfo, uintptr_t instructionPointer)
+{
+    if (frameInfo.SequencePoints.empty() || frameInfo.CodeRanges.empty() || frameInfo.IlToNativeMap.empty())
+    {
+        return 0;
+    }
+
+    // native offset of the IP, relative to the method's code chunks laid end to end
+    // (the same layout GetILToNativeMapping offsets are expressed in)
+    ULONG32 nativeOffset = 0;
+    ULONG32 chunkStartOffset = 0;
+    bool ipFound = false;
+    for (const auto& range : frameInfo.CodeRanges)
+    {
+        if (instructionPointer >= range.startAddress && instructionPointer < range.startAddress + range.size)
+        {
+            nativeOffset = chunkStartOffset + static_cast<ULONG32>(instructionPointer - range.startAddress);
+            ipFound = true;
+            break;
+        }
+        chunkStartOffset += static_cast<ULONG32>(range.size);
+    }
+    if (!ipFound)
+    {
+        // the sample was taken in another code version (e.g. a different compilation tier)
+        return 0;
+    }
+
+    // last IL-to-native entry starting at or before the native offset,
+    // skipping backwards over prolog/epilog/unmapped entries
+    auto entry = std::upper_bound(
+        frameInfo.IlToNativeMap.begin(), frameInfo.IlToNativeMap.end(), nativeOffset,
+        [](ULONG32 offset, const COR_DEBUG_IL_TO_NATIVE_MAP& e) { return offset < e.nativeStartOffset; });
+
+    std::uint32_t ilOffset = 0;
+    bool ilOffsetFound = false;
+    while (entry != frameInfo.IlToNativeMap.begin())
+    {
+        --entry;
+        if (entry->ilOffset == static_cast<ULONG32>(NO_MAPPING) || entry->ilOffset == static_cast<ULONG32>(EPILOG))
+        {
+            continue;
+        }
+        // attribute the prolog to the beginning of the method
+        ilOffset = (entry->ilOffset == static_cast<ULONG32>(PROLOG)) ? 0 : entry->ilOffset;
+        ilOffsetFound = true;
+        break;
+    }
+    if (!ilOffsetFound)
+    {
+        return 0;
+    }
+
+    // last sequence point at or before the IL offset
+    auto point = std::upper_bound(
+        frameInfo.SequencePoints.begin(), frameInfo.SequencePoints.end(), ilOffset,
+        [](std::uint32_t offset, const SequencePointInfo& p) { return offset < p.ILOffset; });
+    if (point == frameInfo.SequencePoints.begin())
+    {
+        return 0;
+    }
+    return std::prev(point)->StartLine;
 }
 
 bool FrameStore::GetTypeName(ClassID classId, std::string& name)
@@ -1029,6 +1153,10 @@ FrameStore::MemoryStats FrameStore::ComputeMemoryStats() const
             stats.methodsCacheSize += frameInfo.ModuleName.capacity();
             stats.methodsCacheSize += frameInfo.Frame.capacity();
             // Filename is a string_view, no additional memory
+            // per-sample line resolution data (only populated when line numbers are enabled)
+            stats.methodsCacheSize += frameInfo.SequencePoints.capacity() * sizeof(SequencePointInfo);
+            stats.methodsCacheSize += frameInfo.CodeRanges.capacity() * sizeof(COR_PRF_CODE_INFO);
+            stats.methodsCacheSize += frameInfo.IlToNativeMap.capacity() * sizeof(COR_DEBUG_IL_TO_NATIVE_MAP);
         }
     }
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/FrameStore.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/FrameStore.h
@@ -91,7 +91,7 @@ private:
         const char* arraySuffix);
     bool GetTypeDesc(ClassID classId, TypeDesc*& typeDesc);
     bool GetCachedTypeDesc(ClassID classId, TypeDesc*& typeDesc);
-    FrameInfoView GetManagedFrame(FunctionID functionId);
+    FrameInfoView GetManagedFrame(FunctionID functionId, uintptr_t instructionPointer);
     std::pair <std::string_view, std::string_view> GetNativeFrame(uintptr_t instructionPointer);
 
 public:   // global helpers
@@ -170,11 +170,23 @@ private:
         std::string_view Filename;
         std::uint32_t StartLine;
 
+        // per-sample line resolution data (only populated when line numbers are enabled)
+        std::vector<SequencePointInfo> SequencePoints;          // sorted by IL offset
+        std::vector<COR_PRF_CODE_INFO> CodeRanges;              // native code chunks, in emission order
+        std::vector<COR_DEBUG_IL_TO_NATIVE_MAP> IlToNativeMap;  // sorted by nativeStartOffset
+
         operator FrameInfoView() const
         {
             return {ModuleName, Frame, Filename, StartLine};
         }
     };
+
+    // fetches the native code ranges and the IL-to-native mapping of the jitted method,
+    // needed to resolve the source line of a sampled instruction pointer
+    void CollectLineResolutionData(FunctionID functionId, FrameInfo& frameInfo);
+    // maps an instruction pointer to a source line via the method's IL-to-native mapping
+    // and sequence points; returns 0 when the line cannot be resolved
+    static std::uint32_t ResolveLine(const FrameInfo& frameInfo, uintptr_t instructionPointer);
 
     ICorProfilerInfo4* _pCorProfilerInfo;
     IDebugInfoStore* _pDebugInfoStore;
@@ -194,6 +206,7 @@ private:
     std::unordered_map<ClassID, std::string> _fullTypeNames;
 
     bool _resolveNativeFrames;
+    bool _areLineNumbersEnabled;
     ManagedCodeCache* _pManagedCodeCache;
     // TODO: dump stats about caches size at the end of the application
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/IConfiguration.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/IConfiguration.h
@@ -66,6 +66,9 @@ public:
     virtual bool IsHeapProfilingEnabled() const = 0;
     virtual bool IsAllocationRecorderEnabled() const = 0;
     virtual bool IsDebugInfoEnabled() const = 0;
+    // when enabled, the source file and the method start line coming from the .pdb are
+    // written into the pprof Function.filename/Function.start_line/Line.line fields
+    virtual bool IsSourceLocationEnabled() const = 0;
     virtual bool IsGcThreadsCpuTimeEnabled() const = 0;
     virtual bool IsThreadLifetimeEnabled() const = 0;
     virtual std::string const& GetGitRepositoryUrl() const = 0;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/IConfiguration.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/IConfiguration.h
@@ -69,6 +69,10 @@ public:
     // when enabled, the source file and the method start line coming from the .pdb are
     // written into the pprof Function.filename/Function.start_line/Line.line fields
     virtual bool IsSourceLocationEnabled() const = 0;
+    // when enabled, Line.line holds the line of the sampled instruction (resolved from its
+    // IL offset and the .pdb sequence points) instead of the method start line; implies
+    // IsSourceLocationEnabled
+    virtual bool IsLineNumbersEnabled() const = 0;
     virtual bool IsGcThreadsCpuTimeEnabled() const = 0;
     virtual bool IsThreadLifetimeEnabled() const = 0;
     virtual std::string const& GetGitRepositoryUrl() const = 0;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/IDebugInfoStore.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/IDebugInfoStore.h
@@ -12,12 +12,24 @@
 
 #include <string_view>
 #include <cstdint>
+#include <vector>
+
+struct SequencePointInfo
+{
+public:
+    std::uint32_t ILOffset;
+    std::uint32_t StartLine;
+};
 
 struct SymbolDebugInfo
 {
 public:
     std::string_view File;
     std::uint32_t StartLine = 0;
+
+    // non-hidden sequence points of the method, sorted by IL offset; used to resolve the
+    // source line of a sampled instruction. Only populated when line numbers are enabled.
+    std::vector<SequencePointInfo> SequencePoints;
 };
 
 class IDebugInfoStore : public IMemoryFootprintProvider

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/IFrameStore.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/IFrameStore.h
@@ -16,7 +16,12 @@ public:
     std::string_view ModuleName;
     std::string_view Frame;
     std::string_view Filename;
-    std::uint32_t StartLine;
+    std::uint32_t StartLine = 0;
+
+    // line of the sampled instruction inside the method, resolved from its IL offset
+    // (0 when unknown). Only filled when line numbers are enabled; consumers fall back
+    // to StartLine otherwise.
+    std::uint32_t Line = 0;
 };
 
 class IFrameStore : public IMemoryFootprintProvider

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/PprofBuilder.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/PprofBuilder.cpp
@@ -25,10 +25,10 @@ void PprofBuilder::AddSample(const Sample& sample, std::span<const int64_t> valu
     assert(values.size() == _sampleTypeDefinitions.size());
     std::lock_guard lock(this->_lock);
     auto* pSample = _profile.add_sample();
-    auto addLocation = [&](std::string_view frame, std::string_view filename, std::uint32_t startLine) {
+    auto addLocation = [&](std::string_view frame, std::string_view filename, std::uint32_t startLine, std::uint32_t line) {
         const auto filenameStringId = AddString(filename);
         const auto functionNameStringId = AddString(frame);
-        const auto locId = AddLocation(functionNameStringId, filenameStringId, startLine);
+        const auto locId = AddLocation(functionNameStringId, filenameStringId, startLine, line);
         pSample->add_location_id(locId);
     };
     auto addFrame = [&](const FrameInfoView& frame) {
@@ -36,11 +36,14 @@ void PprofBuilder::AddSample(const Sample& sample, std::span<const int64_t> valu
         // the .pdb debug info gave us an actual source file for this method.
         if (_emitSourceLocation && !frame.Filename.empty())
         {
-            addLocation(frame.Frame, frame.Filename, frame.StartLine);
+            // Frame.Line holds the line of the sampled instruction when line numbers are
+            // enabled; otherwise fall back to the method start line
+            const auto line = (frame.Line != 0) ? frame.Line : frame.StartLine;
+            addLocation(frame.Frame, frame.Filename, frame.StartLine, line);
         }
         else
         {
-            addLocation(frame.Frame, frame.ModuleName, 0);
+            addLocation(frame.Frame, frame.ModuleName, 0, 0);
         }
     };
     AddTraceContext(sample, pSample);
@@ -50,7 +53,7 @@ void PprofBuilder::AddSample(const Sample& sample, std::span<const int64_t> valu
         _scratchBuffer.reserve(ClassLeafPrefix.size() + frame.size());
         _scratchBuffer.append(ClassLeafPrefix);
         _scratchBuffer.append(frame);
-        addLocation(_scratchBuffer, {}, 0);
+        addLocation(_scratchBuffer, {}, 0, 0);
     }
     for (auto const& frame : sample.GetCallstack())
     {
@@ -122,39 +125,56 @@ int64_t PprofBuilder::AddString(const std::string_view& keyNotOwned)
     return id;
 }
 
-int64_t PprofBuilder::AddLocation(int64_t functionName, int64_t filename, std::uint32_t startLine)
+int64_t PprofBuilder::AddLocation(int64_t functionName, int64_t filename, std::uint32_t startLine, std::uint32_t line)
 {
-    std::tuple<int64_t, int64_t, std::uint32_t> loc(filename, functionName, startLine);
-    auto it = _locations.find(loc);
-    if (it != _locations.end())
+    // a method is a single pprof Function, referenced by one Location per sampled line
+    // (when line numbers are disabled, line == startLine and there is one Location per method)
+    std::tuple<int64_t, int64_t, std::uint32_t> functionKey(filename, functionName, startLine);
+    int64_t functionId;
+    auto functionIt = _functions.find(functionKey);
+    if (functionIt != _functions.end())
     {
-        return it->second;
+        functionId = functionIt->second;
     }
-    int64_t id = (int64_t)_profile.location_size() + 1;
-    assert(_profile.location_size() == _locations.size());
-    assert(_profile.function_size() == _locations.size());
-    auto* pFunction = _profile.add_function();
-    pFunction->set_id(id);
-    pFunction->set_name(functionName);
-    pFunction->set_filename(filename);
+    else
+    {
+        functionId = (int64_t)_profile.function_size() + 1;
+        auto* pFunction = _profile.add_function();
+        pFunction->set_id(functionId);
+        pFunction->set_name(functionName);
+        pFunction->set_filename(filename);
+        if (startLine != 0)
+        {
+            pFunction->set_start_line(startLine);
+        }
+        _functions.insert(std::make_pair(functionKey, functionId));
+    }
+
+    std::pair<int64_t, std::uint32_t> locationKey(functionId, line);
+    auto locationIt = _locations.find(locationKey);
+    if (locationIt != _locations.end())
+    {
+        return locationIt->second;
+    }
+    int64_t locationId = (int64_t)_profile.location_size() + 1;
     auto* pLocation = _profile.add_location();
-    pLocation->set_id(id);
+    pLocation->set_id(locationId);
     auto* pLine = pLocation->add_line();
-    pLine->set_function_id(id);
-    if (startLine != 0)
+    pLine->set_function_id(functionId);
+    if (line != 0)
     {
-        // there is no call site line in the pipeline: the .pdb only gives us the line
-        // the method is declared at, which is reported for both the function and the line
-        pFunction->set_start_line(startLine);
-        pLine->set_line(startLine);
+        // there is no call site line in the pipeline: this is either the line of the sampled
+        // instruction (line numbers enabled) or the line the method is declared at
+        pLine->set_line(line);
     }
-    _locations.insert(std::make_pair(loc, id));
-    return id;
+    _locations.insert(std::make_pair(locationKey, locationId));
+    return locationId;
 }
 
 void PprofBuilder::Reset()
 {
     _samplesCount = 0;
+    _functions.clear();
     _locations.clear();
     _strings.clear();
     _profile = google::v1::Profile();

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/PprofBuilder.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/PprofBuilder.cpp
@@ -13,8 +13,9 @@ auto constexpr traceIDLabelName  = "trace_id";
 
 }
 
-PprofBuilder::PprofBuilder(std::vector<SampleValueType> sampleTypeDefinitions) :
-    _sampleTypeDefinitions(std::move(sampleTypeDefinitions))
+PprofBuilder::PprofBuilder(std::vector<SampleValueType> sampleTypeDefinitions, bool emitSourceLocation) :
+    _sampleTypeDefinitions(std::move(sampleTypeDefinitions)),
+    _emitSourceLocation(emitSourceLocation)
 {
     Reset();
 }
@@ -24,14 +25,23 @@ void PprofBuilder::AddSample(const Sample& sample, std::span<const int64_t> valu
     assert(values.size() == _sampleTypeDefinitions.size());
     std::lock_guard lock(this->_lock);
     auto* pSample = _profile.add_sample();
-    auto addLocation = [&](std::string_view frame, std::string_view module) {
-        const auto moduleNameStringId = AddString(module);
+    auto addLocation = [&](std::string_view frame, std::string_view filename, std::uint32_t startLine) {
+        const auto filenameStringId = AddString(filename);
         const auto functionNameStringId = AddString(frame);
-        const auto locId = AddLocation(functionNameStringId, moduleNameStringId);
+        const auto locId = AddLocation(functionNameStringId, filenameStringId, startLine);
         pSample->add_location_id(locId);
     };
     auto addFrame = [&](const FrameInfoView& frame) {
-        addLocation(frame.Frame, frame.ModuleName);
+        // Function.filename holds the assembly name, unless source locations are enabled and
+        // the .pdb debug info gave us an actual source file for this method.
+        if (_emitSourceLocation && !frame.Filename.empty())
+        {
+            addLocation(frame.Frame, frame.Filename, frame.StartLine);
+        }
+        else
+        {
+            addLocation(frame.Frame, frame.ModuleName, 0);
+        }
     };
     AddTraceContext(sample, pSample);
     if (auto frame = sample.GetLeafFrame(); !frame.empty())
@@ -40,7 +50,7 @@ void PprofBuilder::AddSample(const Sample& sample, std::span<const int64_t> valu
         _scratchBuffer.reserve(ClassLeafPrefix.size() + frame.size());
         _scratchBuffer.append(ClassLeafPrefix);
         _scratchBuffer.append(frame);
-        addLocation(_scratchBuffer, {});
+        addLocation(_scratchBuffer, {}, 0);
     }
     for (auto const& frame : sample.GetCallstack())
     {
@@ -112,9 +122,9 @@ int64_t PprofBuilder::AddString(const std::string_view& keyNotOwned)
     return id;
 }
 
-int64_t PprofBuilder::AddLocation(int64_t functionName, int64_t moduleName)
+int64_t PprofBuilder::AddLocation(int64_t functionName, int64_t filename, std::uint32_t startLine)
 {
-    std::pair<int64_t, int64_t> loc(moduleName, functionName);
+    std::tuple<int64_t, int64_t, std::uint32_t> loc(filename, functionName, startLine);
     auto it = _locations.find(loc);
     if (it != _locations.end())
     {
@@ -126,11 +136,18 @@ int64_t PprofBuilder::AddLocation(int64_t functionName, int64_t moduleName)
     auto* pFunction = _profile.add_function();
     pFunction->set_id(id);
     pFunction->set_name(functionName);
-    pFunction->set_filename(moduleName);
+    pFunction->set_filename(filename);
     auto* pLocation = _profile.add_location();
     pLocation->set_id(id);
     auto* pLine = pLocation->add_line();
     pLine->set_function_id(id);
+    if (startLine != 0)
+    {
+        // there is no call site line in the pipeline: the .pdb only gives us the line
+        // the method is declared at, which is reported for both the function and the line
+        pFunction->set_start_line(startLine);
+        pLine->set_line(startLine);
+    }
     _locations.insert(std::make_pair(loc, id));
     return id;
 }

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/PprofBuilder.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/PprofBuilder.h
@@ -9,16 +9,19 @@
 #include "google/v1/profile.pb.h"
 #include "IExporter.h"
 
+#include <cstdint>
+#include <map>
 #include <memory>
 #include <mutex>
 #include <span>
 #include <string>
 #include <string_view>
+#include <tuple>
 
 class PprofBuilder
 {
 public:
-    PprofBuilder(std::vector<SampleValueType> sampleTypeDefinitions);
+    PprofBuilder(std::vector<SampleValueType> sampleTypeDefinitions, bool emitSourceLocation = false);
     void AddTraceContext(const Sample& sample, google::v1::Sample* pSample);
 
     void AddSample(const Sample& sample, std::span<const int64_t> values);
@@ -27,15 +30,16 @@ public:
 private:
     int64_t AddHexString(std::span<const std::byte> bs);
     int64_t AddString(const std::string_view& sv);
-    int64_t AddLocation(int64_t functionName, int64_t moduleName);
+    int64_t AddLocation(int64_t functionName, int64_t filename, std::uint32_t startLine);
     void Reset();
 
     std::mutex _lock;
     int _samplesCount = 0;
     google::v1::Profile _profile;
     std::map<std::string_view, int64_t> _strings;
-    std::map<std::pair<int64_t, int64_t>, int64_t> _locations;
+    std::map<std::tuple<int64_t, int64_t, std::uint32_t>, int64_t> _locations;
     std::vector<SampleValueType> _sampleTypeDefinitions;
+    bool _emitSourceLocation;
     std::string _scratchBuffer;
 
     int64_t _span_id_str_index{};

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/PprofBuilder.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/PprofBuilder.h
@@ -30,14 +30,17 @@ public:
 private:
     int64_t AddHexString(std::span<const std::byte> bs);
     int64_t AddString(const std::string_view& sv);
-    int64_t AddLocation(int64_t functionName, int64_t filename, std::uint32_t startLine);
+    int64_t AddLocation(int64_t functionName, int64_t filename, std::uint32_t startLine, std::uint32_t line);
     void Reset();
 
     std::mutex _lock;
     int _samplesCount = 0;
     google::v1::Profile _profile;
     std::map<std::string_view, int64_t> _strings;
-    std::map<std::tuple<int64_t, int64_t, std::uint32_t>, int64_t> _locations;
+    // (filename, function name, start line) -> pprof Function id
+    std::map<std::tuple<int64_t, int64_t, std::uint32_t>, int64_t> _functions;
+    // (pprof Function id, line) -> pprof Location id
+    std::map<std::pair<int64_t, std::uint32_t>, int64_t> _locations;
     std::vector<SampleValueType> _sampleTypeDefinitions;
     bool _emitSourceLocation;
     std::string _scratchBuffer;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/PprofExporter.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/PprofExporter.cpp
@@ -14,7 +14,8 @@
 
 PprofExporter::PprofExporter(IApplicationStore* applicationStore,
                              std::shared_ptr<PProfExportSink> sink,
-                             std::vector<SampleValueType> sampleTypeDefinitions) :
+                             std::vector<SampleValueType> sampleTypeDefinitions,
+                             bool emitSourceLocation) :
     _applicationStore(applicationStore),
     _sink(std::move(sink))
 {
@@ -33,7 +34,7 @@ PprofExporter::PprofExporter(IApplicationStore* applicationStore,
             ++i;
         }
 
-        _entries.push_back(std::make_unique<ProfileTypeEntry>(startIndex, groupTypes.size(), currentType, std::move(groupTypes)));
+        _entries.push_back(std::make_unique<ProfileTypeEntry>(startIndex, groupTypes.size(), currentType, std::move(groupTypes), emitSourceLocation));
     }
 
 #ifndef _WIN32

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/PprofExporter.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/PprofExporter.h
@@ -35,8 +35,8 @@ public:
 
 struct ProfileTypeEntry
 {
-    ProfileTypeEntry(size_t startIndex, size_t count, ProfileType profileType, std::vector<SampleValueType> sampleTypes) :
-        startIndex(startIndex), count(count), profileType(profileType), builder(std::move(sampleTypes)) {}
+    ProfileTypeEntry(size_t startIndex, size_t count, ProfileType profileType, std::vector<SampleValueType> sampleTypes, bool emitSourceLocation) :
+        startIndex(startIndex), count(count), profileType(profileType), builder(std::move(sampleTypes), emitSourceLocation) {}
 
     size_t startIndex;                 // offset into Sample::GetValues()
     size_t count;                      // number of values for this profile type
@@ -50,7 +50,8 @@ class PprofExporter : public IExporter
 public:
     PprofExporter(IApplicationStore* applicationStore,
                   std::shared_ptr<PProfExportSink> sink,
-                  std::vector<SampleValueType> sampleTypeDefinitions);
+                  std::vector<SampleValueType> sampleTypeDefinitions,
+                  bool emitSourceLocation = false);
     void Add(std::shared_ptr<Sample> const& sample) override;
     void SetEndpoint(const std::string& runtimeId, uint64_t traceId, const std::string& endpoint) override;
     bool Export(ProfileTime& startTime, ProfileTime& endTime, bool lastCall = false) override;

--- a/profiler/test/Datadog.Profiler.Native.Tests/ConfigurationTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/ConfigurationTest.cpp
@@ -725,6 +725,34 @@ TEST_F(ConfigurationTest, CheckSourceLocationEnablesDebugInfo)
     ASSERT_THAT(configuration.IsDebugInfoEnabled(), true);
 }
 
+TEST_F(ConfigurationTest, CheckLineNumbersIsDisabledByDefault)
+{
+    auto configuration = Configuration{};
+    ASSERT_THAT(configuration.IsLineNumbersEnabled(), false);
+}
+
+TEST_F(ConfigurationTest, CheckLineNumbersIsEnabledIfEnvVarSetToTrue)
+{
+    EnvironmentHelper::EnvironmentVariable ar(EnvironmentVariables::LineNumbersEnabled, WStr("1"));
+    auto configuration = Configuration{};
+    ASSERT_THAT(configuration.IsLineNumbersEnabled(), true);
+}
+
+TEST_F(ConfigurationTest, CheckLineNumbersIsDisabledIfEnvVarSetToFalse)
+{
+    EnvironmentHelper::EnvironmentVariable ar(EnvironmentVariables::LineNumbersEnabled, WStr("0"));
+    auto configuration = Configuration{};
+    ASSERT_THAT(configuration.IsLineNumbersEnabled(), false);
+}
+
+TEST_F(ConfigurationTest, CheckLineNumbersEnablesSourceLocationAndDebugInfo)
+{
+    EnvironmentHelper::EnvironmentVariable ar(EnvironmentVariables::LineNumbersEnabled, WStr("1"));
+    auto configuration = Configuration{};
+    ASSERT_THAT(configuration.IsSourceLocationEnabled(), true);
+    ASSERT_THAT(configuration.IsDebugInfoEnabled(), true);
+}
+
 TEST_F(ConfigurationTest, CheckGcThreadsCpuTimeEnabledTakesOverInternal)
 {
     EnvironmentHelper::EnvironmentVariable ev1(EnvironmentVariables::GcThreadsCpuTimeEnabled, WStr("1"));

--- a/profiler/test/Datadog.Profiler.Native.Tests/ConfigurationTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/ConfigurationTest.cpp
@@ -698,6 +698,33 @@ TEST_F(ConfigurationTest, CheckDebugInfoIsDisabledIfEnvVarSetToFalse)
     ASSERT_THAT(configuration.IsDebugInfoEnabled(), false);
 }
 
+TEST_F(ConfigurationTest, CheckSourceLocationIsDisabledByDefault)
+{
+    auto configuration = Configuration{};
+    ASSERT_THAT(configuration.IsSourceLocationEnabled(), false);
+}
+
+TEST_F(ConfigurationTest, CheckSourceLocationIsEnabledIfEnvVarSetToTrue)
+{
+    EnvironmentHelper::EnvironmentVariable ar(EnvironmentVariables::SourceLocationEnabled, WStr("1"));
+    auto configuration = Configuration{};
+    ASSERT_THAT(configuration.IsSourceLocationEnabled(), true);
+}
+
+TEST_F(ConfigurationTest, CheckSourceLocationIsDisabledIfEnvVarSetToFalse)
+{
+    EnvironmentHelper::EnvironmentVariable ar(EnvironmentVariables::SourceLocationEnabled, WStr("0"));
+    auto configuration = Configuration{};
+    ASSERT_THAT(configuration.IsSourceLocationEnabled(), false);
+}
+
+TEST_F(ConfigurationTest, CheckSourceLocationEnablesDebugInfo)
+{
+    EnvironmentHelper::EnvironmentVariable ar(EnvironmentVariables::SourceLocationEnabled, WStr("1"));
+    auto configuration = Configuration{};
+    ASSERT_THAT(configuration.IsDebugInfoEnabled(), true);
+}
+
 TEST_F(ConfigurationTest, CheckGcThreadsCpuTimeEnabledTakesOverInternal)
 {
     EnvironmentHelper::EnvironmentVariable ev1(EnvironmentVariables::GcThreadsCpuTimeEnabled, WStr("1"));

--- a/profiler/test/Datadog.Profiler.Native.Tests/DebugInfoStoreTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/DebugInfoStoreTest.cpp
@@ -268,6 +268,7 @@ TEST(DebugInfoStoreTest, ParseModuleDebugInfo_NetCorePortable)
 
     auto [configuration, mockConfiguration] = CreateConfiguration();
     EXPECT_CALL(mockConfiguration, IsDebugInfoEnabled()).WillRepeatedly(Return(true));
+    EXPECT_CALL(mockConfiguration, IsLineNumbersEnabled()).WillRepeatedly(Return(false));
 
     DebugInfoStore debugInfoStore(nullptr, configuration.get());
 
@@ -281,4 +282,66 @@ TEST(DebugInfoStoreTest, ParseModuleDebugInfo_NetCorePortable)
     // Portable PDBs use RID-based lookup
     ASSERT_FALSE(moduleInfo.RidToDebugInfo.empty()) << "Expected RID to debug info mapping for Portable PDB";
     ASSERT_FALSE(moduleInfo.Files.empty()) << "Expected source files in debug info";
+
+    // line numbers are disabled: no sequence points should have been kept
+    for (const auto& debugInfo : moduleInfo.RidToDebugInfo)
+    {
+        ASSERT_TRUE(debugInfo.SequencePoints.empty()) << "Sequence points must not be stored when line numbers are disabled";
+    }
+}
+
+// When line numbers are enabled, the whole per-method sequence point table is kept
+// (sorted by IL offset) so a sampled IL offset can be resolved to its source line.
+TEST(DebugInfoStoreTest, ParseModuleDebugInfo_NetCorePortableSequencePoints)
+{
+    auto [pdbPath, modulePath] = GetSamplePdbPath("Samples.BuggyBits", "net10.0");
+    if (pdbPath.empty())
+    {
+        GTEST_SKIP() << "Failed to get current process path";
+        return;
+    }
+
+    std::error_code ec;
+    if (!fs::exists(pdbPath, ec) || !fs::exists(modulePath, ec))
+    {
+        GTEST_SKIP() << "Samples.BuggyBits.pdb (net10.0) not found. This is expected if net10.0 is not compiled.";
+        return;
+    }
+
+    ModuleDebugInfo moduleInfo;
+
+    auto [configuration, mockConfiguration] = CreateConfiguration();
+    EXPECT_CALL(mockConfiguration, IsDebugInfoEnabled()).WillRepeatedly(Return(true));
+    EXPECT_CALL(mockConfiguration, IsLineNumbersEnabled()).WillRepeatedly(Return(true));
+
+    DebugInfoStore debugInfoStore(nullptr, configuration.get());
+    debugInfoStore.ParseModuleDebugInfo(0, pdbPath.string(), modulePath.string(), moduleInfo);
+
+    ASSERT_EQ(moduleInfo.LoadingState, SymbolLoadingState::Portable);
+
+    bool foundSequencePoints = false;
+    for (const auto& debugInfo : moduleInfo.RidToDebugInfo)
+    {
+        if (debugInfo.SequencePoints.empty())
+        {
+            continue;
+        }
+        foundSequencePoints = true;
+
+        // the first non-hidden point defines the method start line
+        ASSERT_EQ(debugInfo.SequencePoints.front().StartLine, debugInfo.StartLine);
+
+        // points must be sorted by IL offset (FrameStore::ResolveLine binary searches them)
+        for (size_t i = 1; i < debugInfo.SequencePoints.size(); ++i)
+        {
+            ASSERT_LE(debugInfo.SequencePoints[i - 1].ILOffset, debugInfo.SequencePoints[i].ILOffset);
+        }
+
+        // hidden sequence points (0xfeefee) must have been filtered out
+        for (const auto& point : debugInfo.SequencePoints)
+        {
+            ASSERT_NE(point.StartLine, 0xfeefee);
+        }
+    }
+    ASSERT_TRUE(foundSequencePoints) << "Expected at least one method with sequence points";
 }

--- a/profiler/test/Datadog.Profiler.Native.Tests/PprofBuilderTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/PprofBuilderTest.cpp
@@ -195,3 +195,47 @@ TEST(PprofBuilderTest, WithSourceLocationSameMethodInDifferentFilesGetsDistinctL
     EXPECT_NE(profile.sample(0).location_id(0), profile.sample(0).location_id(1));
     EXPECT_EQ(profile.location_size(), 2);
 }
+
+TEST(PprofBuilderTest, WithLineNumbersTheSampledLineIsEmitted)
+{
+    // Line (the line of the sampled instruction) takes precedence over StartLine for Line.line
+    auto profile = BuildProfileWithFrames(true, {FrameInfoView{"MyApp", "MyApp.Worker.Run", "/src/MyApp/Worker.cs", 42, 57}});
+
+    ASSERT_EQ(profile.sample_size(), 1);
+    ASSERT_EQ(profile.sample(0).location_id_size(), 1);
+    auto [function, line] = GetFrame(profile, 0);
+
+    EXPECT_EQ(profile.string_table(function.filename()), "/src/MyApp/Worker.cs");
+    EXPECT_EQ(function.start_line(), 42);
+    EXPECT_EQ(line.line(), 57);
+}
+
+TEST(PprofBuilderTest, WithLineNumbersSampledLinesOfTheSameMethodShareOneFunction)
+{
+    auto profile = BuildProfileWithFrames(true, {FrameInfoView{"MyApp", "MyApp.Worker.Run", "/src/MyApp/Worker.cs", 42, 57},
+                                                FrameInfoView{"MyApp", "MyApp.Worker.Run", "/src/MyApp/Worker.cs", 42, 61}});
+
+    ASSERT_EQ(profile.sample_size(), 1);
+    ASSERT_EQ(profile.sample(0).location_id_size(), 2);
+    EXPECT_NE(profile.sample(0).location_id(0), profile.sample(0).location_id(1));
+    EXPECT_EQ(profile.location_size(), 2);
+    EXPECT_EQ(profile.function_size(), 1);
+
+    auto [firstFunction, firstLine] = GetFrame(profile, 0);
+    auto [secondFunction, secondLine] = GetFrame(profile, 1);
+    EXPECT_EQ(firstFunction.id(), secondFunction.id());
+    EXPECT_EQ(firstLine.line(), 57);
+    EXPECT_EQ(secondLine.line(), 61);
+}
+
+TEST(PprofBuilderTest, WithLineNumbersSamplesOnTheSameLineShareASingleLocation)
+{
+    FrameInfoView frame{"MyApp", "MyApp.Worker.Run", "/src/MyApp/Worker.cs", 42, 57};
+    auto profile = BuildProfileWithFrames(true, {frame, frame});
+
+    ASSERT_EQ(profile.sample_size(), 1);
+    ASSERT_EQ(profile.sample(0).location_id_size(), 2);
+    EXPECT_EQ(profile.sample(0).location_id(0), profile.sample(0).location_id(1));
+    EXPECT_EQ(profile.location_size(), 1);
+    EXPECT_EQ(profile.function_size(), 1);
+}

--- a/profiler/test/Datadog.Profiler.Native.Tests/PprofBuilderTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/PprofBuilderTest.cpp
@@ -6,6 +6,8 @@
 #include <chrono>
 #include <map>
 #include <string>
+#include <utility>
+#include <vector>
 
 namespace
 {
@@ -25,6 +27,54 @@ google::v1::Profile BuildProfileWithTraceContext(const TraceContext& traceContex
     google::v1::Profile profile;
     EXPECT_TRUE(profile.ParseFromString(serialized));
     return profile;
+}
+
+google::v1::Profile BuildProfileWithFrames(bool emitSourceLocation, const std::vector<FrameInfoView>& frames)
+{
+    PprofBuilder builder({SampleValueType{"cpu", "nanoseconds", ProfileType::ProcessCpu, -1}}, emitSourceLocation);
+    Sample sample{"runtime-id"};
+    sample.SetTraceContext(TraceContext{}); // Sample leaves it uninitialized: no trace labels wanted here
+    for (auto const& frame : frames)
+    {
+        sample.AddFrame(frame);
+    }
+
+    std::array<int64_t, 1> values{42};
+    builder.AddSample(sample, values);
+
+    ProfileTime start{};
+    auto end = start + std::chrono::milliseconds{1};
+    auto serialized = builder.Build(start, end);
+
+    google::v1::Profile profile;
+    EXPECT_TRUE(profile.ParseFromString(serialized));
+    return profile;
+}
+
+// Returns the function/line pair pprof associates with the location at the given index of the first sample.
+std::pair<google::v1::Function, google::v1::Line> GetFrame(const google::v1::Profile& profile, int frameIndex)
+{
+    auto locationId = profile.sample(0).location_id(frameIndex);
+    for (const auto& location : profile.location())
+    {
+        if (location.id() != locationId)
+        {
+            continue;
+        }
+
+        EXPECT_EQ(location.line_size(), 1);
+        auto line = location.line(0);
+        for (const auto& function : profile.function())
+        {
+            if (function.id() == line.function_id())
+            {
+                return {function, line};
+            }
+        }
+    }
+
+    ADD_FAILURE() << "no function found for frame " << frameIndex;
+    return {};
 }
 
 std::map<std::string, std::string> GetStringLabels(const google::v1::Profile& profile, const google::v1::Sample& sample)
@@ -72,4 +122,76 @@ TEST(PprofBuilderTest, AddSampleWithoutLocalRootSpanIdDoesNotEmitTraceContextLab
 
     EXPECT_EQ(labels.find("span_id"), labels.end());
     EXPECT_EQ(labels.find("trace_id"), labels.end());
+}
+
+TEST(PprofBuilderTest, WithoutSourceLocationTheFunctionFilenameIsTheModuleName)
+{
+    auto profile = BuildProfileWithFrames(false, {FrameInfoView{"MyApp", "MyApp.Worker.Run", "/src/MyApp/Worker.cs", 42}});
+
+    ASSERT_EQ(profile.sample_size(), 1);
+    ASSERT_EQ(profile.sample(0).location_id_size(), 1);
+    auto [function, line] = GetFrame(profile, 0);
+
+    EXPECT_EQ(profile.string_table(function.name()), "MyApp.Worker.Run");
+    EXPECT_EQ(profile.string_table(function.filename()), "MyApp");
+    EXPECT_EQ(function.start_line(), 0);
+    EXPECT_EQ(line.line(), 0);
+}
+
+TEST(PprofBuilderTest, WithSourceLocationTheSourceFileAndStartLineAreEmitted)
+{
+    auto profile = BuildProfileWithFrames(true, {FrameInfoView{"MyApp", "MyApp.Worker.Run", "/src/MyApp/Worker.cs", 42},
+                                                FrameInfoView{"MyLib", "MyLib.Queue.Pop", "/src/MyLib/Queue.cs", 7}});
+
+    ASSERT_EQ(profile.sample_size(), 1);
+    ASSERT_EQ(profile.sample(0).location_id_size(), 2);
+
+    auto [worker, workerLine] = GetFrame(profile, 0);
+    EXPECT_EQ(profile.string_table(worker.name()), "MyApp.Worker.Run");
+    EXPECT_EQ(profile.string_table(worker.filename()), "/src/MyApp/Worker.cs");
+    EXPECT_EQ(worker.start_line(), 42);
+    EXPECT_EQ(workerLine.line(), 42);
+
+    auto [queue, queueLine] = GetFrame(profile, 1);
+    EXPECT_EQ(profile.string_table(queue.name()), "MyLib.Queue.Pop");
+    EXPECT_EQ(profile.string_table(queue.filename()), "/src/MyLib/Queue.cs");
+    EXPECT_EQ(queue.start_line(), 7);
+    EXPECT_EQ(queueLine.line(), 7);
+}
+
+TEST(PprofBuilderTest, WithSourceLocationFramesWithoutDebugInfoFallBackToTheModuleName)
+{
+    // no .pdb was found for that method: Filename is empty and StartLine is 0
+    auto profile = BuildProfileWithFrames(true, {FrameInfoView{"MyApp", "MyApp.Worker.Run", "", 0}});
+
+    ASSERT_EQ(profile.sample_size(), 1);
+    ASSERT_EQ(profile.sample(0).location_id_size(), 1);
+    auto [function, line] = GetFrame(profile, 0);
+
+    EXPECT_EQ(profile.string_table(function.filename()), "MyApp");
+    EXPECT_EQ(function.start_line(), 0);
+    EXPECT_EQ(line.line(), 0);
+}
+
+TEST(PprofBuilderTest, WithSourceLocationIdenticalFramesShareASingleLocation)
+{
+    FrameInfoView frame{"MyApp", "MyApp.Worker.Run", "/src/MyApp/Worker.cs", 42};
+    auto profile = BuildProfileWithFrames(true, {frame, frame});
+
+    ASSERT_EQ(profile.sample_size(), 1);
+    ASSERT_EQ(profile.sample(0).location_id_size(), 2);
+    EXPECT_EQ(profile.sample(0).location_id(0), profile.sample(0).location_id(1));
+    EXPECT_EQ(profile.location_size(), 1);
+    EXPECT_EQ(profile.function_size(), 1);
+}
+
+TEST(PprofBuilderTest, WithSourceLocationSameMethodInDifferentFilesGetsDistinctLocations)
+{
+    auto profile = BuildProfileWithFrames(true, {FrameInfoView{"MyApp", "MyApp.Worker.Run", "/src/MyApp/Worker.cs", 42},
+                                                FrameInfoView{"MyApp", "MyApp.Worker.Run", "/src/MyApp/Worker.g.cs", 42}});
+
+    ASSERT_EQ(profile.sample_size(), 1);
+    ASSERT_EQ(profile.sample(0).location_id_size(), 2);
+    EXPECT_NE(profile.sample(0).location_id(0), profile.sample(0).location_id(1));
+    EXPECT_EQ(profile.location_size(), 2);
 }

--- a/profiler/test/Datadog.Profiler.Native.Tests/ProfilerMockedInterface.h
+++ b/profiler/test/Datadog.Profiler.Native.Tests/ProfilerMockedInterface.h
@@ -79,6 +79,7 @@ public:
     MOCK_METHOD(bool, IsAllocationRecorderEnabled, (), (const override));
     MOCK_METHOD(bool, IsDebugInfoEnabled, (), (const override));
     MOCK_METHOD(bool, IsSourceLocationEnabled, (), (const override));
+    MOCK_METHOD(bool, IsLineNumbersEnabled, (), (const override));
     MOCK_METHOD(bool, IsGcThreadsCpuTimeEnabled, (), (const override));
     MOCK_METHOD(bool, IsThreadLifetimeEnabled, (), (const override));
     MOCK_METHOD(std::string const&, GetGitRepositoryUrl, (), (const override));

--- a/profiler/test/Datadog.Profiler.Native.Tests/ProfilerMockedInterface.h
+++ b/profiler/test/Datadog.Profiler.Native.Tests/ProfilerMockedInterface.h
@@ -78,6 +78,7 @@ public:
     MOCK_METHOD(bool, IsHeapProfilingEnabled, (), (const override));
     MOCK_METHOD(bool, IsAllocationRecorderEnabled, (), (const override));
     MOCK_METHOD(bool, IsDebugInfoEnabled, (), (const override));
+    MOCK_METHOD(bool, IsSourceLocationEnabled, (), (const override));
     MOCK_METHOD(bool, IsGcThreadsCpuTimeEnabled, (), (const override));
     MOCK_METHOD(bool, IsThreadLifetimeEnabled, (), (const override));
     MOCK_METHOD(std::string const&, GetGitRepositoryUrl, (), (const override));


### PR DESCRIPTION
> [!NOTE]
> Stacked on #397 (source locations) — the first commit here is that PR's commit; only 3ff7eaf02 is new. Rebase/merge after #397 lands.

## What

Adds `PYROSCOPE_PROFILING_LINE_NUMBERS_ENABLED` (**off by default**). When enabled, the pprof `Line.line` field holds the source line of the **sampled instruction** instead of the line the method is declared at. Enabling it implies `PYROSCOPE_PROFILING_SOURCE_LOCATION_ENABLED` and .pdb debug info collection.

## How

1. **DebugInfoStore** — the Portable PDB parser already decodes every sequence point but kept only the first line; with the flag on it now stores the full non-hidden sequence point table per method (`{ILOffset, StartLine}`, sorted by IL offset).
2. **FrameStore** — on first resolution of a function it also caches the native code ranges (`ICorProfilerInfo::GetCodeInfo2`) and the IL-to-native map (`GetILToNativeMapping`). Each sampled IP is then resolved lock-free with two binary searches: IP → native offset → IL offset (skipping prolog/epilog/unmapped entries) → sequence point → line, carried in a new `FrameInfoView.Line` field (`0` = unknown).
3. **PprofBuilder** — `Function` is now deduped by (name, filename, start line) and `Location` by (function id, line), so multiple sampled lines of one method share a single pprof `Function` with distinct `Location`s. With the flag off the output shape is unchanged (line falls back to the method start line).

## Known approximations

- Samples taken in a different compilation tier than the cached code version fall back to the method start line.
- Inlined callees attribute to the inliner (pre-existing: inlined frames never appear).
- Non-leaf frame IPs are return addresses, so attribution can occasionally point at the statement after the call.
- The Windows PDB fallback parsers (`SymPdbParser`/`DbgHelpParser`) stay start-line-only and degrade gracefully.

## Testing

- New unit tests: config gating/implication, per-sample line emission + `Function`/`Location` dedup in `PprofBuilder`, sequence point storage (sorted, hidden-filtered, only-when-enabled) in `DebugInfoStore`.
- `Datadog.Profiler.Native` and `Datadog.Profiler.Native.Windows` build clean with MSBuild (Debug x64); the gtest suite is Linux-only and runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)