### PR TITLE
fix(ci): point glibc builder at snapshot.debian.org after bullseye EOL

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,22 @@ Output artifacts:
 - `artifacts/profiler-build/DDProf-Deploy/linux/Pyroscope.Profiler.Native.so`
 - `artifacts/profiler-build/DDProf-Deploy/linux/Datadog.Linux.ApiWrapper.x64.so`
 
+### Do not casually bump the glibc builder base image
+
+`Pyroscope.Dockerfile` is pinned to `debian:bullseye-*`, an EOL distro, **on purpose**: its
+glibc 2.31 is what keeps the shipped `Pyroscope.Profiler.Native.so` at a `GLIBC_2.30` floor.
+Bumping the base raises the minimum glibc for everyone running the profiler (bookworm's
+glibc 2.36 needs `GLIBC_2.34` and drops Ubuntu 20.04 / Debian 11).
+
+Because bullseye is EOL, its apt sources are pinned to a `snapshot.debian.org` timestamp
+that must stay in sync with the base image tag. Read the comment above the `FROM` line
+before touching either. After any change to the builder, verify the floor did not move:
+
+```bash
+readelf -d Pyroscope.Profiler.Native.so | grep NEEDED   # expect separate libpthread/libdl/libm
+readelf -V Pyroscope.Profiler.Native.so | grep -oE 'GLIBC_[0-9.]+' | sort -uV | tail -1  # expect GLIBC_2.30
+```
+
 ## Build the profiler (Windows)
 
 Windows is a supported target: CI (`.github/workflows/windows.yml`) builds `Pyroscope.Profiler.Native.dll` (Release x64) with MSBuild and runs the integration tests against it on Windows runners. Local build (requires MSVC + vcpkg):

--- a/Pyroscope.Dockerfile
+++ b/Pyroscope.Dockerfile
@@ -1,7 +1,22 @@
 FROM debian:bullseye-20260406@sha256:bf53effcacca31b60ce97dabc67578f37e43075d716dc90804d3da3a80d2996c AS builder
 
-# deb.debian.org (Fastly) intermittently resets connections on cold CI builds; retry apt fetches.
-RUN echo 'Acquire::Retries "5";' > /etc/apt/apt.conf.d/80-retries
+# Debian 11 (bullseye) reached end of LTS on 2026-08-31: the bullseye-security
+# Release file expired on 2026-09-07 and its pool has been removed from the live
+# mirrors, so deb.debian.org can no longer resolve this image's packages.
+# snapshot.debian.org is immutable; the timestamp below must match the base image
+# tag above so the suites agree with the packages already baked into the digest.
+RUN printf '%s\n' \
+      "deb http://snapshot.debian.org/archive/debian/20260406T000000Z bullseye main" \
+      "deb http://snapshot.debian.org/archive/debian-security/20260406T000000Z bullseye-security main" \
+      "deb http://snapshot.debian.org/archive/debian/20260406T000000Z bullseye-updates main" \
+      > /etc/apt/sources.list
+
+# snapshot.debian.org serves historical Release files, whose Valid-Until is by
+# definition in the past. Retries cover cold-CI connection resets.
+RUN printf '%s\n' \
+      'Acquire::Retries "5";' \
+      'Acquire::Check-Valid-Until "false";' \
+      > /etc/apt/apt.conf.d/80-retries
 
 RUN apt-get update && apt-get -y install cmake make git curl golang libtool wget perl
 

--- a/Pyroscope.Dockerfile
+++ b/Pyroscope.Dockerfile
@@ -1,10 +1,25 @@
+# This base is deliberately pinned to an EOL distro. bullseye's glibc 2.31 is what keeps
+# the shipped Pyroscope.Profiler.Native.so at a GLIBC_2.30 floor; a newer base raises that
+# floor for everyone running the profiler. bookworm's glibc 2.36, for instance, merged
+# pthread/dl into libc and needs GLIBC_2.34, which drops Ubuntu 20.04 and Debian 11.
+#
+# If you change this tag, you MUST also deal with the apt sources below:
+#   - moving to a still-supported base: delete the snapshot.debian.org sources.list block
+#     and the Check-Valid-Until line; live mirrors work again. Re-check the glibc floor
+#     with `readelf -V` before shipping (see PR #425 for the expected symbol set).
+#   - staying on an EOL-pinned base: update all three snapshot timestamps to match the new
+#     tag, or apt will resolve against packages this image does not actually contain.
+#
+# Renovate will not do either for you: renovate.json extends security:only-security-updates,
+# so only openssl/openssl and grafana/shared-workflows are auto-bumped in this repo.
 FROM debian:bullseye-20260406@sha256:bf53effcacca31b60ce97dabc67578f37e43075d716dc90804d3da3a80d2996c AS builder
 
 # Debian 11 (bullseye) reached end of LTS on 2026-08-31: the bullseye-security
 # Release file expired on 2026-09-07 and its pool has been removed from the live
 # mirrors, so deb.debian.org can no longer resolve this image's packages.
-# snapshot.debian.org is immutable; the timestamp below must match the base image
-# tag above so the suites agree with the packages already baked into the digest.
+# snapshot.debian.org is immutable; the 20260406T000000Z timestamps below must stay in
+# sync with the base image tag above, so the suites agree with the packages already baked
+# into the digest. See the note above the FROM line before changing either.
 RUN printf '%s\n' \
       "deb http://snapshot.debian.org/archive/debian/20260406T000000Z bullseye main" \
       "deb http://snapshot.debian.org/archive/debian-security/20260406T000000Z bullseye-security main" \


