### PR TITLE
build: fix the bullseye apt breakage without moving the glibc floor

### DIFF
--- a/Pyroscope.Dockerfile
+++ b/Pyroscope.Dockerfile
@@ -3,7 +3,32 @@ FROM debian:bullseye-20260406@sha256:bf53effcacca31b60ce97dabc67578f37e43075d716
 # deb.debian.org (Fastly) intermittently resets connections on cold CI builds; retry apt fetches.
 RUN echo 'Acquire::Retries "5";' > /etc/apt/apt.conf.d/80-retries
 
-RUN apt-get update && apt-get -y install cmake make git curl golang libtool wget perl
+# Debian 11 LTS ended 2026-08-31: the bullseye-security .debs were purged from the pool
+# while the indices are still served, so apt resolves versions that 404 (retries do not
+# help -- a 404 is not retried), and bullseye-security's Release file expired 2026-09-07,
+# after which apt-get update itself fails. Pin to a snapshot taken just after the final
+# bullseye-security update so the build keeps resolving the exact same packages.
+#
+# Do not "fix" this by bumping the base image. The linker binds each call to the newest
+# symbol version the build host offers, so the base image -- not anything in our source
+# -- sets the profiler's runtime glibc requirement. A bookworm base measures GLIBC_2.36,
+# which drops Ubuntu 22.04 (2.35), RHEL 9 (2.34) and Amazon Linux 2023 (2.34), with no
+# compile error and no failing test. The check-glibc-compat.sh step below enforces it.
+#
+# Plain HTTP because snapshot.debian.org over HTTPS would need ca-certificates, which
+# this image lacks and which cannot be installed before apt works. Integrity still comes
+# from the signed Release file and its per-package hashes.
+ARG DEBIAN_SNAPSHOT=20260901T000000Z
+RUN printf '%s\n' \
+      "deb http://snapshot.debian.org/archive/debian/${DEBIAN_SNAPSHOT} bullseye main" \
+      "deb http://snapshot.debian.org/archive/debian-security/${DEBIAN_SNAPSHOT} bullseye-security main" \
+      "deb http://snapshot.debian.org/archive/debian/${DEBIAN_SNAPSHOT} bullseye-updates main" \
+      > /etc/apt/sources.list && \
+    echo 'Acquire::Check-Valid-Until "false";' > /etc/apt/apt.conf.d/80-no-valid-until
+
+# binutils for the readelf that check-glibc-compat.sh needs; it is otherwise only
+# present incidentally, as a transitive dependency.
+RUN apt-get update && apt-get -y install cmake make git curl golang libtool wget perl binutils
 
 # Build OpenSSL from source with static libs
 ARG OPENSSL_VERSION=3.5.8
@@ -47,6 +72,23 @@ RUN mkdir build-${CMAKE_BUILD_TYPE} && \
         -DOPENSSL_ROOT_DIR=/usr/local/openssl
 
 RUN cd build-${CMAKE_BUILD_TYPE} && make -j16 Pyroscope.Profiler.Native Datadog.Linux.ApiWrapper.x64
+
+# Gate the runtime glibc requirement, so a future base-image change fails the build
+# instead of shipping a binary that will not load on a customer's distro. Each file is
+# pinned to its own measured value rather than a shared floor, so neither can drift.
+#
+# The wrapper's floor is per-arch: glibc's arm64 port was added in 2.17, so no symbol
+# there can be versioned older than that, while on x86_64 the wrapper reaches back to
+# 2.14. Both values are what the shipped 1.4.0 artifacts measure. The profiler is 2.30
+# on both. See build/check-glibc-compat.sh.
+RUN OUT=/profiler/artifacts/profiler-build/DDProf-Deploy/linux && \
+    case "$(uname -m)" in \
+        x86_64)  WRAPPER_FLOOR=2.14 ;; \
+        aarch64) WRAPPER_FLOOR=2.17 ;; \
+        *) echo "no glibc floor recorded for $(uname -m)" >&2; exit 1 ;; \
+    esac && \
+    build/check-glibc-compat.sh 2.30 "$OUT/Pyroscope.Profiler.Native.so" && \
+    build/check-glibc-compat.sh "$WRAPPER_FLOOR" "$OUT/Datadog.Linux.ApiWrapper.x64.so"
 
 FROM build AS test
 RUN cd build-${CMAKE_BUILD_TYPE} && make -j$(nproc) profiler-native-tests wrapper-native-tests

