### PR TITLE
fix(profiler): disable thread lifetime profiles by default

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.cpp
@@ -83,7 +83,7 @@ Configuration::Configuration()
     _isGcThreadsCpuTimeEnabled = GetEnvironmentValue(EnvironmentVariables::GcThreadsCpuTimeEnabled,
                                   GetEnvironmentValue(EnvironmentVariables::GcThreadsCpuTimeInternalEnabled, true), true);
     _isThreadLifetimeEnabled = GetEnvironmentValue(EnvironmentVariables::ThreadLifetimeEnabled,
-                                GetEnvironmentValue(EnvironmentVariables::ThreadLifetimeInternalEnabled, true), true);
+                                GetEnvironmentValue(EnvironmentVariables::ThreadLifetimeInternalEnabled, false), true);
     _gitRepositoryUrl = GetEnvironmentValue(EnvironmentVariables::GitRepositoryUrl, DefaultEmptyString);
     _gitCommitSha = GetEnvironmentValue(EnvironmentVariables::GitCommitSha, DefaultEmptyString);
     _isInternalMetricsEnabled = GetEnvironmentValue(EnvironmentVariables::InternalMetricsEnabled, false);

--- a/profiler/test/Datadog.Profiler.Native.Tests/ConfigurationTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/ConfigurationTest.cpp
@@ -771,10 +771,10 @@ TEST_F(ConfigurationTest, CheckInternalThreadLifetimeProfilingIsTakenIntoAccount
     ASSERT_THAT(configuration.IsThreadLifetimeEnabled(), expectedValue);
 }
 
-TEST_F(ConfigurationTest, CheckThreadLifetimeIsEnabledByDefault)
+TEST_F(ConfigurationTest, CheckThreadLifetimeIsDisabledByDefault)
 {
     auto configuration = Configuration{};
-    ASSERT_THAT(configuration.IsThreadLifetimeEnabled(), true);
+    ASSERT_THAT(configuration.IsThreadLifetimeEnabled(), false);
 }
 
 TEST_F(ConfigurationTest, CheckThreadLifetimeIfEnvVarSetToTrue)


### PR DESCRIPTION
## Summary
- disable thread lifetime profiling when neither configuration variable is set
- preserve `DD_THREAD_LIFETIME_ENABLED` and `DD_INTERNAL_THREAD_LIFETIME_ENABLED` as explicit opt-in overrides
- update the configuration test to assert the disabled default

## Test plan
- [x] `git diff --check`
- [ ] Native profiler tests in CI (local profiler builds are unsupported on macOS)