### PR TITLE
build: build glibc profiler on manylinux2014 (glibc 2.17) and gate the glibc floor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,12 @@ else
     $(error LIBC must be either musl or glibc)
 endif
 
+# manylinux2014 (CentOS 7, glibc 2.17) keeps the shipped .so runnable on old distros.
+# See the comment at the top of Pyroscope.Dockerfile.
+BASE_IMAGE_x86_64 := quay.io/pypa/manylinux2014_x86_64@sha256:493d2032114d757aaa761a9385ad8497f391503bf71acef9abeeb66682ca5d90
+BASE_IMAGE_aarch64 := quay.io/pypa/manylinux2014_aarch64@sha256:f4cd164263e4ec2b7da7ee40b319bb5e30f0d7a2abd7ad4730e716a512dfb529
+BASE_IMAGE := $(BASE_IMAGE_$(ARCH))
+
 ifeq ($(ARCH),x86_64)
 else ifeq ($(ARCH),aarch64)
 else
@@ -24,7 +30,9 @@ endif
 
 .PHONY: docker/archive
 docker/archive:
-	docker build -f $(DOCKERFILE) -o out.$(RELEASE_VERSION)-$(LIBC)-$(ARCH)  .
+	docker build -f $(DOCKERFILE) \
+		$(if $(filter glibc,$(LIBC)),--build-arg BASE_IMAGE=$(BASE_IMAGE),) \
+		-o out.$(RELEASE_VERSION)-$(LIBC)-$(ARCH) .
 	cd out.$(RELEASE_VERSION)-$(LIBC)-$(ARCH) && tar -czvf ../pyroscope.$(RELEASE_VERSION)-$(LIBC)-$(ARCH).tar.gz *.so 
 	rm -rf out.$(RELEASE_VERSION)-$(LIBC)-$(ARCH)
 

--- a/Pyroscope.Dockerfile
+++ b/Pyroscope.Dockerfile
@@ -1,9 +1,58 @@
-FROM debian:bullseye-20260406@sha256:bf53effcacca31b60ce97dabc67578f37e43075d716dc90804d3da3a80d2996c AS builder
+# Build on CentOS 7 (via pypa's manylinux2014) so the shipped .so keeps a glibc 2.17
+# baseline and runs on any distro with glibc >= 2.17 -- RHEL 7+, Ubuntu 18.04+,
+# Amazon Linux 2/2023, Debian 10+. This matches the floor DataDog enforces for their
+# .NET profiler. Building on a newer glibc silently raises the floor and breaks users:
+# a bookworm (2.36) base pushes it to GLIBC_2.36, dropping Ubuntu 22.04 and RHEL 9.
+# The check-glibc-compat.sh step further down enforces the floor.
+#
+# cmake and curl come from the manylinux image itself, so they are not installed below.
+# manylinux2014 has no multi-arch manifest -- the arch is part of the image name -- so the
+# Makefile overrides this per target arch. The default keeps plain `docker build` working.
+ARG BASE_IMAGE=quay.io/pypa/manylinux2014_x86_64@sha256:493d2032114d757aaa761a9385ad8497f391503bf71acef9abeeb66682ca5d90
+FROM ${BASE_IMAGE} AS builder
 
-# deb.debian.org (Fastly) intermittently resets connections on cold CI builds; retry apt fetches.
-RUN echo 'Acquire::Retries "5";' > /etc/apt/apt.conf.d/80-retries
+# manylinux2014's stock repos already point at vault.centos.org, which is where CentOS 7
+# went when it went EOL -- the same mirror DataDog's centos7 build image uses.
+# perl-core rather than the minimal `perl`: OpenSSL's Configure needs IPC::Cmd and
+# Time::Piece.
+RUN yum install -y make git libtool wget perl-core zlib-devel xz && yum clean all
 