--- a/Pyroscope.Dockerfile
+++ b/Pyroscope.Dockerfile
@@ -43,9 +43,22 @@ RUN wget -q "https://github.com/openssl/openssl/releases/download/openssl-${OPEN
 
 RUN apt-get -y install lsb-release wget software-properties-common gnupg
 
-RUN wget https://apt.llvm.org/llvm.sh && \
-  chmod +x llvm.sh && \
-  ./llvm.sh 18
+# apt.llvm.org intermittently drops connections and llvm.sh fetches the signing key with
+# a single un-retried wget, which fails the build with wget's exit 4. So retry it.
+#
+# The rm matters. llvm.sh pipes the key straight into the keyring and skips the download
+# when the file already exists, so one dropped connection leaves a truncated key behind
+# and every later apt-get update fails with "NO_PUBKEY 15CF4D18AF4F7421" instead --
+# retrying without clearing it just reproduces the same failure five times. Each attempt
+# therefore starts from a clean slate; llvm.sh is otherwise idempotent.
+RUN for attempt in 1 2 3 4 5; do \
+      rm -f /etc/apt/trusted.gpg.d/apt.llvm.org.asc; \
+      wget -q -O llvm.sh https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && ./llvm.sh 18 && exit 0; \
+      echo "apt.llvm.org attempt ${attempt} failed, retrying" >&2; \
+      sleep $((attempt * 5)); \
+    done; \
+    echo "apt.llvm.org still unreachable after 5 attempts" >&2; \
+    exit 1
 
 ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/lib/llvm-18/bin/
 

--- a/build/check-glibc-compat.sh
+++ b/build/check-glibc-compat.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+#
+# Fail if a shipped shared object requires a glibc newer than our supported floor.
+#
+# The floor is set by the glibc of the *build* image, not by anything in our source:
+# the linker binds each call to the newest symbol version the build host offers. So a
+# base-image bump silently raises the runtime requirement and breaks users on older
+# distros, with no compile error and no test failure. This check makes that a build
+# failure instead.
+#
+# Reference points for the floor: glibc 2.17 = RHEL 7 / Amazon Linux 2,
+# 2.28 = RHEL 8 / Debian 10, 2.31 = Ubuntu 20.04, 2.34 = RHEL 9 / Amazon Linux 2023,
+# 2.35 = Ubuntu 22.04, 2.36 = Debian 12.
+#
+# Note that the floor is per-arch. glibc's arm64 port was added in 2.17, so on aarch64
+# every symbol is versioned at 2.17 or newer and a floor below that is unsatisfiable.
+#
+# Usage: check-glibc-compat.sh <max-glibc-version> <file.so> [file.so ...]
+
+set -euo pipefail
+
+if [ "$#" -lt 2 ]; then
+    echo "usage: $0 <max-glibc-version> <file.so> [file.so ...]" >&2
+    exit 2
+fi
+
+max_version="$1"
+shift
+
+# `nm` does not report symbol versions reliably across binutils releases, so read the
+# version-requirements section with readelf instead.
+required_versions() {
+    readelf -V "$1" | grep -oE 'GLIBC_[0-9]+(\.[0-9]+)+' | sed 's/^GLIBC_//' | sort -uV
+}
+
+status=0
+
+for file in "$@"; do
+    if [ ! -f "$file" ]; then
+        echo "FAIL $file: not found" >&2
+        status=1
+        continue
+    fi
+
+    versions="$(required_versions "$file")"
+    if [ -z "$versions" ]; then
+        echo "OK   $(basename "$file"): no versioned glibc dependencies"
+        continue
+    fi
+
+    highest="$(printf '%s\n' "$versions" | tail -1)"
+
+    # sort -V puts the greater of the two last; equal versions are fine.
+    if [ "$highest" != "$max_version" ] && \
+       [ "$(printf '%s\n%s\n' "$highest" "$max_version" | sort -V | tail -1)" = "$highest" ]; then
+        echo "FAIL $(basename "$file"): requires GLIBC_${highest}, above the GLIBC_${max_version} floor" >&2
+        echo "     offending symbols:" >&2
+        readelf --dyn-syms --wide "$file" \
+            | grep -oE '@GLIBC_[0-9]+(\.[0-9]+)+ .*|[A-Za-z_][A-Za-z0-9_]*@+GLIBC_[0-9]+(\.[0-9]+)+' \
+            | grep -vE "@\+?GLIBC_(${max_version//./\\.})$" \
+            | awk -F'@' -v max="$max_version" '{
+                  v = $NF; sub(/^\+/, "", v); sub(/^GLIBC_/, "", v);
+                  split(v, a, "."); split(max, b, ".");
+                  if (a[1] > b[1] || (a[1] == b[1] && a[2] > b[2])) print "       " $0
+              }' \
+            | sort -u >&2 || true
+        status=1
+    else
+        echo "OK   $(basename "$file"): max GLIBC_${highest} (floor GLIBC_${max_version})"
+    fi
+done
+
+exit $status


