### PR TITLE
chore(deps): bump musl builder image from EOL Alpine 3.18 to 3.22

### DIFF
--- a/Pyroscope.musl.Dockerfile
+++ b/Pyroscope.musl.Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.18 AS builder
+FROM alpine:3.22@sha256:14358309a308569c32bdc37e2e0e9694be33a9d99e68afb0f5ff33cc1f695dce AS builder
 
 RUN apk add \
             clang \


### PR DESCRIPTION
## What

Bumps the Alpine base image for the musl profiler build in `Pyroscope.musl.Dockerfile`.

## Why

Alpine **3.18 reached end of support on 2025-05-09** — over a year ago. It receives no security updates, and its `apk` mirrors will eventually be retired.

Target is **3.22** (released 2025-05-30, supported until **2027-05-01**). 3.21 is technically the oldest still-supported branch, but it goes EOL on 2026-11-01, which would mean bumping again almost immediately.

Pinned by digest to match the convention already used by the glibc builder (`debian:bullseye-*@sha256:...`) and both busybox runtime stages. Renovate's Dockerfile manager keeps the digest current.

This is the only literal Alpine image in the repo. The `-alpine` .NET SDK/ASP.NET tags used by the integration tests float on Microsoft's tags and are unaffected.

## Impact on shipped artifacts

Toolchain moves clang 16 → 20 and musl 1.2.4 → 1.2.5. **No runtime floor is raised for consumers** — both shipped `.so` files still declare only `libc.musl-x86_64.so.1` as `NEEDED`, with no versioned symbol dependencies and no `libstdc++`/`libgcc` linkage:

```
=== Pyroscope.Profiler.Native.so ===
 (NEEDED)  Shared library: [libc.musl-x86_64.so.1]
=== Datadog.Linux.ApiWrapper.x64.so ===
 (NEEDED)  Shared library: [libc.musl-x86_64.so.1]
```

OpenSSL is still built from source via `ARG OPENSSL_VERSION`, so the crypto dependency is untouched.

## Verification

Run locally against this branch:

- `docker build --target test --build-arg CMAKE_BUILD_TYPE=Debug -f Pyroscope.musl.Dockerfile .` — the exact command from `test_cpp_profiler.yml`. Passes; both `profiler-native-tests` and the `LD_PRELOAD` `WrappedFunctionsTest` suites green. Build produces only pre-existing third-party warnings (nlohmann_json deprecated literal operators), no new errors.
- `LIBC_TYPE=musl DOTNET_VERSION=8.0 go test -timeout 60m -count=1 ./...` in `integration-test/` — **passed** (844s), covering rideshare profiles, OTEL, dynamic CPU toggle, TLS upload, and the allocation/exception/lock stacktrace tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)