### PR TITLE
fix(build): migrate profiler base images to manylinux_2_28 / musllinux_1_2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,9 +22,13 @@ else
     $(error ARCH must be either x86_64, aarch64)
 endif
 
+# The manylinux/musllinux base images are published per-arch rather than as
+# multi-arch manifests, so the builder stage takes the arch as a build arg.
+BUILD_ARGS := --build-arg BASE_ARCH=$(ARCH)
+
 .PHONY: docker/archive
 docker/archive:
-	docker build -f $(DOCKERFILE) -o out.$(RELEASE_VERSION)-$(LIBC)-$(ARCH)  .
+	docker build -f $(DOCKERFILE) $(BUILD_ARGS) -o out.$(RELEASE_VERSION)-$(LIBC)-$(ARCH)  .
 	cd out.$(RELEASE_VERSION)-$(LIBC)-$(ARCH) && tar -czvf ../pyroscope.$(RELEASE_VERSION)-$(LIBC)-$(ARCH).tar.gz *.so 
 	rm -rf out.$(RELEASE_VERSION)-$(LIBC)-$(ARCH)
 

--- a/Pyroscope.Dockerfile
+++ b/Pyroscope.Dockerfile
@@ -1,13 +1,27 @@
-FROM debian:bullseye-20260406@sha256:bf53effcacca31b60ce97dabc67578f37e43075d716dc90804d3da3a80d2996c AS builder
+# manylinux_2_28 (AlmaLinux 8, glibc 2.28). Debian 11 is EOL. The image is
+# published per-arch, so BASE_ARCH selects the repository; the Makefile passes it.
+ARG BASE_ARCH=x86_64
+ARG BASE_TAG=2026.09.05-1
+FROM quay.io/pypa/manylinux_2_28_${BASE_ARCH}:${BASE_TAG} AS builder
 
-# deb.debian.org (Fastly) intermittently resets connections on cold CI builds; retry apt fetches.
-RUN echo 'Acquire::Retries "5";' > /etc/apt/apt.conf.d/80-retries
+# clang via the image's own helper: installs a sha256-verified static toolchain
+# into /opt/clang (already first on PATH) and writes clang.cfg with
+# --gcc-toolchain=/opt/rh/gcc-toolset-14/root/usr, so clang uses GCC 14's
+# libstdc++ -- the profiler needs <span>, which AlmaLinux 8's system libstdc++
+# (GCC 8) lacks. AlmaLinux's own llvm-toolset caps at clang 17, and there is no
+# RPM equivalent of apt.llvm.org, which is why this replaces the llvm.sh install.
+ARG CLANG_VERSION=20.1.8.0
+RUN manylinux-install-clang -v ${CLANG_VERSION}
 
-RUN apt-get update && apt-get -y install cmake make git curl golang libtool wget perl
+# OpenSSL 3's Configure/Makefile.in need perl modules that el8 splits into
+# separate RPMs (IPC::Cmd, Time::Piece, ...); perl-core pulls the lot. Everything
+# else the build needs (cmake, make, git, curl, autoconf/automake/libtool,
+# gcc-toolset-14) already ships in the image.
+RUN dnf -y install perl-core && dnf clean all
 
 # Build OpenSSL from source with static libs
 ARG OPENSSL_VERSION=3.5.8
-RUN wget -q "https://github.com/openssl/openssl/releases/download/openssl-${OPENSSL_VERSION}/openssl-${OPENSSL_VERSION}.tar.gz" && \
+RUN curl -fsSLO --retry 10 "https://github.com/openssl/openssl/releases/download/openssl-${OPENSSL_VERSION}/openssl-${OPENSSL_VERSION}.tar.gz" && \
     tar xf openssl-${OPENSSL_VERSION}.tar.gz && \
     cd openssl-${OPENSSL_VERSION} && \
     ./config no-shared no-tests --prefix=/usr/local/openssl --openssldir=/etc/ssl && \
@@ -15,14 +29,6 @@ RUN wget -q "https://github.com/openssl/openssl/releases/download/openssl-${OPEN
     make install_sw && \
     ln -s /usr/local/openssl/lib64 /usr/local/openssl/lib && \
     cd .. && rm -rf openssl-${OPENSSL_VERSION} openssl-${OPENSSL_VERSION}.tar.gz
-
-RUN apt-get -y install lsb-release wget software-properties-common gnupg
-
-RUN wget https://apt.llvm.org/llvm.sh && \
-  chmod +x llvm.sh && \
-  ./llvm.sh 18
-
-ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/lib/llvm-18/bin/
 
 FROM builder as build
 