-RUN apt-get update && apt-get -y install cmake make git curl golang libtool wget perl
+# CentOS 7 predates every official clang 18 binary (they all need glibc >= 2.27), so pull
+# clang from conda-forge, which is built against a glibc 2.17 baseline.
+#
+# conda-forge's clang ships its own gcc 16 libstdc++ headers, which clang 18 cannot parse
+# (they use gcc-14+ builtins such as __builtin_popcountg). Delete them and point clang at
+# the image's devtoolset-10 libstdc++ instead. The flag goes in a clang config file rather
+# than CFLAGS so that nested build systems -- libunwind's autotools, protobuf's cmake --
+# pick it up too, and specifically into conda's own <triple>.cfg because that one is
+# loaded last and would otherwise win.
+#
+# --sysroot=/ is needed for the same reason: conda's clang defaults to its own sysroot,
+# which has no zlib.h or other CentOS headers. CentOS 7's glibc is 2.17 itself, so
+# building against the image root keeps the same floor.
+ARG LLVM_VERSION=18
+ARG GCC_TOOLCHAIN=/opt/rh/devtoolset-10/root/usr
+RUN case "$(uname -m)" in \
+      x86_64)  MAMBA_ARCH=linux-64 ;; \
+      aarch64) MAMBA_ARCH=linux-aarch64 ;; \
+      *) echo "unsupported arch $(uname -m)" >&2; exit 1 ;; \
+    esac && \
+    curl -sSL "https://micro.mamba.pm/api/micromamba/${MAMBA_ARCH}/latest" -o /tmp/micromamba.tar.bz2 && \
+    tar xjf /tmp/micromamba.tar.bz2 -C /tmp bin/micromamba && \
+    /tmp/bin/micromamba create -y -p /opt/llvm -c conda-forge \
+        "clang=${LLVM_VERSION}" "clangxx=${LLVM_VERSION}" "lld=${LLVM_VERSION}" && \
+    rm -rf /opt/llvm/lib/gcc /opt/llvm/include/c++ /opt/llvm/pkgs \
+           /tmp/micromamba.tar.bz2 /tmp/bin && \
+    for cfg in /opt/llvm/bin/*-conda-linux-gnu.cfg; do \
+        printf '%s\n' "--gcc-toolchain=${GCC_TOOLCHAIN}" "--sysroot=/" > "${cfg}"; \
+    done
+
+ENV PATH=/opt/llvm/bin:$PATH
+
+# Fail early and loudly if the config file above stops being picked up, rather than
+# surfacing later as thousands of libstdc++ template errors.
+RUN printf '#include <atomic>\n#include <string>\n#include <zlib.h>\nint main(){return std::string(zlibVersion()).empty();}\n' > /tmp/probe.cpp && \
+    clang++ -std=c++20 -stdlib=libstdc++ /tmp/probe.cpp -lz -o /tmp/probe && /tmp/probe && rm -f /tmp/probe /tmp/probe.cpp
 
 # Build OpenSSL from source with static libs
 ARG OPENSSL_VERSION=3.5.8
@@ -15,14 +64,6 @@ RUN wget -q "https://github.com/openssl/openssl/releases/download/openssl-${OPEN
     make install_sw && \
     ln -s /usr/local/openssl/lib64 /usr/local/openssl/lib && \
     cd .. && rm -rf openssl-${OPENSSL_VERSION} openssl-${OPENSSL_VERSION}.tar.gz
-
-RUN apt-get -y install lsb-release wget software-properties-common gnupg
-
-RUN wget https://apt.llvm.org/llvm.sh && \
-  chmod +x llvm.sh && \
-  ./llvm.sh 18
-
-ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/lib/llvm-18/bin/
 
 FROM builder as build
 
@@ -47,6 +88,13 @@ RUN mkdir build-${CMAKE_BUILD_TYPE} && \
         -DOPENSSL_ROOT_DIR=/usr/local/openssl
 
 RUN cd build-${CMAKE_BUILD_TYPE} && make -j16 Pyroscope.Profiler.Native Datadog.Linux.ApiWrapper.x64
+
+# Gate the runtime glibc requirement. See build/check-glibc-compat.sh for why this
+# cannot be caught by compiling or by the unit tests.
+ARG MAX_GLIBC_VERSION=2.17
+RUN build/check-glibc-compat.sh "${MAX_GLIBC_VERSION}" \
+        artifacts/profiler-build/DDProf-Deploy/linux/Pyroscope.Profiler.Native.so \
+        artifacts/profiler-build/DDProf-Deploy/linux/Datadog.Linux.ApiWrapper.x64.so
 
 FROM build AS test
 RUN cd build-${CMAKE_BUILD_TYPE} && make -j$(nproc) profiler-native-tests wrapper-native-tests

--- a/build/check-glibc-compat.sh
+++ b/build/check-glibc-compat.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+#
+# Fail if a shipped shared object requires a glibc newer than our supported floor.
+#
+# The floor is set by the glibc of the *build* image, not by anything in our source:
+# the linker binds each call to the newest symbol version the build host offers. So a
+# base-image bump silently raises the runtime requirement and breaks users on older
+# distros, with no compile error and no test failure. This check makes that a build
+# failure instead.
+#
+# Reference points for the floor: glibc 2.17 = RHEL 7 / Amazon Linux 2,
+# 2.28 = RHEL 8 / Debian 10, 2.31 = Ubuntu 20.04, 2.34 = RHEL 9 / Amazon Linux 2023,
+# 2.35 = Ubuntu 22.04, 2.36 = Debian 12.
+#
+# Usage: check-glibc-compat.sh <max-glibc-version> <file.so> [file.so ...]
+
+set -euo pipefail
+
+if [ "$#" -lt 2 ]; then
+    echo "usage: $0 <max-glibc-version> <file.so> [file.so ...]" >&2
+    exit 2
+fi
+
+max_version="$1"
+shift
+
+# Old binutils (CentOS 7 ships 2.27) has an `nm` too limited to report symbol
+# versions reliably, so read the version-requirements section with readelf instead.
+required_versions() {
+    readelf -V "$1" | grep -oE 'GLIBC_[0-9]+(\.[0-9]+)+' | sed 's/^GLIBC_//' | sort -uV
+}
+
+status=0
+
+for file in "$@"; do
+    if [ ! -f "$file" ]; then
+        echo "FAIL $file: not found" >&2
+        status=1
+        continue
+    fi
+
+    versions="$(required_versions "$file")"
+    if [ -z "$versions" ]; then
+        echo "OK   $(basename "$file"): no versioned glibc dependencies"
+        continue
+    fi
+
+    highest="$(printf '%s\n' "$versions" | tail -1)"
+
+    # sort -V puts the greater of the two last; equal versions are fine.
+    if [ "$highest" != "$max_version" ] && \
+       [ "$(printf '%s\n%s\n' "$highest" "$max_version" | sort -V | tail -1)" = "$highest" ]; then
+        echo "FAIL $(basename "$file"): requires GLIBC_${highest}, above the GLIBC_${max_version} floor" >&2
+        echo "     offending symbols:" >&2
+        readelf --dyn-syms --wide "$file" \
+            | grep -oE '@GLIBC_[0-9]+(\.[0-9]+)+ .*|[A-Za-z_][A-Za-z0-9_]*@+GLIBC_[0-9]+(\.[0-9]+)+' \
+            | grep -vE "@\+?GLIBC_(${max_version//./\\.})$" \
+            | awk -F'@' -v max="$max_version" '{
+                  v = $NF; sub(/^\+/, "", v); sub(/^GLIBC_/, "", v);
+                  split(v, a, "."); split(max, b, ".");
+                  if (a[1] > b[1] || (a[1] == b[1] && a[2] > b[2])) print "       " $0
+              }' \
+            | sort -u >&2 || true
+        status=1
+    else
+        echo "OK   $(basename "$file"): max GLIBC_${highest} (floor GLIBC_${max_version})"
+    fi
+done
+
+exit $status


### PR DESCRIPTION
## Why CI is red

Debian 11 LTS ended **2026-08-31**. The bullseye `.deb` files have been purged from the `debian-security` pool, but the `bullseye-security` indices are still served — so `apt-get update` succeeds and then apt resolves versions that 404:

```
E: Failed to fetch .../libperl5.32_5.32.1-4+deb11u5_amd64.deb  404  Not Found
E: Failed to fetch .../libc-dev-bin_2.31-13+deb11u14_amd64.deb 404  Not Found
E: Failed to fetch .../linux-libc-dev_5.10.262-1_amd64.deb     404  Not Found
```

The pool directory now contains only bookworm packages:

```
$ curl -sS http://deb.debian.org/debian-security/pool/updates/main/p/perl/ | grep -oE 'libperl5[^"<]*\.deb'
libperl5.36_5.36.0-7+deb12u2_amd64.deb      # every bullseye 5.32 .deb is gone
```

It looked intermittent only because whether a given `.deb` is still in Fastly's edge cache decides it — the same URL that 404'd in CI returns 200 from a cache with `Age: 897833`. The existing `Acquire::Retries "5"` cannot help; a 404 is not retried.

This was also about to stop being intermittent: `bullseye-security`'s Release file carries `Valid-Until: Mon, 07 Sep 2026 21:13:04 UTC`, after which `apt-get update` itself fails on the expired file.

## Why not just bump to a newer Debian

Because it silently breaks users. The linker binds each call to the newest symbol version the build host offers, so the base image — not anything in our source — sets the runtime glibc requirement. Measured by actually building on `debian:bookworm`:

| | max required |
|---|---|
| today (bullseye) | `GLIBC_2.30` |
| bookworm base | `GLIBC_2.36` |

That drops **Ubuntu 22.04 (2.35), RHEL 9 (2.34) and Amazon Linux 2023 (2.34)**. Ubuntu 22.04 as a base is no better — it lands on exactly `GLIBC_2.35` (via `_dl_find_object`, added in precisely 2.35 and picked up by libunwind whenever available) and still breaks RHEL 9 and AL2023.

None of this shows up as a compile error or a failing test.

## What this PR does

Moves the other way: builds on CentOS 7 via pypa's `manylinux2014`, which lands the profiler on **`GLIBC_2.17`** — the same floor DataDog enforces for their .NET profiler, and better than the 2.30 we ship today.

For reference, DataDog builds their glibc profiler on `centos:7` (`.azure-pipelines/ultimate-pipeline.yml` → `nativeBaseImage: centos7`) and gates it in CI at 2.17 with an explicit "we must **NOT** increase it beyond 2.23, or increase the version on x64". Their shipped v3.52.0 `Datadog.Profiler.Native.so` measures exactly `GLIBC_2.17`.

### How this differs from DataDog's setup

Worth being explicit, since the CentOS 7 route is well-trodden and this deviates in one place:

- **clang.** No official clang 18 binary runs on glibc 2.17 (they all need >= 2.27). DataDog solves this by building LLVM 16.0.6 from source on CentOS 7 (`tracer/build/_build/docker/centos7.build.dockerfile`, `build-llvm-clang` stage) and baking it into a prebuilt image (`gleocadie/centos7-clang16`) that their CI consumes, so the hour-long LLVM build never runs per-CI. This PR instead takes clang 18 from conda-forge, which is built to a glibc 2.17 baseline — no LLVM build and no prebuilt image to maintain. Its bundled gcc 16 libstdc++ headers are unparseable by clang 18, so they're swapped for the image's devtoolset-10 via a clang config file (a config file rather than `CFLAGS` so nested build systems — libunwind's autotools, protobuf's cmake — pick it up too). This is the one genuinely novel piece here and the main thing to review.
- **yum mirror.** No deviation. `manylinux2014`'s stock repos already point at `vault.centos.org`, the same mirror DataDog's image patches to, so nothing needed doing.
- **cmake.** DataDog builds cmake 3.13.4 from source; `manylinux2014` already ships cmake 4.4.3, so this just uses the image's.

### The gate

Adds `build/check-glibc-compat.sh`, run inside the build stage, so a future base-image change fails the build instead of shipping a binary that will not load on a customer's distro:

```
OK   Pyroscope.Profiler.Native.so: max GLIBC_2.17 (floor GLIBC_2.17)
OK   Datadog.Linux.ApiWrapper.x64.so: max GLIBC_2.14 (floor GLIBC_2.17)
```

## Verification

Locally on x86_64, `--no-cache`:

- Release build ✓, Debug build ✓ (both report `GLIBC_2.17` / `GLIBC_2.14`)
- 583/583 profiler unit tests, 42/42 wrapper unit tests
- The gate self-checks correctly: passes DataDog's 2.17 binary, and fails the bookworm build listing the offending symbols (`arc4random@GLIBC_2.36`, `_dl_find_object@GLIBC_2.35`, `dlopen@GLIBC_2.34`, …)

## Notes for review

- **aarch64 is not verified locally** — no arm64 builder available here. `manylinux2014` has no multi-arch manifest (the arch is in the image name), so the Makefile selects a digest-pinned image per `ARCH`; the arm64 leg needs CI to confirm.
- The musl build is untouched. Its jobs in the failing run were only cancelled by `fail-fast`; `alpine:3.18` is unaffected. Worth noting separately that alpine 3.18 is itself EOL.
- `golang` was dropped from the install list — nothing in the build referenced it.
- Pre-existing and unrelated: the `test` stage's `ARG CMAKE_BUILD_TYPE` is not in scope, which only bites the legacy (non-BuildKit) builder, since it walks every stage. CI sets `DOCKER_BUILDKIT: 1` and is unaffected.
- If the conda-forge toolchain is more novelty than we want mid-release, the minimal alternative is pinning apt to `snapshot.debian.org` — validated working, and preserves the current 2.30 floor exactly rather than improving it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)