### PR TITLE
ci: build the profiler once and share it with the integration tests

### DIFF
--- a/.github/workflows/build_linux_profiler.yml
+++ b/.github/workflows/build_linux_profiler.yml
@@ -1,9 +1,8 @@
 name: Build linux profiler
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
-    branches: [main]
+  workflow_call:
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -25,6 +24,16 @@ jobs:
           submodules: 'true'
           persist-credentials: false
       - run: ARCH=x86_64 LIBC=${{ matrix.name }} make docker/archive
+      - name: Stage profiler binaries
+        run: |
+          mkdir profiler-bin
+          tar -xzf pyroscope.*-${{ matrix.name }}-x86_64.tar.gz -C profiler-bin
+      - name: Upload profiler binaries
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: profiler-linux-x86_64-${{ matrix.name }}
+          path: profiler-bin/
+          if-no-files-found: error
   build-linux-profiler-aarch64:
 
     runs-on: ${{ github.repository_owner == 'grafana' && 'ubuntu-arm64-large' || 'ubuntu-24.04-arm' }}
@@ -44,6 +53,16 @@ jobs:
         with:
           global-json-file: global.json
       - run: ARCH=aarch64 LIBC=${{ matrix.name }} make docker/archive
+      - name: Stage profiler binaries
+        run: |
+          mkdir profiler-bin
+          tar -xzf pyroscope.*-${{ matrix.name }}-aarch64.tar.gz -C profiler-bin
+      - name: Upload profiler binaries
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: profiler-linux-aarch64-${{ matrix.name }}
+          path: profiler-bin/
+          if-no-files-found: error
   build-managed-helper:
     runs-on: ${{ github.repository_owner == 'grafana' && 'ubuntu-x64-small' || 'ubuntu-latest' }}
     steps:

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -11,23 +11,8 @@ permissions:
   contents: read
 
 jobs:
-  discover:
-
-    name: discover tests
-    runs-on: ubuntu-latest
-    outputs:
-      tests: ${{ steps.tests.outputs.tests }}
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Set up Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
-        with:
-          go-version: 'stable'
-          cache-dependency-path: integration-test/go.sum
-      - name: Generate test matrix
-        id: tests
-        run: echo "tests=$(make ci-matrix)" >> "$GITHUB_OUTPUT"
-        working-directory: integration-test
+  build-profiler:
+    uses: ./.github/workflows/build_linux_profiler.yml
 
   unit-test:
     name: dockertest unit tests
@@ -44,13 +29,12 @@ jobs:
         working-directory: integration-test
 
   test:
-    name: integration-test ${{ matrix.test }} ${{ matrix.libc_type }} .NET ${{ matrix.version }}
-    needs: discover
+    name: integration tests (${{ matrix.libc_type }}, .NET ${{ matrix.version }})
+    needs: build-profiler
     runs-on: ${{ github.repository_owner == 'grafana' && 'ubuntu-x64-large' || 'ubuntu-latest' }}
     strategy:
       fail-fast: false
       matrix:
-        test: ${{ fromJSON(needs.discover.outputs.tests) }}
         libc_type: [glibc, musl]
         version: ['8.0', '9.0', '10.0']
     steps:
@@ -62,8 +46,13 @@ jobs:
         with:
           go-version: 'stable'
           cache-dependency-path: integration-test/go.sum
+      - name: Download profiler binaries
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: profiler-linux-x86_64-${{ matrix.libc_type }}
+          path: profiler-bin
       - name: Run integration test
-        run: go test -v -timeout 60m -count=1 -run '^${{ matrix.test }}$$' .
+        run: go test -v -timeout 90m -count=1 .
         env:
           LIBC_TYPE: ${{ matrix.libc_type }}
           DOTNET_VERSION: ${{ matrix.version }}

--- a/.gitignore
+++ b/.gitignore
@@ -91,6 +91,7 @@ dlldata.c
 project.lock.json
 project.fragment.lock.json
 artifacts/
+/profiler-bin/
 
 *_i.c
 *_p.c

--- a/integration-test-with-otel.Dockerfile
+++ b/integration-test-with-otel.Dockerfile
@@ -1,13 +1,11 @@
-ARG BUILDPLATFORM=linux/amd64
 ARG SDK_VERSION=8.0