@@ -36,11 +42,15 @@ ADD CMakeLists.txt CMakeLists.txt
 # Allow build type to be passed as build arg, default to Release
 ARG CMAKE_BUILD_TYPE=Release
 
+# CMAKE_POLICY_VERSION_MINIMUM: the image ships cmake 4, which hard-errors on
+# cmake_minimum_required < 3.5; vendored third_party trees still declare 2.6-3.4
+# (e.g. profiler/third_party/CxxUrl).
 RUN mkdir build-${CMAKE_BUILD_TYPE} && \
     cd build-${CMAKE_BUILD_TYPE} && \
     cmake .. \
         -DCMAKE_C_COMPILER=clang \
         -DCMAKE_CXX_COMPILER=clang++ \
+        -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
         -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} \
         -DCMAKE_CXX_FLAGS_DEBUG="-g -O0" \
         -DCMAKE_C_FLAGS_DEBUG="-g -O0" \

--- a/Pyroscope.musl.Dockerfile
+++ b/Pyroscope.musl.Dockerfile
@@ -1,27 +1,22 @@
-FROM alpine:3.22@sha256:14358309a308569c32bdc37e2e0e9694be33a9d99e68afb0f5ff33cc1f695dce AS builder
+# musllinux_1_2 (Alpine 3.22, musl 1.2). Published per-arch, so BASE_ARCH selects
+# the repository; the Makefile passes it.
+ARG BASE_ARCH=x86_64
+ARG BASE_TAG=2026.09.05-1
+FROM quay.io/pypa/musllinux_1_2_${BASE_ARCH}:${BASE_TAG} AS builder
 
-RUN apk add \
-            clang \
-            cmake \
-            git \
-            bash \
-            make \
-            alpine-sdk \
-            util-linux-dev \
-            autoconf \
-            libtool \
-            automake \
-            xz-dev \
-            musl-dbg \
-            perl \
-            linux-headers
+# Same static clang toolchain as the glibc build, so one pinned compiler version
+# covers both libc flavours (this image carried clang 20 via apk before).
+ARG CLANG_VERSION=20.1.8.0
+RUN manylinux-install-clang -v ${CLANG_VERSION}
 
-RUN apk add wget
-RUN apk add go
+# musl-dbg is the only build dep the image lacks. cmake, git, bash, make,
+# gcc/g++/musl-dev, autoconf/automake/libtool, util-linux-dev, xz-dev,
+# linux-headers, perl and curl are all preinstalled.
+RUN apk add --no-cache musl-dbg
 
 # Build OpenSSL from source with static libs
 ARG OPENSSL_VERSION=3.5.8
-RUN wget -q "https://github.com/openssl/openssl/releases/download/openssl-${OPENSSL_VERSION}/openssl-${OPENSSL_VERSION}.tar.gz" && \
+RUN curl -fsSLO --retry 10 "https://github.com/openssl/openssl/releases/download/openssl-${OPENSSL_VERSION}/openssl-${OPENSSL_VERSION}.tar.gz" && \
     tar xf openssl-${OPENSSL_VERSION}.tar.gz && \
     cd openssl-${OPENSSL_VERSION} && \
     ./config no-shared no-tests --prefix=/usr/local/openssl --openssldir=/etc/ssl && \
@@ -42,11 +37,15 @@ ADD CMakeLists.txt CMakeLists.txt
 
 # Allow build type to be passed as build arg, default to Release
 ARG CMAKE_BUILD_TYPE=Release
+# CMAKE_POLICY_VERSION_MINIMUM: the image ships cmake 4, which hard-errors on
+# cmake_minimum_required < 3.5; vendored third_party trees still declare 2.6-3.4
+# (e.g. profiler/third_party/CxxUrl).
 RUN mkdir build-${CMAKE_BUILD_TYPE} && \
     cd build-${CMAKE_BUILD_TYPE} && \
     cmake .. \
         -DCMAKE_C_COMPILER=clang \
         -DCMAKE_CXX_COMPILER=clang++ \
+        -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
         -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} \
         -DCMAKE_CXX_FLAGS_DEBUG="-g -O0" \
         -DCMAKE_C_FLAGS_DEBUG="-g -O0" \


### PR DESCRIPTION
## What

Move the two profiler builder images to the PyPA maximum-portability images:

| | before | after |
|---|---|---|
| glibc | `debian:bullseye-20260406` (glibc 2.31), clang 18 from apt.llvm.org | `quay.io/pypa/manylinux_2_28_$ARCH` (AlmaLinux 8, glibc 2.28), clang 20.1.8.0 |
| musl | `alpine:3.22`, clang 20 from apk | `quay.io/pypa/musllinux_1_2_$ARCH` (Alpine 3.22, musl 1.2), clang 20.1.8.0 |