### PR DESCRIPTION
## What

Repoints `Pyroscope.Dockerfile`'s apt sources at `snapshot.debian.org`, pinned to `20260406T000000Z` to match the base image tag.

## Why

Debian 11 (bullseye) reached end of LTS on **2026-08-31**. Its final `bullseye-security` `Release` file carried `Valid-Until: Mon, 07 Sep 2026 21:13:04 UTC`, and the suite's `pool/` has since been removed from the live mirrors. Since that lapsed, **every glibc CI job fails in the first apt layer**, including the required checks `build-linux-profiler-x86_64 (glibc)` and `build-linux-profiler-aarch64 (glibc)`:

```
E: Release file for http://deb.debian.org/debian-security/dists/bullseye-security/InRelease
   is expired (invalid since 6h 36min 13s).
```

This has been blocking all PRs -- #423 could only be merged by temporarily removing the `required_status_checks` rule from the repo ruleset, which is not something to repeat.

## Approaches that do not work

Each was reproduced with a real `docker build` against the pinned digest:

| Candidate | Result |
| --- | --- |
| `Acquire::Check-Valid-Until "false"` alone | **Fails.** Clears the expiry error, then every `debian-security` `.deb` 404s -- the pool is gone. |
| Drop the `bullseye-security` line | **Fails.** The pinned image already ships security-suite packages (`perl-base 5.32.1-4+deb11u4`); bullseye `main` only offers `deb11u3`, so apt reports `held broken packages` and `libc6-dev but it is not installable`. |
| Repoint at `archive.debian.org` | **Fails.** `archive.debian.org/debian-security` carries no `bullseye-security` at all (404). |
| `snapshot-cloudflare.debian.org` | Works, but pathologically slow (killed at 768s still fetching). |

## Why snapshot.debian.org

`snapshot.debian.org` is immutable and `20260406T000000Z` is the base image's own build date, so the suites agree **by construction** with the packages already baked into the pinned digest. No version skew is possible, and it cannot rot again the way `deb.debian.org` just did. `Check-Valid-Until` must be disabled alongside it, because snapshot serves historical `Release` files whose `Valid-Until` is by definition in the past.

The official image ships these same three lines commented out in its `sources.list`; they are written out in full here so the effective configuration is readable in the Dockerfile rather than implied by the base image's contents.

## Why not bookworm

Bookworm builds fine, but glibc 2.34 merged `pthread`/`dl` into `libc`. A test object compiled there needs `GLIBC_2.34` and lists only `libc.so.6`, versus `GLIBC_2.30` today -- so bumping would silently **drop Ubuntu 20.04 and Debian 11 runtimes** for every consumer of the NuGet package.

## Verification

Full builds run locally on x86_64 against this branch:

- `docker build --target test --build-arg CMAKE_BUILD_TYPE=Debug -f Pyroscope.Dockerfile .` -- the exact command from `test_cpp_profiler.yml`. Green: **583/583** `profiler-native-tests` and **42/42** `LD_PRELOAD` `WrappedFunctionsTest`.
- `docker build -f Pyroscope.Dockerfile -o out .` (Release) -- green.

**Shipped artifacts are bit-for-bit equivalent in ABI shape to released 1.4.0**, which is the check that actually protects users:

```
=== Pyroscope.Profiler.Native.so ===
NEEDED: libpthread.so.0, libdl.so.2, libm.so.6, libc.so.6, ld-linux-x86-64.so.2
GLIBC:  2.2.5 2.3 2.3.2 2.3.4 2.7 2.9 2.12 2.14 2.16 2.17 2.18 2.25 2.29 2.30
GLIBCXX/CXXABI: none

=== Pyroscope.Linux.ApiWrapper.x64.so ===
NEEDED: libdl.so.2, libpthread.so.0, libc.so.6, ld-linux-x86-64.so.2
GLIBC:  2.2.5 2.3 2.14
GLIBCXX/CXXABI: none
```

Both lists are identical to the 1.4.0 release artifacts. This run also covers `OPENSSL_VERSION=3.5.8`, which landed on `main` but had never actually been built on glibc because CI was already broken.

aarch64 was not testable locally (no qemu binfmt on the build host), but the arm64 `Packages` indices were confirmed present on all three snapshot suites, and CI runs that job on native ARM runners.

## Follow-up, not in this PR

bullseye is EOL and this builder will keep accumulating problems. The durable answer for a binary shipped to arbitrary Linux users is a purpose-built portable toolchain image such as `quay.io/pypa/manylinux_2_28_x86_64` (glibc 2.28, actively maintained), which would *lower* the floor from 2.30 to 2.28 rather than raise it.

## Note for future bumps

This is now documented in the tree (above the `FROM` line in `Pyroscope.Dockerfile`, and in `CLAUDE.md` for agents) rather than only here:

- The base is pinned to an EOL distro **on purpose** -- bullseye's glibc 2.31 is what holds the `GLIBC_2.30` floor.
- Moving to a still-supported base means **deleting** the snapshot block, not re-syncing it, and re-checking the floor with `readelf -V`.
- Staying on an EOL-pinned base means updating all three snapshot timestamps to match the new tag.

Worth correcting one thing: `renovate.json` extends `security:only-security-updates`, which disables everything not explicitly re-enabled, and only `openssl/openssl` and `grafana/shared-workflows` are. So the base image digest is **not** on a routine auto-bump path here, and since bullseye is EOL there are no new `bullseye-*` tags to bump to anyway. The realistic trigger is a human or agent doing the migration in the follow-up above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

