### PR TITLE
fix(build): pin profiler builder base images by digest

### DIFF
--- a/Pyroscope.Dockerfile
+++ b/Pyroscope.Dockerfile
@@ -1,8 +1,12 @@
 # manylinux_2_28 (AlmaLinux 8, glibc 2.28). Debian 11 is EOL. The image is
-# published per-arch, so BASE_ARCH selects the repository; the Makefile passes it.
+# published per-arch rather than as a multi-arch manifest, so each arch has its
+# own digest and gets its own pinned stage; BASE_ARCH picks one and the Makefile
+# passes it. Under BuildKit only the selected stage is pulled. Bump the tag and
+# both digests together.
 ARG BASE_ARCH=x86_64
-ARG BASE_TAG=2026.09.05-1
-FROM quay.io/pypa/manylinux_2_28_${BASE_ARCH}:${BASE_TAG} AS builder
+FROM quay.io/pypa/manylinux_2_28_x86_64:2026.09.05-1@sha256:53390351aeb4688114b02c36a23b3e6ce1166ee9b7afc5df1a4f776354fc764c AS base-x86_64
+FROM quay.io/pypa/manylinux_2_28_aarch64:2026.09.05-1@sha256:ad74e53b713f3b07d8c889c526dc0c6500da9827b45e38739570875fef52e28f AS base-aarch64
+FROM base-${BASE_ARCH} AS builder
 
 # clang via the image's own helper: installs a sha256-verified static toolchain
 # into /opt/clang (already first on PATH) and writes clang.cfg with

--- a/Pyroscope.musl.Dockerfile
+++ b/Pyroscope.musl.Dockerfile
@@ -1,8 +1,11 @@
-# musllinux_1_2 (Alpine 3.22, musl 1.2). Published per-arch, so BASE_ARCH selects
-# the repository; the Makefile passes it.
+# musllinux_1_2 (Alpine 3.22, musl 1.2). Published per-arch rather than as a
+# multi-arch manifest, so each arch has its own digest and gets its own pinned
+# stage; BASE_ARCH picks one and the Makefile passes it. Under BuildKit only the
+# selected stage is pulled. Bump the tag and both digests together.
 ARG BASE_ARCH=x86_64
-ARG BASE_TAG=2026.09.05-1
-FROM quay.io/pypa/musllinux_1_2_${BASE_ARCH}:${BASE_TAG} AS builder
+FROM quay.io/pypa/musllinux_1_2_x86_64:2026.09.05-1@sha256:621f8004ed526a5a6bf6a866fb415ad8da54d59a991e50b3b69167c3a768a616 AS base-x86_64
+FROM quay.io/pypa/musllinux_1_2_aarch64:2026.09.05-1@sha256:4dffcd49f0b6fc6928a49915f3cd939f973bbecbdfe96e1e7926b6049bc0bad5 AS base-aarch64
+FROM base-${BASE_ARCH} AS builder
 
 # Same static clang toolchain as the glibc build, so one pinned compiler version
 # covers both libc flavours (this image carried clang 20 via apk before).


### PR DESCRIPTION
Follow-up to #427, addressing https://github.com/grafana/pyroscope-dotnet/pull/427#discussion_r3956327474.

## What

#427 moved the two builder stages to the PyPA manylinux/musllinux images but referenced them **by tag only**, dropping the `@sha256:` pin the previous `debian`/`alpine` bases had. The `busybox` output stages in the same files stayed pinned, so the builders were the one unpinned input — and they are the stages that compile `Pyroscope.Profiler.Native.so` and the API wrapper. A retag upstream would land in the shipped native libraries with no Dockerfile change.

## Why it needs two pins per file

These images are published as **per-arch repositories** (`manylinux_2_28_x86_64`, `manylinux_2_28_aarch64`, …) rather than as multi-arch manifests, so no single digest covers both arches. Each arch gets its own digest-pinned stage and `BASE_ARCH` selects between them:

```dockerfile
ARG BASE_ARCH=x86_64
FROM quay.io/pypa/manylinux_2_28_x86_64:2026.09.05-1@sha256:5339... AS base-x86_64
FROM quay.io/pypa/manylinux_2_28_aarch64:2026.09.05-1@sha256:ad74... AS base-aarch64
FROM base-${BASE_ARCH} AS builder
```

No Makefile change — `BASE_ARCH` is already passed. Tag is unchanged (`2026.09.05-1`); this only adds the pins.

I also dropped the `BASE_TAG` build arg (it had no callers). With the digest written inline, overriding the tag alone could only ever produce a tag/digest mismatch.

Each digest was checked against the registry config blob before pinning:

| repository | digest | config reports |
|---|---|---|
| `manylinux_2_28_x86_64` | `sha256:5339…c764c` | `amd64/linux`, built 2026-09-05 |
| `manylinux_2_28_aarch64` | `sha256:ad74…2e28f` | `arm64/linux`, built 2026-09-05 |
| `musllinux_1_2_x86_64` | `sha256:621f…a616` | `amd64/linux`, built 2026-09-05 |
| `musllinux_1_2_aarch64` | `sha256:4dff…0bad5` | `arm64/linux`, built 2026-09-05 |

## Verification

- `docker build --target builder` exits 0 for both libcs on x86_64, and every `RUN` layer is a **cache hit** against the pre-pin builds — which is the direct evidence that each digest resolves to the same image the tag did.
- **Only the selected arch's stage is resolved.** In a real build the unused cross-arch stage is never fetched (build log shows a single `load metadata`, for the selected arch only), so there is no `InvalidBaseImagePlatform` warning and no extra image pull. Note `docker build --check` *does* report that warning, because it lints every stage exhaustively rather than following the build graph — that path is not how these images are built. The only lint warning on a real build is the pre-existing `FromAsCasing` on the `FROM builder as build` line, untouched here.
- `BASE_ARCH` genuinely interpolates into the stage alias: a bogus value fails resolving `base-bogusarch` rather than silently falling through.
- `BASE_ARCH=aarch64` selects the aarch64 stages — confirmed running them reports `aarch64` on AlmaLinux 8.10 (glibc) and Alpine 3.22.5 (musl).

**Not verified: a full aarch64 profiler compile**, same as in #427 — that stays covered by the `build-linux-profiler-aarch64` CI leg. What is verified here is that the aarch64 pins resolve to the correct arch and are what that leg will consume.

🤖 Generated with [Claude Code](https://claude.com/claude-code)