**Why:** Debian 11 is EOL, and this is no longer theoretical — **the glibc build on `main`
is currently broken.** Building `main`'s `Pyroscope.Dockerfile` today fails at
`apt-get update`:

```
E: Release file for http://deb.debian.org/debian-security/dists/bullseye-security/InRelease
   is expired (invalid since 10h 55min 7s).
... apt-get update ... did not complete successfully: exit code: 100
```

Debian 11 LTS ended 2026-08-31, so `bullseye-security`'s `Release` file has passed its
`Valid-Until` and will never be re-signed. AlmaLinux 8 is supported to 2029.

A side benefit: both flavours now use one pinned clang instead of two
independently-drifting ones (clang 18 via apt.llvm.org vs clang 20 via apk).

Note the musl side was already on Alpine 3.22, so that half is not an EOL fix — it moves
to `musllinux_1_2` (the same Alpine 3.22 underneath) only to share the toolchain.

## Things worth reviewing

- **clang.** clang 18 is not obtainable on AlmaLinux 8: AppStream's `llvm-toolset` is a
  single rolling stream capped at 17.0.6, there is no RPM equivalent of apt.llvm.org, and
  the system libstdc++ (GCC 8) has no `<span>`, which the profiler uses
  (`PprofBuilder.h`, `PprofExporter.h`). Both images ship
  `manylinux-install-clang`, which installs a sha256-verified static clang into
  `/opt/clang` (already first on `PATH`) and writes `clang.cfg` with
  `--gcc-toolchain=/opt/rh/gcc-toolset-14/root/usr`, so clang picks up GCC 14's
  libstdc++. Since `-static-libstdc++` is already used, this adds no runtime dependency.
  The helper is marked BETA upstream and ships only a subset toolchain (clang/lld/nm) —
  the `RUN_ASAN`/`RUN_UBSAN`/`RUN_TSAN` cmake options would not work under it.
- **cmake 4.** Both images ship cmake 4.4.3, which hard-errors on
  `cmake_minimum_required < 3.5`; `profiler/third_party/CxxUrl/CMakeLists.txt:1` declares
  `3.4` and ~15 other vendored trees go down to 2.6.4. Fixed with
  `-DCMAKE_POLICY_VERSION_MINIMUM=3.5` (the escape hatch cmake's own error suggests)
  rather than editing vendored files. Everything else configured cleanly under cmake 4,
  including the `CMP0169`/`FetchContent_Populate` workaround.
- **Per-arch images.** Unlike `debian`/`alpine`, these are published as per-arch
  repositories, not multi-arch manifests. So the builder stage takes `ARG BASE_ARCH` and
  the Makefile passes `$(ARCH)` through. `TARGETARCH` was not used because it is
  unavailable under `DOCKER_BUILDKIT=0`.

## Verification

`docker build --target test` for both libcs, on this exact code:

| check | glibc / manylinux_2_28 | musl / musllinux_1_2 |
|---|---|---|
| build | ✅ exit 0 | ✅ exit 0 |
| compiler resolved | ✅ `Clang 20.1.8` | ✅ `Clang 20.1.8` |
| `ctest -E WrappedFunctionsTest` | ✅ 100% of 583 | ✅ 100% of 583 |
| `ctest -R WrappedFunctionsTest` under `LD_PRELOAD` | ✅ 100% of 42 | ✅ 100% of 46 |

Release-mode artifact (`-o`, glibc):

| property | `Profiler.Native.so` | `ApiWrapper.x64.so` |
|---|---|---|
| max `GLIBC_` symbol required | 2.25 | 2.14 |
| `GNU_STACK` | `RW` (not `RWE`) | `RW` (not `RWE`) |
| `libstdc++.so.6` / `libgcc_s.so.1` in `NEEDED` | absent | absent |

So `-static-libstdc++`/`-static-libgcc` still take effect under gcc-toolset-14, and the
`-Wl,-z,noexecstack` hardening survives the switch from Debian's binutils to
gcc-toolset-14's.

I could not measure the *previous* artifact's glibc floor for comparison, because
`main`'s Dockerfile no longer builds (see above). 2.25 is comfortably below the 2.28
ceiling that AlmaLinux 8 imposes.

**Not verified: aarch64.** It cannot be built on this machine, so `BASE_ARCH=aarch64` is
exercised only by the `build-linux-profiler-aarch64` CI leg. That is the one part of this
change with no local coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