### PR DESCRIPTION
## Why CI is red

Debian 11 LTS ended **2026-08-31**. The `bullseye-security` `.deb` files have been purged from the pool, but the `bullseye-security` indices are still served — so `apt-get update` succeeds and then apt resolves versions that 404.

Reproduced on the unmodified base image, today:

```
$ docker run --rm debian:bullseye-20260406@sha256:bf53eff... \
    bash -c 'apt-get update && apt-get -y install cmake make git curl golang libtool wget perl'
...
E: Failed to fetch .../p/perl/libperl5.32_5.32.1-4+deb11u5_amd64.deb   404  Not Found
E: Failed to fetch .../g/glibc/libc-dev-bin_2.31-13+deb11u14_amd64.deb 404  Not Found
E: Failed to fetch .../l/linux/linux-libc-dev_5.10.262-1_amd64.deb     404  Not Found
E: Unable to fetch some archives
exit 100
```

It looked intermittent only because whether a given `.deb` is still in Fastly's edge cache decides it. The same URL, cached vs. cache-busted to origin:

```
$ curl -sSI http://deb.debian.org/debian-security/pool/updates/main/g/glibc/libc-dev-bin_2.31-13+deb11u14_amd64.deb
HTTP/1.1 200 OK          X-Cache: HIT, HIT    Age: 1511818
$ curl -sSI '...same URL...?cachebust=1'
HTTP/1.1 404 Not Found   X-Cache: MISS, MISS  Age: 0
```

The existing `Acquire::Retries "5"` cannot help — a 404 is not retried.

This was also about to stop being intermittent. `bullseye-security`'s Release file carries `Valid-Until: Mon, 07 Sep 2026 21:13:04 UTC`, after which `apt-get update` itself fails on the expired file.

## Why not just bump the base image

Because it silently breaks users. The linker binds each call to the newest symbol version the build host offers, so the base image — not anything in our source — sets the runtime glibc requirement:

| | max required |
|---|---|
| today (bullseye) | `GLIBC_2.30` |
| bookworm base | `GLIBC_2.36` |

That drops **Ubuntu 22.04 (2.35), RHEL 9 (2.34) and Amazon Linux 2023 (2.34)**. Ubuntu 22.04 as a base is no better — it lands on exactly `GLIBC_2.35` (via `_dl_find_object`, picked up by libunwind whenever available) and still breaks RHEL 9 and AL2023. None of it shows up as a compile error or a failing test.

This PR therefore changes **nothing** about the toolchain or the base image. It keeps `debian:bullseye-20260406` at the same digest and only changes where apt fetches from.

## What this PR does

**1. Pins apt to `snapshot.debian.org` at `20260901T000000Z`** — just after the final bullseye-security update (2026-08-31 21:13 UTC), before the purge. The snapshot resolves the *identical* package versions we build with today, including the three that now 404:

```
Setting up libc6-dev:amd64 (2.31-13+deb11u14) ...   # the version that 404s live
perl 5.32.1-4+deb11u5, linux-libc-dev 5.10.262-1    # likewise
```

