### PR TITLE
fix(ci): update shared workflow actions

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -20,7 +20,7 @@ jobs:
       tracing_sha: ${{ steps.release.outputs['Pyroscope--sha'] }}
     steps:
       - id: get-github-app-token
-        uses: grafana/shared-workflows/actions/create-github-app-token@580590a644e82e79bb2598bdaba0be245a14dda0 # create-github-app-token/v0.2.2
+        uses: grafana/shared-workflows/actions/create-github-app-token@46f48da11e78ebdba7a8747ae456b11062fac83e # create-github-app-token/v0.3.1
         with:
           github_app: pyroscope-development-app
       - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5
@@ -197,7 +197,7 @@ jobs:
     steps:
       - name: Fetch Azure Trusted Signing credentials
         id: get-signing-secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@e46fe1e9a2bf9e618bcf8d8d32f3a7381b45c06d # get-vault-secrets/v2.0.0
+        uses: grafana/shared-workflows/actions/get-vault-secrets@2e3743a1f8abfd3e921e53a7726ec0744c11bb01 # get-vault-secrets/v2.0.1
         with:
           repo_secrets: |
             client-id=azure-trusted-signing:client-id

--- a/renovate.json
+++ b/renovate.json
@@ -1,9 +1,16 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
+    "github>grafana/grafana-renovate-config//presets/shared-workflows",
     "security:only-security-updates"
   ],
   "packageRules": [
+    {
+      "description": "Always update grafana/shared-workflows actions to their latest releases. Overrides the wildcard enabled:false from security:only-security-updates.",
+      "matchManagers": ["github-actions"],
+      "matchPackageNames": ["grafana/shared-workflows"],
+      "enabled": true
+    },
     {
       "description": "Always update openssl/openssl to latest. Overrides the wildcard enabled:false from security:only-security-updates.",
       "matchPackageNames": ["openssl/openssl"],


### PR DESCRIPTION
## Summary
- update the blocked `create-github-app-token` action to v0.3.1
- update `get-vault-secrets` to v2.0.1 and confirm Azure Trusted Signing is current
- enable Grafana's shared-workflows Renovate preset and allow these updates despite the security-only configuration

Fixes the startup failure in [Release Please run 33470485086](https://github.com/grafana/pyroscope-dotnet/actions/runs/33470485086).

## Test plan
- [x] Validate `renovate.json` as JSON
- [x] Parse `.github/workflows/release-please.yml` as YAML
- [x] Run `git diff --check`
- [x] Confirm action tags resolve to the pinned commit SHAs