-ARG PYROSCOPE_SDK_IMAGE
 ARG SDK_IMAGE_SUFFIX
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:$SDK_VERSION$SDK_IMAGE_SUFFIX AS build
+ARG DOTNET_RUNTIME_ID=linux-x64
+FROM mcr.microsoft.com/dotnet/sdk:$SDK_VERSION$SDK_IMAGE_SUFFIX AS build
 
-ARG TARGETPLATFORM
-ARG BUILDPLATFORM
 ARG SDK_VERSION
 ARG SDK_IMAGE_SUFFIX
+ARG DOTNET_RUNTIME_ID
 
 WORKDIR /dotnet
 
@@ -21,17 +19,14 @@ RUN sed -i -E 's|<TargetFrameworks>.*</TargetFrameworks>|<TargetFramework>net'$S
 
 WORKDIR /dotnet/app
 
-# We hardcode linux-x64 here, as the profiler doesn't support any other platform.
 # Publish to a separate directory: .NET 10+ cleans the output dir before compiling,
 # so -o . (source dir) would delete source files and cause CS5001.
-RUN dotnet publish -o /dotnet/publish --framework net$SDK_VERSION --runtime linux-x64 --no-self-contained
+RUN dotnet publish -o /dotnet/publish --framework net$SDK_VERSION --runtime $DOTNET_RUNTIME_ID --no-self-contained
 
