### PR TITLE
Add Windows support to the CMake build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,7 +58,7 @@ endif()
 
 # Detect operating system
 if (CMAKE_SYSTEM_NAME MATCHES "Windows")
-    message(FATAL_ERROR "Windows builds are not supported using CMAKE. Please use Visual Studio")
+    message(STATUS "Preparing Windows build")
     SET(ISWINDOWS true)
 elseif (CMAKE_SYSTEM_NAME MATCHES "Linux")
     message(STATUS "Preparing Linux build")
@@ -78,11 +78,22 @@ SET(DOTNET_TRACER_REPO_ROOT_PATH ${CMAKE_CURRENT_SOURCE_DIR})
 
 LIST(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/build/cmake")
 
+if (ISWINDOWS)
+    # Match vcpkg's x64-windows-static triplet (static CRT), otherwise linking
+    # against vcpkg-supplied static libs (e.g. OpenSSL) fails with LNK2038.
+    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+endif()
+
 find_package(Coreclr REQUIRED)
 message(STATUS "Coreclr files ")
 
-find_package(Re2 REQUIRED)
-message(STATUS "Re2 library " ${RE2_VERSION})
+if (NOT ISWINDOWS)
+    # re2 is vestigial in this fork: re2-lib is never linked anywhere, and no
+    # source file includes re2/re2.h. Its ExternalProject_Add build also uses
+    # Unix-only tooling (autoreconf/make/lipo), so just skip it on Windows.
+    find_package(Re2 REQUIRED)
+    message(STATUS "Re2 library " ${RE2_VERSION})
+endif()
 
 # spdlog - header-only logging library (git submodule)
 set(SPDLOG_BUILD_EXAMPLE OFF CACHE INTERNAL "")
@@ -94,8 +105,14 @@ add_library(spdlog-headers INTERFACE)
 target_link_libraries(spdlog-headers INTERFACE spdlog::spdlog_header_only)
 message(STATUS "Spdlog library v" ${SPDLOG_VERSION})
 
-find_package(Libunwind REQUIRED)
-message(STATUS "Libunwind library " ${LIBUNWIND_VERSION})
+if (NOT ISWINDOWS)
+    # libunwind is only used by Datadog.Profiler.Native.Linux's own stack
+    # walker; Windows has its own unwinder under Datadog.Profiler.Native.Windows,
+    # and libunwind's ExternalProject_Add build (autoreconf/configure/make) is
+    # Unix-only tooling, so skip it on Windows.
+    find_package(Libunwind REQUIRED)
+    message(STATUS "Libunwind library " ${LIBUNWIND_VERSION})
+endif()
 
 # NOTE (pyroscope fork): libdatadog is intentionally NOT used by this fork.
 # The Datadog profile exporter was removed; nothing links or compiles against

--- a/build/cmake/FindCoreclr.cmake
+++ b/build/cmake/FindCoreclr.cmake
@@ -1,21 +1,44 @@
-add_library(coreclr OBJECT
-    ${DOTNET_TRACER_REPO_ROOT_PATH}/shared/src/native-lib/coreclr/src/pal/prebuilt/idl/corprof_i.cpp
-)
+if (ISWINDOWS)
+    # MSVC's __uuidof() resolves directly from the MIDL_INTERFACE(...) attributes
+    # already present in the vendored corprof.h, so unlike Clang there is no need
+    # to compile the classic MIDL-generated corprof_i.cpp companion (which defines
+    # IID_*/CLSID_* symbols) - neither Windows vcxproj compiles it either. Common
+    # code still needs the vendored coreclr headers (e.g. SymPdbParser.h pulls
+    # corsym.h/metahost.h from pal/prebuilt/inc), so keep coreclr as an
+    # include-only target on Windows.
+    # NOTE: only pal/prebuilt/inc + inc - NOT pal/inc/rt or pal/inc. Those two
+    # contain PAL replacements for COM primitives (IUnknown, IID, the `interface`
+    # macro, etc.) that exist only because Linux/macOS lack the real Windows SDK.
+    # On real Windows they collide with (and shadow) the genuine SDK headers of
+    # the same name, causing cascading redefinition/syntax errors. The real
+    # Datadog.Profiler.Native.vcxproj confirms this - it only ever adds
+    # $(CORECLR-PATH)/pal/prebuilt/inc and $(CORECLR-PATH)/inc.
+    add_library(coreclr INTERFACE)
 
-target_include_directories(coreclr PUBLIC
-    ${DOTNET_TRACER_REPO_ROOT_PATH}/shared/src/native-lib/coreclr/src/pal/inc/rt
-    ${DOTNET_TRACER_REPO_ROOT_PATH}/shared/src/native-lib/coreclr/src/pal/prebuilt/inc
-    ${DOTNET_TRACER_REPO_ROOT_PATH}/shared/src/native-lib/coreclr/src/pal/inc
-    ${DOTNET_TRACER_REPO_ROOT_PATH}/shared/src/native-lib/coreclr/src/inc
-)
+    target_include_directories(coreclr INTERFACE
+        ${DOTNET_TRACER_REPO_ROOT_PATH}/shared/src/native-lib/coreclr/src/pal/prebuilt/inc
+        ${DOTNET_TRACER_REPO_ROOT_PATH}/shared/src/native-lib/coreclr/src/inc
+    )
+else()
+    add_library(coreclr OBJECT
+        ${DOTNET_TRACER_REPO_ROOT_PATH}/shared/src/native-lib/coreclr/src/pal/prebuilt/idl/corprof_i.cpp
+    )
 
-target_compile_options(coreclr PUBLIC
-    -std=c++20
-    -DPAL_STDCPP_COMPAT
-    -DPLATFORM_UNIX
-    -DUNICODE
-    -fms-extensions
-    -DHOST_64BIT
-    -Wno-pragmas
-    -g
-)
+    target_include_directories(coreclr PUBLIC
+        ${DOTNET_TRACER_REPO_ROOT_PATH}/shared/src/native-lib/coreclr/src/pal/inc/rt
+        ${DOTNET_TRACER_REPO_ROOT_PATH}/shared/src/native-lib/coreclr/src/pal/prebuilt/inc
+        ${DOTNET_TRACER_REPO_ROOT_PATH}/shared/src/native-lib/coreclr/src/pal/inc
+        ${DOTNET_TRACER_REPO_ROOT_PATH}/shared/src/native-lib/coreclr/src/inc
+    )
+
+    target_compile_options(coreclr PUBLIC
+        -std=c++20
+        -DPAL_STDCPP_COMPAT
+        -DPLATFORM_UNIX
+        -DUNICODE
+        -fms-extensions
+        -DHOST_64BIT
+        -Wno-pragmas
+        -g
+    )
+endif()

--- a/build/cmake/FindPPDB.cmake
+++ b/build/cmake/FindPPDB.cmake
@@ -7,10 +7,16 @@ add_library(PPDB STATIC
   ${DOTNET_TRACER_REPO_ROOT_PATH}/shared/src/native-lib/PPDB/Reader/Streams.cpp
   ${DOTNET_TRACER_REPO_ROOT_PATH}/shared/src/native-lib/PPDB/Reader/Tables.cpp)
 
-# Sets compiler options
-target_compile_options(PPDB PRIVATE -std=c++20 -fPIC -fms-extensions)
-target_compile_options(PPDB PUBLIC -DPAL_STDCPP_COMPAT -DPLATFORM_UNIX -DUNICODE)
-target_compile_options(PPDB PRIVATE -Wno-invalid-noreturn -Wno-macro-redefined)
+if (ISWINDOWS)
+    # No -DPLATFORM_UNIX on Windows; no -fms-extensions equivalent needed since
+    # those MS-specific extensions are native under real cl.exe.
+    target_compile_options(PPDB PUBLIC /std:c++20 /DPAL_STDCPP_COMPAT /DUNICODE)
+else()
+    # Sets compiler options
+    target_compile_options(PPDB PRIVATE -std=c++20 -fPIC -fms-extensions)
+    target_compile_options(PPDB PUBLIC -DPAL_STDCPP_COMPAT -DPLATFORM_UNIX -DUNICODE)
+    target_compile_options(PPDB PRIVATE -Wno-invalid-noreturn -Wno-macro-redefined)
+endif()
 
 target_include_directories(PPDB
    PUBLIC ${DOTNET_TRACER_REPO_ROOT_PATH}/shared/src/native-lib/PPDB/inc)

--- a/profiler/CMakeLists.txt
+++ b/profiler/CMakeLists.txt
@@ -14,7 +14,7 @@ endif()
 
 # Detect operating system
 if (CMAKE_SYSTEM_NAME MATCHES "Windows")
-    message(FATAL_ERROR "Windows builds are not supported using CMAKE. Please use Visual Studio")
+    message(STATUS "Preparing Windows build")
     SET(ISWINDOWS true)
 elseif (CMAKE_SYSTEM_NAME MATCHES "Linux")
     message(STATUS "Preparing Linux build")
@@ -56,19 +56,22 @@ endif()
 # Detect prerequisites
 # ******************************************************
 
-find_program(FOUND_CLANG clang)
+if (NOT ISWINDOWS)
+    # Windows builds use the MSVC toolset via the Visual Studio generator; no clang required.
+    find_program(FOUND_CLANG clang)
 
-if (NOT FOUND_CLANG)
-    message(FATAL_ERROR "CLANG is required to build the project")
-else()
-    message(STATUS "CLANG was found")
-endif()
+    if (NOT FOUND_CLANG)
+        message(FATAL_ERROR "CLANG is required to build the project")
+    else()
+        message(STATUS "CLANG was found")
+    endif()
 
-find_program(FOUND_CLANGPP clang++)
-if (NOT FOUND_CLANGPP)
-    message(FATAL_ERROR "CLANG++ is required to build the project")
-else()
-    message(STATUS "CLANG++ was found")
+    find_program(FOUND_CLANGPP clang++)
+    if (NOT FOUND_CLANGPP)
+        message(FATAL_ERROR "CLANG++ is required to build the project")
+    else()
+        message(STATUS "CLANG++ was found")
+    endif()
 endif()
 
 find_program(FOUND_GIT "git")
@@ -88,7 +91,11 @@ if (DEFINED RUN_ANALYSIS AND RUN_ANALYSIS EQUAL 1)
     endif()
 endif()
 
-add_definitions("-D_GLIBCXX_USE_CXX11_ABI=0")
+if (NOT ISWINDOWS)
+    # libstdc++ ABI selector; meaningless (and not safely portable via add_definitions'
+    # dash-style flag) under MSVC's STL.
+    add_definitions("-D_GLIBCXX_USE_CXX11_ABI=0")
+endif()
 
 # ******************************************************
 # Output folders
@@ -106,10 +113,14 @@ else()
     SET(ARCH_POSTFIX "x86")
 endif()
 
-SET(ARCH_BASENAME "linux")
-if (DEFINED ENV{IsAlpine} AND "$ENV{IsAlpine}" MATCHES "true")
-    SET(IS_ALPINE)
-    SET(ARCH_BASENAME "${ARCH_BASENAME}-musl")
+if (ISWINDOWS)
+    SET(ARCH_BASENAME "win")
+else()
+    SET(ARCH_BASENAME "linux")
+    if (DEFINED ENV{IsAlpine} AND "$ENV{IsAlpine}" MATCHES "true")
+        SET(IS_ALPINE)
+        SET(ARCH_BASENAME "${ARCH_BASENAME}-musl")
+    endif()
 endif()
 
 SET(DEPLOY_DIR ${OUTPUT_BUILD_DIR}/DDProf-Deploy/${ARCH_BASENAME})
@@ -121,7 +132,9 @@ FILE(MAKE_DIRECTORY ${OUTPUT_DEPS_DIR})
 FILE(MAKE_DIRECTORY ${OUTPUT_TMP_DIR})
 
 
-add_compile_options(-fPIC)
+if (NOT ISWINDOWS)
+    add_compile_options(-fPIC)
+endif()
 option(USE_STATIC_OPENSSL "Link OpenSSL statically" ON)
 set(OPENSSL_USE_STATIC_LIBS ${USE_STATIC_OPENSSL})
 find_package(OpenSSL REQUIRED)
@@ -136,20 +149,27 @@ set_property(TARGET libprotobuf PROPERTY POSITION_INDEPENDENT_CODE ON)
 
 include_directories(third_party/cppcodec)
 
-add_subdirectory(src/ProfilerEngine/Datadog.Profiler.Native.Linux)
-add_subdirectory(src/ProfilerEngine/Datadog.Linux.ApiWrapper)
-enable_testing()
-add_subdirectory(test)
+if (ISLINUX)
+    add_subdirectory(src/ProfilerEngine/Datadog.Profiler.Native.Linux)
+    add_subdirectory(src/ProfilerEngine/Datadog.Linux.ApiWrapper)
+    enable_testing()
+    add_subdirectory(test)
 
-add_custom_target(profiler)
-add_dependencies(profiler Pyroscope.Profiler.Native)
+    add_custom_target(profiler)
+    add_dependencies(profiler Pyroscope.Profiler.Native)
 
-add_custom_target(all-profiler)
-add_dependencies(all-profiler profiler profiler-native-tests)
+    add_custom_target(all-profiler)
+    add_dependencies(all-profiler profiler profiler-native-tests)
 
-add_custom_target(wrapper)
-add_dependencies(wrapper Datadog.Linux.ApiWrapper.x64)
+    add_custom_target(wrapper)
+    add_dependencies(wrapper Datadog.Linux.ApiWrapper.x64)
 
-add_custom_target(all-wrapper)
-add_dependencies(all-wrapper wrapper wrapper-native-tests)
+    add_custom_target(all-wrapper)
+    add_dependencies(all-wrapper wrapper wrapper-native-tests)
+elseif (ISWINDOWS)
+    add_subdirectory(src/ProfilerEngine/Datadog.Profiler.Native.Windows)
+
+    add_custom_target(profiler)
+    add_dependencies(profiler Pyroscope.Profiler.Native)
+endif()
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/CMakeLists.txt
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/CMakeLists.txt
@@ -1,0 +1,103 @@
+# ******************************************************
+# Project definition
+# ******************************************************
+
+project("Datadog.Profiler.Native.Windows" VERSION 3.45.0)
+
+# ******************************************************
+# Environment detection
+# ******************************************************
+
+SET(PROFILER_SHARED_LIB_NAME Pyroscope.Profiler.Native)
+
+SET(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${DEPLOY_DIR})
+SET(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${DEPLOY_DIR})
+SET(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${DEPLOY_DIR})
+
+# ******************************************************
+# Sources
+# ******************************************************
+
+# Own-directory Windows-specific sources, mirroring Datadog.Profiler.Native.Windows.vcxproj's
+# explicit ClCompile list. Deliberately excluded:
+#  - CrashReportingWindows.cpp: <ExcludedFromBuild>true</ExcludedFromBuild> in the vcxproj too
+#    (kept only for clean upstream merges; crash reporting isn't shipped in this fork).
+#  - Timer.Windows.cpp (this directory's copy): stale duplicate of the common-dir file of the
+#    same name, not referenced by any vcxproj. The common-dir Timer.Windows.cpp (picked up via
+#    COMMON_PROFILER_SRC below) is the one the real Windows build actually uses.
+FILE(GLOB WINDOWS_PROFILER_SRC CONFIGURE_DEPENDS "*.cpp")
+list(REMOVE_ITEM WINDOWS_PROFILER_SRC
+    "${CMAKE_CURRENT_SOURCE_DIR}/CrashReportingWindows.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/Timer.Windows.cpp"
+)
+FILE(GLOB WINDOWS_ETW_SRC CONFIGURE_DEPENDS "ETW/*.cpp")
+
+FILE(GLOB COMMON_PROFILER_SRC LIST_DIRECTORIES false "../Datadog.Profiler.Native/*.cpp")
+FILE(GLOB_RECURSE PROTO_PROFILER_SRC CONFIGURE_DEPENDS "../Datadog.Profiler.Native/gen/*.pb.cc")
+
+# ******************************************************
+# Define shared target
+# ******************************************************
+
+add_library(${PROFILER_SHARED_LIB_NAME} SHARED
+    ${WINDOWS_PROFILER_SRC}
+    ${WINDOWS_ETW_SRC}
+    ${COMMON_PROFILER_SRC}
+    ${PROTO_PROFILER_SRC}
+    ${DOTNET_TRACER_REPO_ROOT_PATH}/shared/src/native-src/string.cpp
+    ${DOTNET_TRACER_REPO_ROOT_PATH}/shared/src/native-src/util.cpp
+    ${DOTNET_TRACER_REPO_ROOT_PATH}/shared/src/native-src/miniutf.cpp
+    Resource.rc
+)
+
+set_target_properties(${PROFILER_SHARED_LIB_NAME} PROPERTIES PREFIX "")
+
+target_include_directories(${PROFILER_SHARED_LIB_NAME} PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${CMAKE_CURRENT_SOURCE_DIR}/ETW
+    ${CMAKE_CURRENT_SOURCE_DIR}/../Datadog.Profiler.Native
+    ${CMAKE_CURRENT_SOURCE_DIR}/../Datadog.Profiler.Native/gen
+    ${DOTNET_TRACER_REPO_ROOT_PATH}
+    ${DOTNET_TRACER_REPO_ROOT_PATH}/profiler/third_party/cpp-httplib
+)
+
+target_compile_definitions(${PROFILER_SHARED_LIB_NAME} PRIVATE
+    WIN32
+    BIT64
+    DATADOGAUTOINSTRUMENTATIONPROFILERNATIVEWINDOWS_EXPORTS
+    _WINDOWS
+    _USRDLL
+    NOMINMAX
+    _SILENCE_STDEXT_ARR_ITERS_DEPRECATION_WARNING
+    MICROSOFT_WINDOWS_WINBASE_H_DEFINE_INTERLOCKED_CPLUSPLUS_OVERLOADS=1
+    CPPHTTPLIB_OPENSSL_SUPPORT
+    # NOTE: deliberately no CPPHTTPLIB_USE_POLL - that's POSIX-only (poll()), used only by
+    # the Linux CMakeLists; cpp-httplib's Windows path doesn't need or support it.
+)
+
+target_compile_options(${PROFILER_SHARED_LIB_NAME} PRIVATE
+    /utf-8
+    "/FI${DOTNET_TRACER_REPO_ROOT_PATH}/profiler/src/ProfilerEngine/Datadog.Profiler.Native/PyroscopeWindowsIncludeOrder.h"
+)
+
+# .def file controls DLL exports (DllMain/DllGetClassObject/DllCanUnloadNow + fork API),
+# equivalent of the vcxproj's <ModuleDefinitionFile>.
+set(dd_profiling_def_file "${CMAKE_CURRENT_SOURCE_DIR}/Datadog.Profiler.Native.def")
+target_link_options(${PROFILER_SHARED_LIB_NAME} PRIVATE "/DEF:${dd_profiling_def_file}")
+set_target_properties(${PROFILER_SHARED_LIB_NAME} PROPERTIES LINK_DEPENDS "${dd_profiling_def_file}")
+
+target_link_libraries(${PROFILER_SHARED_LIB_NAME} PRIVATE
+    coreclr
+    PPDB
+    spdlog-headers
+    libprotobuf
+    chmike::CxxUrl
+    OpenSSL::Crypto
+    OpenSSL::SSL
+    dbghelp
+    ole32
+    mscoree
+    ws2_32
+)
+
+add_dependencies(${PROFILER_SHARED_LIB_NAME} spdlog-headers PPDB)


### PR DESCRIPTION
## Summary

Today the CMake build hard-fails on Windows (`message(FATAL_ERROR "Windows builds are not supported using CMAKE...")` in both `CMakeLists.txt` and `profiler/CMakeLists.txt`), so the only way to build the Windows profiler is the separate MSBuild/vcxproj + vcpkg path. This adds a working Windows path through CMake itself:

- **At minimum**: CMake configure now succeeds on Windows, so CLion can open and fully index the project.
- **At most**: a new CMake target actually builds `Pyroscope.Profiler.Native.dll`, verified end-to-end on a Windows machine (VS 2026 generator + the vcpkg bundled with VS). The existing MSBuild/vcxproj path is untouched and remains what CI uses.

## What changed

- `CMakeLists.txt` / `profiler/CMakeLists.txt`: drop the Windows `FATAL_ERROR`; guard the tool/dependency requirements that are Unix-only and unneeded on Windows (clang discovery, `-fPIC`, `re2` — dead code, never actually linked anywhere in this fork — and `libunwind` — only used by Linux's own stack walker, since Windows has its own unwinder).
- `build/cmake/FindPPDB.cmake`: MSVC-flavored compile options for the same 3 source files Linux already builds.
- `build/cmake/FindCoreclr.cmake`: on Windows, `coreclr` becomes an include-only `INTERFACE` target rather than compiling `corprof_i.cpp` — MSVC's `__uuidof()` resolves IIDs/CLSIDs directly from `corprof.h`'s `MIDL_INTERFACE` attributes, so no Clang-style IID companion object is needed (neither Windows vcxproj compiles it either).
- New `profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/CMakeLists.txt`: builds the DLL as a single `SHARED` target (exports controlled via the existing `.def` file, so no need for Linux's static-lib/whole-archive/version-script split), mirroring the vcxproj's source list, defines, and forced-include/`/utf-8` workarounds. protobuf is built from the existing git submodule (same as Linux) rather than vcpkg, to avoid mixing vcpkg's compiled lib with submodule headers; vcpkg is used only for OpenSSL.

## The real bug

One genuine bug surfaced while getting the build to compile, now fixed in `FindCoreclr.cmake`: my first attempt included `coreclr/src/pal/inc/rt` and `coreclr/src/pal/inc` on Windows too (mirroring the Linux target). Those directories contain **PAL replacements for COM primitives** (`IUnknown`, `IID`, the `interface` macro, `unknwn.h`, `objidl.h`, etc.) that exist purely because Linux/macOS lack the real Windows SDK. On Windows they collide with — and shadow — the genuine SDK headers of the same name, which caused a cascade of redefinition and syntax errors starting deep inside common code (first surfaced compiling `miniutf.cpp`, which doesn't even use COM). The fix, confirmed against the real `Datadog.Profiler.Native.vcxproj`'s `AdditionalIncludeDirectories`, is to only ever add `pal/prebuilt/inc` and `inc` on Windows — never `pal/inc/rt` or bare `pal/inc`.

## Test plan

- [x] `git submodule update --init --recursive` for `protobuf`/`cpp-httplib`/`cppcodec`/`spdlog`
- [x] `cmake -G "Visual Studio 18 2026" -A x64 -DCMAKE_TOOLCHAIN_FILE=<vcpkg>/scripts/buildsystems/vcpkg.cmake -DVCPKG_TARGET_TRIPLET=x64-windows-static` configures cleanly
- [x] `cmake --build . --config RelWithDebInfo --target Pyroscope.Profiler.Native` builds `Pyroscope.Profiler.Native.dll` with zero errors
- [x] `dumpbin /exports` on the resulting DLL matches `Datadog.Profiler.Native.def` (`DllMain`, `SetConfiguration`, `FlushProfile`, etc.)
- [ ] Not covered here: wiring this into CI, the Windows native gtest target, and full .NET-side integration testing — all left as-is/out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)