glibc stays **2.31**, so the bound symbol versions cannot move. `Acquire::Check-Valid-Until "false"` is required because snapshot serves the historical Release file, whose `Valid-Until` is by definition in the past.

Plain HTTP is deliberate: snapshot over HTTPS would need `ca-certificates`, which this image lacks and which cannot be installed before apt works. Integrity still comes from the signed Release file and its per-package hashes.

**2. Adds `build/check-glibc-compat.sh`**, run inside the build stage, so a future base-image change fails the build instead of shipping a binary that will not load on a customer's distro. Floors are taken from the **shipped 1.4.0 artifacts**, not from a local build:

| | x86_64 | aarch64 |
|---|---|---|
| `Pyroscope.Profiler.Native.so` | `2.30` | `2.30` |
| `Pyroscope.Linux.ApiWrapper.x64.so` | `2.14` | `2.17` |

The wrapper's floor is per-arch because glibc's arm64 port was added in 2.17, so no symbol there can be versioned older than that. CI caught this — the first push had a single 2.14 floor and the aarch64 leg failed, which is the check working as intended.

**3. Adds `binutils`** to the install list — the check needs `readelf`, previously present only as a transitive dependency.

**4. Retries the `apt.llvm.org` fetch** (separate commit, easy to drop). `llvm.sh` downloads the LLVM signing key with a single un-retried `wget`; a dropped connection failed three of ten builds here. Retrying alone isn't enough: `llvm.sh` pipes the key straight into the keyring and skips the download when the file exists, so a partial fetch leaves a truncated key and `apt-get update` then fails with `NO_PUBKEY 15CF4D18AF4F7421` on every subsequent attempt — one wget failure followed by four identical NO_PUBKEY failures. So the key file is cleared before each attempt. Pre-existing fragility, unrelated to the apt change, but it makes the build randomly red.

## Verification

The build workflows can't run on a fork PR without maintainer approval, so I ran the same two workflows on a branch in my fork. **Full matrix green:**

```
Build linux profiler       C++ profiler unit tests
  x86_64  (glibc)  ✓         glibc  ✓
  x86_64  (musl)   ✓         musl   ✓
  aarch64 (glibc)  ✓
  aarch64 (musl)   ✓
  managed-helper   ✓
```

Zero apt fetch errors on either arch, and the gate reports, in CI:

```
x86_64    OK  Pyroscope.Profiler.Native.so: max GLIBC_2.30 (floor GLIBC_2.30)
          OK  Datadog.Linux.ApiWrapper.x64.so: max GLIBC_2.14 (floor GLIBC_2.14)
aarch64   OK  Pyroscope.Profiler.Native.so: max GLIBC_2.30 (floor GLIBC_2.30)
          OK  Datadog.Linux.ApiWrapper.x64.so: max GLIBC_2.17 (floor GLIBC_2.17)
```

which is exactly what the shipped 1.4.0 tarballs measure on each arch. Also locally on x86_64: Release and Debug both build `--no-cache`, 583/583 profiler and 42/42 wrapper unit tests pass, and the gate is not vacuous — given a deliberately low floor it exits non-zero and lists the offending symbols (`pthread_cond_clockwait@GLIBC_2.30`, `exp@GLIBC_2.29`, `getentropy@GLIBC_2.25`, …).

## Notes

- **This is a stopgap.** bullseye is EOL; the snapshot pin buys time but a real base-image migration still has to happen deliberately. The point of the gate is that when it does, the glibc consequence shows up as a build failure rather than a support ticket.
- The musl build is untouched — `alpine:3.18` is unaffected by this. Worth flagging separately that alpine 3.18 is itself EOL.
- Pre-existing and not touched here: the `test` stage does not re-declare `ARG CMAKE_BUILD_TYPE`, so `cd build-${CMAKE_BUILD_TYPE}` becomes `cd build-` on the legacy (non-BuildKit) builder. CI sets `DOCKER_BUILDKIT: 1` and is unaffected; it only bites local builds without buildx.
- Supersedes #420, which fixed the same breakage by moving to manylinux2014 and *lowering* the floor to 2.17. This keeps the floor exactly where it is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