-# This uses a locally built image of the SDK
-FROM --platform=linux/amd64 $PYROSCOPE_SDK_IMAGE AS sdk
-ARG PYROSCOPE_SDK_IMAGE
-
-# Runtime only image of the targetplatfrom, so the platform the image will be running on.
-FROM --platform=linux/amd64 mcr.microsoft.com/dotnet/aspnet:$SDK_VERSION$SDK_IMAGE_SUFFIX
+# Runtime-only image of the target platform.
+FROM mcr.microsoft.com/dotnet/aspnet:$SDK_VERSION$SDK_IMAGE_SUFFIX
+ARG DOTNET_RUNTIME_ID
+ARG PROFILER_BINARIES_DIR=profiler-bin
 
 RUN if command -v apt-get > /dev/null 2>&1; then \
         apt-get update && apt-get install -y --no-install-recommends curl unzip && rm -rf /var/lib/apt/lists/*; \
@@ -49,7 +44,7 @@ RUN mkdir -p ${OTEL_DOTNET_AUTO_HOME} && \
 # OTEL as the main (classic) profiler
 ENV CORECLR_ENABLE_PROFILING=1
 ENV CORECLR_PROFILER={918728DD-259F-4A6A-AC2B-B85E1B658318}
-ENV CORECLR_PROFILER_PATH=${OTEL_DOTNET_AUTO_HOME}/linux-x64/OpenTelemetry.AutoInstrumentation.Native.so
+ENV CORECLR_PROFILER_PATH=${OTEL_DOTNET_AUTO_HOME}/${DOTNET_RUNTIME_ID}/OpenTelemetry.AutoInstrumentation.Native.so
 ENV DOTNET_ADDITIONAL_DEPS=${OTEL_DOTNET_AUTO_HOME}/AdditionalDeps
 ENV DOTNET_SHARED_STORE=${OTEL_DOTNET_AUTO_HOME}/store
 ENV DOTNET_STARTUP_HOOKS=${OTEL_DOTNET_AUTO_HOME}/net/OpenTelemetry.AutoInstrumentation.StartupHook.dll
@@ -62,8 +57,8 @@ ENV OTEL_LOGS_EXPORTER=none
 WORKDIR /dotnet
 
 # Pyroscope as the notification profiler
-COPY --from=sdk /Pyroscope.Profiler.Native.so ./subfolder/Pyroscope.Profiler.Native.so
-COPY --from=sdk /Pyroscope.Linux.ApiWrapper.x64.so ./subfolder/Pyroscope.Linux.ApiWrapper.x64.so
+COPY ${PROFILER_BINARIES_DIR}/Pyroscope.Profiler.Native.so ./subfolder/Pyroscope.Profiler.Native.so
+COPY ${PROFILER_BINARIES_DIR}/Pyroscope.Linux.ApiWrapper.x64.so ./subfolder/Pyroscope.Linux.ApiWrapper.x64.so
 COPY --from=build /dotnet/publish ./
 
 ENV LD_LIBRARY_PATH=/dotnet/subfolder/

--- a/integration-test.Dockerfile
+++ b/integration-test.Dockerfile
@@ -1,13 +1,11 @@
-ARG BUILDPLATFORM=linux/amd64
 ARG SDK_VERSION=8.0
-ARG PYROSCOPE_SDK_IMAGE
 ARG SDK_IMAGE_SUFFIX
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:$SDK_VERSION$SDK_IMAGE_SUFFIX AS build
+ARG DOTNET_RUNTIME_ID=linux-x64
+FROM mcr.microsoft.com/dotnet/sdk:$SDK_VERSION$SDK_IMAGE_SUFFIX AS build
 
-ARG TARGETPLATFORM
-ARG BUILDPLATFORM
 ARG SDK_VERSION
 ARG SDK_IMAGE_SUFFIX
+ARG DOTNET_RUNTIME_ID
 
 WORKDIR /dotnet
 
@@ -21,24 +19,20 @@ RUN sed -i -E 's|<TargetFrameworks>.*</TargetFrameworks>|<TargetFramework>net'$S
 
 WORKDIR /dotnet/app
 
-# We hardcode linux-x64 here, as the profiler doesn't support any other platform.
 # Publish to a separate directory: .NET 10+ cleans the output dir before compiling,
 # so -o . (source dir) would delete source files and cause CS5001.
-RUN dotnet publish -o /dotnet/publish --framework net$SDK_VERSION --runtime linux-x64 --no-self-contained
+RUN dotnet publish -o /dotnet/publish --framework net$SDK_VERSION --runtime $DOTNET_RUNTIME_ID --no-self-contained
 
-# This uses a locally built image of the SDK
-FROM --platform=linux/amd64 $PYROSCOPE_SDK_IMAGE AS sdk
-ARG PYROSCOPE_SDK_IMAGE
-
-# Runtime only image of the targetplatfrom, so the platform the image will be running on.
-FROM --platform=linux/amd64 mcr.microsoft.com/dotnet/aspnet:$SDK_VERSION$SDK_IMAGE_SUFFIX
+# Runtime-only image of the target platform.
+FROM mcr.microsoft.com/dotnet/aspnet:$SDK_VERSION$SDK_IMAGE_SUFFIX
+ARG PROFILER_BINARIES_DIR=profiler-bin
 
 WORKDIR /dotnet
 
 # place the binaries in a subfolder - to rigger a problme when SONAME was Datadog.Profiler.Native
 # and dynamic linker could not find the profiler lib.
-COPY --from=sdk /Pyroscope.Profiler.Native.so ./subfolder/Pyroscope.Profiler.Native.so
-COPY --from=sdk /Pyroscope.Linux.ApiWrapper.x64.so ./subfolder/Pyroscope.Linux.ApiWrapper.x64.so
+COPY ${PROFILER_BINARIES_DIR}/Pyroscope.Profiler.Native.so ./subfolder/Pyroscope.Profiler.Native.so
+COPY ${PROFILER_BINARIES_DIR}/Pyroscope.Linux.ApiWrapper.x64.so ./subfolder/Pyroscope.Linux.ApiWrapper.x64.so
 COPY --from=build /dotnet/publish ./
 
 # Fix for alpine not being able to dlopen an already loaded library

--- a/integration-test/Makefile
+++ b/integration-test/Makefile
@@ -1,17 +1,10 @@
 REPO_ROOT := $(shell git rev-parse --show-toplevel)
+PROFILER_BINARIES_DIR ?= $(REPO_ROOT)/profiler-bin
 
-# Build profiler images
-.PHONY: build-profiler-glibc
-build-profiler-glibc:
-	docker build --platform linux/amd64 -t pyroscope-dotnet-glibc:test \
-		-f $(REPO_ROOT)/Pyroscope.Dockerfile \
-		--build-arg CMAKE_BUILD_TYPE=Debug $(REPO_ROOT)
-
-.PHONY: build-profiler-musl
-build-profiler-musl:
-	docker build --platform linux/amd64 -t pyroscope-dotnet-musl:test \
-		-f $(REPO_ROOT)/Pyroscope.musl.Dockerfile \
-		--build-arg CMAKE_BUILD_TYPE=Debug $(REPO_ROOT)
+.PHONY: check-profiler-binaries
+check-profiler-binaries:
+	test -f $(PROFILER_BINARIES_DIR)/Pyroscope.Profiler.Native.so
+	test -f $(PROFILER_BINARIES_DIR)/Pyroscope.Linux.ApiWrapper.x64.so
 
 .PHONY: ci-matrix
 ci-matrix:

--- a/integration-test/integration_test.go
+++ b/integration-test/integration_test.go
@@ -33,7 +33,8 @@ import (
 func startPyroscope(t *testing.T, net *dockertest.Network) string {
 	t.Helper()
 	c := dockertest.StartContainer(t, dockertest.ContainerRequest{
-		Image: "grafana/pyroscope:2.1.0@sha256:5a5f97d007be75746d336cf0f6a9ae8008c42d9d8200319ee92e52fea4ae38df",
+		Image:    "grafana/pyroscope:2.1.0@sha256:73b23dbb99f154a0803c136abafdff825475f415dd4d4587538d014c672b5a55",
+		Platform: dockerPlatform(runtime.GOARCH),
 		Cmd: []string{
 			"-validation.disable-label-sanitization=true",
 			"-distributor.health-check-ingesters=false",
@@ -59,12 +60,13 @@ func buildAppImage(t *testing.T, libcType, version string, otel bool) string {
 	dockertest.BuildImage(t, dockertest.BuildRequest{
 		Context:    repoRoot(),
 		Dockerfile: filepath.Join(repoRoot(), appDockerfile(otel)),
-		Platform:   "linux/amd64",
+		Platform:   dockerPlatform(runtime.GOARCH),
 		Tag:        tag,
 		BuildArgs: map[string]string{
-			"PYROSCOPE_SDK_IMAGE": profilerImageTag(libcType),
-			"SDK_VERSION":         version,
-			"SDK_IMAGE_SUFFIX":    sdkImageSuffix(libcType, version),
+			"PROFILER_BINARIES_DIR": profilerBinariesDir(t),
+			"SDK_VERSION":           version,
+			"SDK_IMAGE_SUFFIX":      sdkImageSuffix(libcType, version),
+			"DOTNET_RUNTIME_ID":     dotnetRuntimeID(runtime.GOARCH, libcType),
 		},
 	})
 	return tag
@@ -76,7 +78,6 @@ func startAppWithEnv(t *testing.T, net *dockertest.Network, pyroscopeURL, libcTy
 	if runtime.GOOS == "windows" {
 		return startHostApp(t, version, otel, svcName, pyroscopeURL, extraEnv)
 	}
-	ensureProfilerImage(t, libcType)
 	image := buildAppImage(t, libcType, version, otel)
 	env := map[string]string{
 		"REGION":                     "us-east",
@@ -89,7 +90,7 @@ func startAppWithEnv(t *testing.T, net *dockertest.Network, pyroscopeURL, libcTy
 	}
 	c := dockertest.StartContainer(t, dockertest.ContainerRequest{
 		Image:          image,
-		Platform:       "linux/amd64",
+		Platform:       dockerPlatform(runtime.GOARCH),
 		Network:        net.Name,
 		NetworkAliases: []string{"rideshare"},
 		Env:            env,
@@ -548,7 +549,6 @@ func startAppForTLSTest(t *testing.T, libcType, version, serverAddress string, c
 			"SSL_CERT_FILE": caPath,
 		})
 	}
-	ensureProfilerImage(t, libcType)
 	image := buildAppImage(t, libcType, version, false)
 
 	extraHost := hostDockerInternalExtraHost(t)
@@ -559,7 +559,7 @@ func startAppForTLSTest(t *testing.T, libcType, version, serverAddress string, c
 
 	c := dockertest.StartContainer(t, dockertest.ContainerRequest{
 		Image:    image,
-		Platform: "linux/amd64",
+		Platform: dockerPlatform(runtime.GOARCH),
 		Env: map[string]string{
 			"REGION":                     "us-east",
 			"PYROSCOPE_APPLICATION_NAME": "tls-test-app",

--- a/integration-test/matrix.go
+++ b/integration-test/matrix.go
@@ -3,12 +3,10 @@ package integrationtest
 import (
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"runtime"
-	"sync"
+	"strings"
 	"testing"
-	"time"
 )
 
 func envOrDefault(key, defaultValue string) string {
@@ -28,6 +26,38 @@ func envLibcType() string {
 }
 func envDotnetVersion() string { return envOrDefault("DOTNET_VERSION", "10.0") }
 
+func dockerPlatform(goarch string) string {
+	switch goarch {
+	case "amd64":
+		return "linux/amd64"
+	case "arm64":
+		return "linux/arm64"
+	default:
+		panic(fmt.Sprintf("unsupported architecture %q", goarch))
+	}
+}
+
+func dotnetRuntimeID(goarch, libcType string) string {
+	var arch string
+	switch goarch {
+	case "amd64":
+		arch = "x64"
+	case "arm64":
+		arch = "arm64"
+	default:
+		panic(fmt.Sprintf("unsupported architecture %q", goarch))
+	}
+
+	switch libcType {
+	case "glibc":
+		return "linux-" + arch
+	case "musl":
+		return "linux-musl-" + arch
+	default:
+		panic(fmt.Sprintf("unsupported libc type %q", libcType))
+	}
+}
+
 func sdkImageSuffix(libcType, version string) string {
 	if libcType == "musl" {
 		return "-alpine"
@@ -40,17 +70,6 @@ func sdkImageSuffix(libcType, version string) string {
 	default:
 		panic(fmt.Sprintf("unknown dotnet version %q: add the SDK image suffix mapping", version))
 	}
-}
-
-func profilerDockerfile(libcType string) string {
-	if libcType == "musl" {
-		return "Pyroscope.musl.Dockerfile"
-	}
-	return "Pyroscope.Dockerfile"
-}
-
-func profilerImageTag(libcType string) string {
-	return fmt.Sprintf("pyroscope-dotnet-%s:test", libcType)
 }
 
 func appDockerfile(otel bool) string {
@@ -73,45 +92,26 @@ func repoRoot() string {
 	return filepath.Dir(filepath.Dir(filename))
 }
 
-type profilerBuildResult struct {
-	once sync.Once
-	err  error
-}
-
-var profilerBuilds sync.Map
-
-func ensureProfilerImage(t *testing.T, libcType string) {
+func profilerBinariesDir(t *testing.T) string {
 	t.Helper()
-	val, _ := profilerBuilds.LoadOrStore(libcType, &profilerBuildResult{})
-	pb := val.(*profilerBuildResult)
-	pb.once.Do(func() {
-		tag := profilerImageTag(libcType)
-		// Retry the build: cold CI builds re-fetch every apt package from
-		// deb.debian.org, which intermittently resets the connection.
-		const maxAttempts = 3
-		for attempt := 1; attempt <= maxAttempts; attempt++ {
-			t.Logf("building profiler image %s (attempt %d/%d) ...", tag, attempt, maxAttempts)
-			cmd := exec.Command("docker", "build",
-				"--platform", "linux/amd64",
-				"-t", tag,
-				"-f", filepath.Join(repoRoot(), profilerDockerfile(libcType)),
-				"--build-arg", "CMAKE_BUILD_TYPE=Debug",
-				repoRoot(),
-			)
-			out, err := cmd.CombinedOutput()
-			if err == nil {
-				pb.err = nil
-				t.Logf("profiler image %s built successfully", tag)
-				return
-			}
-			pb.err = fmt.Errorf("failed to build profiler image %s: %w\n%s", tag, err, out)
-			if attempt < maxAttempts {
-				t.Logf("profiler image %s build attempt %d/%d failed, retrying: %v", tag, attempt, maxAttempts, err)
-				time.Sleep(5 * time.Second)
-			}
-		}
-	})
-	if pb.err != nil {
-		t.Fatal(pb.err)
+
+	configuredDir := envOrDefault("PROFILER_BINARIES_DIR", "profiler-bin")
+	fullDir := configuredDir
+	if !filepath.IsAbs(fullDir) {
+		fullDir = filepath.Join(repoRoot(), fullDir)
 	}
+
+	relativeDir, err := filepath.Rel(repoRoot(), fullDir)
+	if err != nil || relativeDir == ".." || strings.HasPrefix(relativeDir, ".."+string(filepath.Separator)) {
+		t.Fatalf("PROFILER_BINARIES_DIR must be inside the repository build context, got %q", configuredDir)
+	}
+
+	for _, name := range []string{"Pyroscope.Profiler.Native.so", "Pyroscope.Linux.ApiWrapper.x64.so"} {
+		path := filepath.Join(fullDir, name)
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("required profiler binary %q is unavailable: %v; build and stage profiler binaries before running integration tests", path, err)
+		}
+	}
+
+	return filepath.ToSlash(relativeDir)
 }

--- a/integration-test/matrix_test.go
+++ b/integration-test/matrix_test.go
@@ -1,0 +1,53 @@
+package integrationtest
+
+import "testing"
+
+func TestDockerPlatform(t *testing.T) {
+	tests := map[string]string{
+		"amd64": "linux/amd64",
+		"arm64": "linux/arm64",
+	}
+	for goarch, want := range tests {
+		t.Run(goarch, func(t *testing.T) {
+			if got := dockerPlatform(goarch); got != want {
+				t.Fatalf("dockerPlatform(%q) = %q, want %q", goarch, got, want)
+			}
+		})
+	}
+}
+
+func TestDotnetRuntimeID(t *testing.T) {
+	tests := []struct {
+		goarch   string
+		libcType string
+		want     string
+	}{
+		{goarch: "amd64", libcType: "glibc", want: "linux-x64"},
+		{goarch: "amd64", libcType: "musl", want: "linux-musl-x64"},
+		{goarch: "arm64", libcType: "glibc", want: "linux-arm64"},
+		{goarch: "arm64", libcType: "musl", want: "linux-musl-arm64"},
+	}
+	for _, test := range tests {
+		t.Run(test.goarch+"-"+test.libcType, func(t *testing.T) {
+			if got := dotnetRuntimeID(test.goarch, test.libcType); got != test.want {
+				t.Fatalf("dotnetRuntimeID(%q, %q) = %q, want %q", test.goarch, test.libcType, got, test.want)
+			}
+		})
+	}
+}
+
+func TestArchitectureHelpersRejectUnsupportedValues(t *testing.T) {
+	assertPanics(t, func() { dockerPlatform("386") })
+	assertPanics(t, func() { dotnetRuntimeID("386", "glibc") })
+	assertPanics(t, func() { dotnetRuntimeID("amd64", "unknown") })
+}
+
+func assertPanics(t *testing.T, fn func()) {
+	t.Helper()
+	defer func() {
+		if recover() == nil {
+			t.Fatal("expected panic")
+		}
+	}()
+	fn()
+}


### PR DESCRIPTION
Stage 1 of 2 splitting up `chore/arm64tests`. This PR is x86_64-only and contains no ARM64 enablement; #416 turns ARM64 on.

## What

The integration tests used to build a profiler Docker image themselves -- with a three-attempt retry wrapped around flaky `apt` fetches -- once per libc per job, rebuilding the same profiler up to six times per PR.

Now the profiler is built once by the reusable `build_linux_profiler` workflow, which uploads the extracted `.so` files as artifacts. Each integration job downloads them. The Dockerfiles `COPY` from `PROFILER_BINARIES_DIR` (default `profiler-bin/`) inside the build context instead of pulling them out of a locally built SDK image stage, so `ensureProfilerImage` and the `build-profiler-*` make targets are gone.

`profilerBinariesDir()` validates that the configured directory is inside the build context and fails fast with an actionable message when the binaries have not been staged.

Because a job no longer pays for a profiler build, per-test sharding is not worth the matrix explosion any more: each job runs the whole suite with a 90m timeout and the `discover` job is dropped. `build_linux_profiler` becomes `workflow_call`/`workflow_dispatch` only; it still runs on every pull request, as a nested job of Integration Test.

Also makes the Docker platform and the dotnet runtime identifier derived values (`dockerPlatform`, `dotnetRuntimeID`) rather than hardcoded `linux/amd64` and `linux-x64`. Both are no-ops on x86_64 and are covered by new unit tests in `matrix_test.go`.

## Two things for the reviewer

- **Branch protection.** The profiler build now reports as a nested job of Integration Test rather than as a standalone `Build linux profiler` check. If that is a required status check it needs updating, or this PR will not be mergeable.
- **The 90m budget.** 9 integration tests now share one job instead of one test per shard. First CI run will show whether 90m is comfortable.

## Local checks

- `go vet ./...` clean, `matrix_test.go` passes
- both workflow YAMLs parse

🤖 Generated with [Claude Code](https://claude.com/claude-code)
